### PR TITLE
fix(macos): anchor titlebar controls to the titlebar band

### DIFF
--- a/packages/typescript/src/api/spaces.ts
+++ b/packages/typescript/src/api/spaces.ts
@@ -33,6 +33,12 @@ export interface SpaceDescriptor {
 export interface SpacesSidebarOptions {
   /** Supply one to keep a stable id across reloads; generated otherwise. */
   id?: string
+  /**
+   * Fewer than two and the native control stays hidden — one space renders as a
+   * single selected segment naming the space the user is already in. It is
+   * hidden rather than destroyed, so a later `setSpaces` with two or more
+   * brings it straight back.
+   */
   spaces?: SpaceDescriptor[]
   /** Which space opens selected. Defaults to the first. */
   activeSpace?: string

--- a/packages/typescript/src/types.ts
+++ b/packages/typescript/src/types.ts
@@ -154,6 +154,10 @@ export interface WindowOptions {
    * Draw native macOS sidebar material behind a web-rendered sidebar.
    * Useful for apps whose sidebar is authored in HTML/STX but should sit over
    * real AppKit vibrancy in transparent titlebar windows.
+   *
+   * The window title is hidden in this mode: the host draws its own
+   * sidebar/back/forward row into the titlebar, where AppKit would otherwise
+   * print the title underneath it.
    * @default false
    */
   webSidebarMaterial?: boolean

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -507,6 +507,18 @@ pub fn build(b: *std.Build) void {
         }),
     });
 
+    // The space list is the AppKit-free half of the spaces switcher, so its
+    // tests are the ones that can run anywhere. They root at the source file
+    // itself: nothing else in the build reaches it, and Zig's lazy analysis
+    // means tests in an unreferenced file are silently never compiled.
+    const space_list_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/components/space_list.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
     const config_tests = b.addTest(.{
         .root_module = b.createModule(.{
             .root_source_file = b.path("test/config_test.zig"),
@@ -834,6 +846,7 @@ pub fn build(b: *std.Build) void {
     const run_animation_tests = b.addRunArtifact(animation_tests);
     const run_cli_tests = b.addRunArtifact(cli_tests);
     const run_native_sidebar_tests = b.addRunArtifact(native_sidebar_tests);
+    const run_space_list_tests = b.addRunArtifact(space_list_tests);
     const run_config_tests = b.addRunArtifact(config_tests);
     const run_ipc_tests = b.addRunArtifact(ipc_tests);
     const run_performance_tests = b.addRunArtifact(performance_tests);
@@ -924,6 +937,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_animation_tests.step);
     test_step.dependOn(&run_cli_tests.step);
     test_step.dependOn(&run_native_sidebar_tests.step);
+    test_step.dependOn(&run_space_list_tests.step);
     test_step.dependOn(&run_config_tests.step);
     test_step.dependOn(&run_ipc_tests.step);
     test_step.dependOn(&run_performance_tests.step);
@@ -1013,6 +1027,9 @@ pub fn build(b: *std.Build) void {
 
     const test_native_sidebar_step = b.step("test:native-sidebar", "Run Native Sidebar tests");
     test_native_sidebar_step.dependOn(&run_native_sidebar_tests.step);
+
+    const test_space_list_step = b.step("test:space-list", "Run Space List tests");
+    test_space_list_step.dependOn(&run_space_list_tests.step);
 
     const test_config_step = b.step("test:config", "Run Config tests");
     test_config_step.dependOn(&run_config_tests.step);

--- a/packages/zig/src/components/native_space_switcher.zig
+++ b/packages/zig/src/components/native_space_switcher.zig
@@ -44,6 +44,13 @@ pub const SpaceSwitcher = struct {
             _ = macos.msgSend0(self.control, "removeFromSuperview");
             self.control = null;
         }
+        // The responder is a view too, and `create` destroys the old switcher
+        // before building the new one — leaving it parented would strand a
+        // zero-sized subview in the window chrome on every re-create.
+        if (self.responder != null) {
+            _ = macos.msgSend0(self.responder, "removeFromSuperview");
+            self.responder = null;
+        }
         self.spaces.deinit();
         self.allocator.free(self.id);
         self.allocator.destroy(self);
@@ -133,6 +140,13 @@ fn rebuildSegments(self: *SpaceSwitcher) void {
     const count = self.spaces.count();
     macos.msgSendVoid1Ulong(control, "setSegmentCount:", @intCast(count));
 
+    // Hidden rather than destroyed, and written in both directions on every
+    // rebuild: `createSpacesSidebar()` with no options posts an empty list, so
+    // create-empty-then-`setSpaces` is the ordinary flow from JS, and a list
+    // that grows back to two has to bring the same control back with it.
+    const hidden = @as(c_int, if (space_list.shouldShowSwitcher(count)) 0 else 1);
+    _ = macos.msgSend1(control, "setHidden:", hidden);
+
     for (0..count) |i| {
         const space = self.spaces.at(i) orelse continue;
         const label = macos.createNSString(space.label);
@@ -192,18 +206,22 @@ fn attach(self: *SpaceSwitcher, window: objc.id) void {
     const NSSegmentedControl = macos.getClass("NSSegmentedControl");
     const control_alloc = macos.msgSend0(NSSegmentedControl, "alloc");
 
-    // Sit clear of the traffic lights, vertically centred on them.
+    // Sit clear of the traffic lights, centred in the titlebar band.
+    //
+    // Only the button's x is read from its frame. `standardWindowButton:`
+    // answers in NSTitlebarView coordinates; that view spans the window at
+    // x = 0, so its x is the theme frame's, but its y is not — see
+    // `macos.titlebarControlY`, which takes the band instead.
     const closeButton = macos.msgSend1(window, "standardWindowButton:", @as(c_ulong, 0));
-    const closeFrame = if (closeButton != null)
-        macos.msgSendRect(closeButton, "frame")
+    const closeX: f64 = if (closeButton != null)
+        macos.msgSendRect(closeButton, "frame").origin.x
     else
-        macos.NSRect{ .origin = .{ .x = 20.0, .y = 832.0 }, .size = .{ .width = 14.0, .height = 14.0 } };
-    const themeBounds = macos.msgSendRect(themeFrame, "bounds");
+        20.0;
     const height: f64 = 24.0;
-    const y = themeBounds.size.height - closeFrame.origin.y - closeFrame.size.height - ((height - closeFrame.size.height) / 2.0);
+    const y = macos.titlebarControlY(window, themeFrame, height);
 
     const control = macos.msgSend1Rect(control_alloc, "initWithFrame:", .{
-        .origin = .{ .x = closeFrame.origin.x + 200.0, .y = y },
+        .origin = .{ .x = closeX + 200.0, .y = y },
         .size = .{ .width = 240.0, .height = height },
     });
 
@@ -211,7 +229,7 @@ fn attach(self: *SpaceSwitcher, window: objc.id) void {
     _ = macos.msgSend1(control, "setTrackingMode:", @as(c_long, 0)); // SelectOne
     _ = macos.msgSend1(control, "setTarget:", responder);
     _ = macos.msgSend1(control, "setAction:", macos.sel("craftSpaceSelected:"));
-    macos.msgSendVoid1(control, "setAutoresizingMask:", @as(c_ulong, 4)); // min-Y margin flexible
+    macos.msgSendVoid1(control, "setAutoresizingMask:", macos.titlebar_control_autoresizing_mask);
     _ = macos.msgSend1(themeFrame, "addSubview:", control);
 
     self.control = control;

--- a/packages/zig/src/components/space_list.zig
+++ b/packages/zig/src/components/space_list.zig
@@ -112,6 +112,20 @@ pub const SpaceList = struct {
     }
 };
 
+/// Whether a switcher over `count` spaces is worth putting on screen.
+///
+/// One space renders as a single selected segment naming the space the user is
+/// already in — a lone pill in the window chrome that says nothing and does
+/// nothing. The web rail hides its dots for exactly this case (`showDots =
+/// spaces.length > 1` in `<SidebarSpaceSwitcher>`, following Dia); the native
+/// control follows the same rule.
+///
+/// Lives here rather than next to the NSSegmentedControl so the rule can be
+/// tested without a window, like the rest of this file.
+pub fn shouldShowSwitcher(count: usize) bool {
+    return count >= 2;
+}
+
 // =============================================================================
 
 const testing = std.testing;
@@ -203,6 +217,45 @@ test "replacing with nothing leaves no active space" {
 
     try testing.expectEqual(@as(?usize, null), list.active);
     try testing.expectEqual(@as(?Space, null), list.activeSpace());
+}
+
+test "a switcher over fewer than two spaces stays hidden" {
+    try testing.expect(!shouldShowSwitcher(0));
+    try testing.expect(!shouldShowSwitcher(1));
+    try testing.expect(shouldShowSwitcher(2));
+    try testing.expect(shouldShowSwitcher(7));
+}
+
+test "growing from one space to two brings the switcher back" {
+    var list = make(testing.allocator);
+    defer list.deinit();
+    try list.append(.{ .id = "personal", .label = "Personal" });
+
+    // One space: nothing to switch between, so nothing to show.
+    try testing.expect(!shouldShowSwitcher(list.count()));
+
+    try list.replace(&.{
+        .{ .id = "personal", .label = "Personal" },
+        .{ .id = "work", .label = "Work" },
+    });
+
+    // The control is hidden, not destroyed, so this is all it takes to get it
+    // back — and the user is still in the space they were in.
+    try testing.expect(shouldShowSwitcher(list.count()));
+    try testing.expectEqualStrings("personal", list.activeSpace().?.id);
+}
+
+test "shrinking back to one space hides it again" {
+    var list = make(testing.allocator);
+    defer list.deinit();
+    try list.append(.{ .id = "personal", .label = "Personal" });
+    try list.append(.{ .id = "work", .label = "Work" });
+    try testing.expect(shouldShowSwitcher(list.count()));
+
+    try list.replace(&.{.{ .id = "work", .label = "Work" }});
+
+    try testing.expect(!shouldShowSwitcher(list.count()));
+    try testing.expectEqualStrings("work", list.activeSpace().?.id);
 }
 
 /// Mirrors `native_space_switcher.sanitizeId`. Duplicated rather than imported

--- a/packages/zig/src/macos.zig
+++ b/packages/zig/src/macos.zig
@@ -616,6 +616,19 @@ pub fn createWindowWithStyle(title: []const u8, width: u32, height: u32, html: ?
         _ = msgSend1(window, "setLevel:", NSFloatingWindowLevel);
     }
 
+    // A web-sidebar-material window draws its own chrome row into the theme
+    // frame, starting 68pt right of the close button — and AppKit puts the
+    // window title at x = 82. Left visible, the title prints underneath that
+    // row. Hiding it is the whole fix; the rest of the titlebar treatment below
+    // must NOT follow, because `setTitlebarAppearsTransparent:` hides
+    // NSTitlebarBackgroundView, and on a window that did not also ask for
+    // `titlebar_hidden` the content view stops 32pt short of the top, so with
+    // the non-opaque background craft sets further down there would be nothing
+    // left to paint that strip: a see-through hole where the titlebar was.
+    if (style.web_sidebar_material and !style.titlebar_hidden) {
+        _ = msgSend1(window, "setTitleVisibility:", @as(c_int, 1)); // NSWindowTitleHidden
+    }
+
     // Configure titlebar transparency for full-size content view
     if (style.titlebar_hidden) {
         _ = msgSend1(window, "setTitlebarAppearsTransparent:", @as(c_int, 1)); // YES
@@ -628,9 +641,8 @@ pub fn createWindowWithStyle(title: []const u8, width: u32, height: u32, html: ?
         _ = msgSend1(window, "setTitlebarSeparatorStyle:", @as(c_long, 2)); // NSWindowTitlebarSeparatorStyleNone
 
         // CRITICAL: Position traffic lights in the sidebar (Tahoe/Settings style).
-        // Web-sidebar material windows also draw custom sidebar/back/forward
-        // controls from the close-button frame, so this one inset defines the
-        // whole native chrome row.
+        // Web-sidebar material windows draw custom sidebar/back/forward controls
+        // to the right of these, from the close button's x.
         const trafficLightTopInset: f64 = if (style.web_sidebar_material) 32.0 else 28.0;
 
         // Close button (red) - NSWindowCloseButton = 0
@@ -2728,6 +2740,75 @@ fn ensureSidebarToggleResponder() void {
     objc.objc_registerClassPair(sidebarToggleResponderClass);
 }
 
+// =============================================================================
+// Titlebar geometry
+//
+// Anything craft draws into the window chrome — the web-sidebar chrome row, the
+// spaces switcher — has to answer the same two questions: how far down the
+// theme frame does the titlebar band reach, and which autoresizing bits keep a
+// control up there when the window grows. Both used to be answered inline, and
+// wrongly, wherever they came up.
+//
+// The native-sidebar toggle button in `createWindowWithSidebarURL` still has
+// its own hand-rolled 52pt titlebar constant for y; it takes the mask from here
+// but not the band. Migrating it moves a button in a feature this change has
+// not otherwise touched, so it is left for its own commit.
+// =============================================================================
+
+/// Height of the titlebar band, in points.
+///
+/// `contentLayoutRect` is the part of the window AppKit leaves to content, so
+/// the difference against the theme frame is the band — 32pt for a standard
+/// window, and still 32pt when `fullSizeContentView` lets the webview draw
+/// underneath it. A borderless window has no band at all and reports 0.
+fn titlebarBandHeight(window: objc.id, themeFrame: objc.id) f64 {
+    const themeHeight = msgSendRect(themeFrame, "bounds").size.height;
+    const layoutHeight = msgSendRect(window, "contentLayoutRect").size.height;
+    return themeHeight - layoutHeight;
+}
+
+/// Where to put a `height`-point control so it sits centred in the titlebar,
+/// in theme-frame coordinates.
+///
+/// The obvious-looking alternative — read `standardWindowButton:`'s frame and
+/// mirror it through the theme frame's height — is what the switcher and the
+/// chrome row both used to do, and it is wrong twice over. Those frames are in
+/// *NSTitlebarView* coordinates, not the theme frame's, and the arithmetic then
+/// mirrors an already-top-relative y a second time. The two errors cancel
+/// exactly while the buttons sit at their default position (the band is 32 and
+/// the button is centred in it: 2*9 + 14 == 32), which is why it looked correct
+/// for so long. Move the traffic lights — craft does, in `createWindowWithStyle`
+/// and again in the native-UI bridge — and the control lands at the far edge:
+/// measured at y = -6 on an 800pt window against a correct 772.
+///
+/// Anchoring to the band instead is immune to where the buttons are, agrees
+/// with today's value to the point in every case where today's value was right,
+/// and keeps the control on screen when `standardWindowButton:` returns nothing
+/// at all.
+pub fn titlebarControlY(window: objc.id, themeFrame: objc.id, height: f64) f64 {
+    const themeHeight = msgSendRect(themeFrame, "bounds").size.height;
+    const measured = titlebarBandHeight(window, themeFrame);
+    // A window that reports no band has no titlebar to centre in — a borderless
+    // one, most obviously. Fall back to a nominal titlebar's worth so the
+    // control lands just inside the top of the content rather than off-window,
+    // which is where the old arithmetic put it.
+    const band: f64 = if (measured > 1.0) measured else 28.0;
+    return themeHeight - band + ((band - height) / 2.0);
+}
+
+/// Autoresizing mask that keeps a titlebar control pinned to the window's
+/// top-left corner as the window resizes.
+///
+/// NSViewMaxXMargin (4) holds the left edge by letting the right margin absorb
+/// the extra width; NSViewMinYMargin (8) holds the top edge by letting the
+/// *bottom* margin absorb the extra height — NSThemeFrame is not a flipped
+/// view, so the bottom margin is the one below the control. 4 on its own, which
+/// is what every one of these controls used to be given (under a comment
+/// claiming it was the min-Y bit), has no vertical effect whatsoever: measured,
+/// a control set that way stayed put while the window grew 100pt taller, ending
+/// up 100pt further from the titlebar it belongs to.
+pub const titlebar_control_autoresizing_mask: c_ulong = 4 | 8;
+
 fn webChromeToggleSidebarCallback(_: objc.id, _: objc.SEL, _: objc.id) callconv(.c) void {
     const webview = getGlobalWebView() orelse return;
     const js = createNSString("document.querySelector('[data-sidebar-collapse]')?.click()");
@@ -2792,15 +2873,13 @@ fn addWebSidebarChromeControls(window: objc.id, webview: objc.id) void {
     });
     _ = msgSend1(themeFrame, "addSubview:", responder);
 
+    // Only the button's x is read from its frame; see `titlebarControlY` for
+    // why its y cannot be mixed with the theme frame's.
     const closeButton = msgSend1(window, "standardWindowButton:", @as(c_ulong, 0));
-    const closeFrame = if (closeButton != null) msgSendRect(closeButton, "frame") else NSRect{
-        .origin = .{ .x = 20.0, .y = 832.0 },
-        .size = .{ .width = 14.0, .height = 14.0 },
-    };
-    const themeBounds = msgSendRect(themeFrame, "bounds");
+    const closeX: f64 = if (closeButton != null) msgSendRect(closeButton, "frame").origin.x else 20.0;
     const buttonSize = NSSize{ .width = 28.0, .height = 28.0 };
-    const buttonY = themeBounds.size.height - closeFrame.origin.y - closeFrame.size.height - ((buttonSize.height - closeFrame.size.height) / 2.0);
-    const firstButtonX = closeFrame.origin.x + 68.0;
+    const buttonY = titlebarControlY(window, themeFrame, buttonSize.height);
+    const firstButtonX = closeX + 68.0;
     const buttonGap = 42.0;
 
     const buttons = [_]struct {
@@ -2828,7 +2907,7 @@ fn addWebSidebarChromeControls(window: objc.id, webview: objc.id) void {
         _ = msgSend1(btn, "setTarget:", responder);
         _ = msgSend1(btn, "setAction:", sel(button.action));
         _ = msgSend1(btn, "setToolTip:", createNSString(button.tooltip));
-        msgSendVoid1(btn, "setAutoresizingMask:", @as(c_ulong, 4));
+        msgSendVoid1(btn, "setAutoresizingMask:", titlebar_control_autoresizing_mask);
         _ = msgSend1(themeFrame, "addSubview:", btn);
         if (std.mem.eql(u8, button.symbol, "sidebar.left")) {
             web_sidebar_toggle_button = btn;
@@ -3208,7 +3287,7 @@ pub fn createWindowWithSidebarURL(
                 .origin = .{ .x = btnX, .y = btnY },
                 .size = .{ .width = 28, .height = 22 },
             });
-            msgSendVoid1(toggleBtn, "setAutoresizingMask:", @as(c_ulong, 4)); // NSViewMinYMargin - stick to top
+            msgSendVoid1(toggleBtn, "setAutoresizingMask:", titlebar_control_autoresizing_mask);
             _ = msgSend1(themeFrame, "addSubview:", toggleBtn);
         }
     }


### PR DESCRIPTION
Closes #18.

The native space switcher landed at the bottom of the window instead of beside the traffic lights, and showed a lone pill when there was only one space to switch between.

## Placement

`standardWindowButton:` answers in **NSTitlebarView** coordinates, not the theme frame's, and `attach()` mixed that y with `themeFrame.bounds`. The two errors cancel *exactly* while the buttons sit at their default centred position — the band is 32pt and `2*9 + 14 == 32` — which is why it looked right. Craft moves the lights itself in two places, and there it collapses.

Measured against real `NSWindow`s, old vs. new y:

| window | old | new |
| --- | --- | --- |
| default lights (800 / 832 / 1400pt) | 772 / 804 / 1372 | identical |
| lights moved by `macos.zig:639` | 13 | 772 |
| lights moved by `bridge_native_ui.zig:432` → (13, 787) | **−6** | 772 |
| borderless, nil-button fallback | **−151** | 674 |

`titlebarControlY` takes the band from `contentLayoutRect` instead, so the result no longer depends on where the buttons are.

The autoresizing mask was a second defect: `4` is `NSViewMaxXMargin` and has no vertical effect at all — measured, the control drifted 504pt below the top on a 400→900 grow. `titlebar_control_autoresizing_mask` is `4|8`, which pins it at 4pt.

> **On the issue's stated cause:** NSThemeFrame reports `isFlipped = 0` on macOS 26.3.1 (as do NSTitlebarView and NSTitlebarContainerView). Branching the y math on `isFlipped` would be permanently dead code and would not fix the bug, so that part is deliberately not implemented.

## Single space

One space renders as a single selected segment naming the space the user is already in. `shouldShowSwitcher` hides it below two, matching the web rail's `spaces.length > 1`. Hidden rather than destroyed, because `createSpacesSidebar()` with no options posts an empty list — create-empty-then-`setSpaces` is the ordinary flow from JS, and a list that grows back to two has to bring the same control with it.

## Title overlap

In web-sidebar-material mode the host draws its own chrome row 68pt right of the close button, and AppKit prints the window title at x = 82 underneath it. Hiding the title is the whole fix.

It is deliberately its own two-line gate rather than joining the `titlebar_hidden` block below: `setTitlebarAppearsTransparent:` hides `NSTitlebarBackgroundView`, and on a window that did not *also* ask for `titlebar_hidden` the content view stops 32pt short of the top — with craft's `setOpaque:NO` that would leave a see-through strip where the titlebar was. Verified empirically before narrowing it.

## Also in here

- `deinit` removes the responder view. `create()` destroys the old switcher first, so leaving it parented stranded a zero-sized subview in the chrome on every re-create.
- `space_list.zig` is registered as a test root. Its 11 tests had never been compiled by any build step — nothing in the build reached the file, and Zig's lazy analysis meant they silently never ran.

## Verification

- `zig build`, `zig build test`, `zig fmt --check` on the touched files — all green (needs `-Djs-runtime=false`; `tsc` error count is unchanged at 472, all pre-existing).
- A Zig harness that imports the **shipped** `macos.zig` and calls `titlebarControlY` / `titlebar_control_autoresizing_mask` against real `NSWindow`s across 7 configurations — that is where the table above comes from — plus `setHidden:` on a real `NSSegmentedControl` (hidden for 0 and 1, visible for 2 and 5).
- The patched binary run end-to-end against a page calling `createSpacesSidebar`, at 1, 2 and 3 spaces, with `--web-sidebar-material` and with `--titlebar-hidden --web-sidebar-material`.
- **Not** verified: anything visual. `screencapture` is blocked without Screen Recording permission, so the arithmetic is measured but the aesthetics are not.

## Follow-ups, deliberately left out

- `bridge_native_ui.zig:428` writes a hardcoded `traffic_light_y = 787.0` into an NSTitlebarView-relative frame. Measured, that puts the close button off the top of the window, and AppKit resets it on the next layout. Inert today and the switcher is now immune to it, but it is wrong.
- `createWindowWithSidebarURL`'s sidebar toggle button took the shared mask but still uses a hand-rolled 52pt titlebar constant for its y (measured band there is 40pt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
