### PR TITLE
fix(macos): trust local development certificates behind an opt-in

### DIFF
--- a/docs/advanced/configuration.md
+++ b/docs/advanced/configuration.md
@@ -290,8 +290,34 @@ CRAFT_BUILD_TARGET=macos,linux,windows
 
 # Development
 CRAFT_DEV_PORT=3000
+CRAFT_ALLOW_LOCAL_TLS=1
 NODE_ENV=development
 ```
+
+### `CRAFT_ALLOW_LOCAL_TLS`
+
+A development proxy that fronts your local services over HTTPS — rpx, or
+anything else using a locally issued certificate — presents a certificate
+signed by a CA that is not a public root. The webview rejects it, the
+navigation fails, and you get a blank window with no explanation on something
+like `https://dashboard.myapp.localhost`.
+
+Setting this variable tells Craft to accept that certificate:
+
+```bash
+CRAFT_ALLOW_LOCAL_TLS=1 craft --url https://dashboard.myapp.localhost
+```
+
+It applies only to loopback addresses (`127.0.0.0/8`, `::1`) and the
+`localhost` TLD (`localhost`, `*.localhost`). Every other host keeps ordinary
+certificate validation, including a host that *resolves* to loopback but is
+not named for it — `127.0.0.1.nip.io` is still validated normally.
+
+This is deliberately an environment variable and not a `craft.config.ts`
+option: config travels into the app you ship, and a certificate exception that
+can be committed is one that eventually reaches users who never asked for it.
+Set it on the machine doing the development. Unset — or set to `0`, `false` or
+`no` — Craft installs no certificate handling at all.
 
 ### Environment Files
 

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -519,6 +519,17 @@ pub fn build(b: *std.Build) void {
         }),
     });
 
+    // The host-matching and opt-in rules behind the local development TLS
+    // exception. Security-relevant and AppKit-free, so they are tested here
+    // rather than only exercised through a window.
+    const local_tls_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/local_tls.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
     const config_tests = b.addTest(.{
         .root_module = b.createModule(.{
             .root_source_file = b.path("test/config_test.zig"),
@@ -847,6 +858,7 @@ pub fn build(b: *std.Build) void {
     const run_cli_tests = b.addRunArtifact(cli_tests);
     const run_native_sidebar_tests = b.addRunArtifact(native_sidebar_tests);
     const run_space_list_tests = b.addRunArtifact(space_list_tests);
+    const run_local_tls_tests = b.addRunArtifact(local_tls_tests);
     const run_config_tests = b.addRunArtifact(config_tests);
     const run_ipc_tests = b.addRunArtifact(ipc_tests);
     const run_performance_tests = b.addRunArtifact(performance_tests);
@@ -938,6 +950,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_cli_tests.step);
     test_step.dependOn(&run_native_sidebar_tests.step);
     test_step.dependOn(&run_space_list_tests.step);
+    test_step.dependOn(&run_local_tls_tests.step);
     test_step.dependOn(&run_config_tests.step);
     test_step.dependOn(&run_ipc_tests.step);
     test_step.dependOn(&run_performance_tests.step);
@@ -1030,6 +1043,9 @@ pub fn build(b: *std.Build) void {
 
     const test_space_list_step = b.step("test:space-list", "Run Space List tests");
     test_space_list_step.dependOn(&run_space_list_tests.step);
+
+    const test_local_tls_step = b.step("test:local-tls", "Run local development TLS tests");
+    test_local_tls_step.dependOn(&run_local_tls_tests.step);
 
     const test_config_step = b.step("test:config", "Run Config tests");
     test_config_step.dependOn(&run_config_tests.step);

--- a/packages/zig/src/local_tls.zig
+++ b/packages/zig/src/local_tls.zig
@@ -1,0 +1,239 @@
+//! The half of the local-development TLS exception that has no AppKit in it.
+//!
+//! `macos.zig` owns the `WKNavigationDelegate`; this owns the two decisions it
+//! makes — whether the process opted in at all, and whether a host name is this
+//! machine. Both are security-relevant and neither needs a window, so they live
+//! here where they can be tested.
+
+const std = @import("std");
+
+/// The environment variable that turns the exception on.
+///
+/// Deliberately an environment variable rather than a `WindowStyle` field or a
+/// CLI flag, which is how every other window option travels. Those options are
+/// written in `craft.config.ts` and ship inside the built app; a certificate
+/// bypass that can be committed to an app's config is a bypass that eventually
+/// ships to users who never asked for it. This one is set on the machine doing
+/// the development and cannot be baked into the artefact.
+pub const env_var = "CRAFT_ALLOW_LOCAL_TLS";
+
+/// Whether the environment opted this process in. `raw` is the value of
+/// `env_var`, or null when it is unset.
+///
+/// Unset, empty, `0`, `false` and `no` all mean no. Anything else means yes:
+/// the variable exists only to be switched on deliberately, so an unrecognised
+/// value is far likelier to be someone trying to enable it than someone trying
+/// to disable it.
+pub fn allowedByEnv(raw: ?[]const u8) bool {
+    const value = raw orelse return false;
+    if (value.len == 0) return false;
+    return !std.ascii.eqlIgnoreCase(value, "0") and
+        !std.ascii.eqlIgnoreCase(value, "false") and
+        !std.ascii.eqlIgnoreCase(value, "no");
+}
+
+/// Whether `host` names this machine over loopback.
+///
+/// Two families count: the loopback literals, and the `localhost` reserved TLD
+/// (RFC 6761 §6.3), which is what a local CA like tlsx issues for —
+/// `dashboard.stacks.localhost` and friends.
+///
+/// This is a check on the *name* the webview was asked to load, not on the
+/// address the connection reached: WKWebView does not hand us the peer, and
+/// `foo.localhost` resolving to loopback is a convention the resolver honours
+/// rather than something verifiable from here. That gap is exactly why the
+/// whole path is behind `env_var` instead of being on by default.
+///
+/// Matching is case-insensitive because DNS names are. A case-folded miss would
+/// fail safe, but it would fail *confusingly* — `https://Dashboard.localhost`
+/// working and `https://dashboard.localhost` not is nobody's idea of a good
+/// afternoon.
+pub fn isLocalHostName(host: []const u8) bool {
+    if (host.len == 0) return false;
+
+    // `NSURLProtectionSpace` hands back a bare host, but tolerate the URL's
+    // bracketed IPv6 form in case this is ever called with one.
+    const bare = if (host.len >= 2 and host[0] == '[' and host[host.len - 1] == ']')
+        host[1 .. host.len - 1]
+    else
+        host;
+
+    if (std.ascii.eqlIgnoreCase(bare, "localhost")) return true;
+    if (isLoopbackLiteral(bare)) return true;
+
+    // `*.localhost`, but not a bare `.localhost`: a leading-dot host is not a
+    // name anything can reach, so matching it would widen the exception for
+    // nothing.
+    const suffix = ".localhost";
+    return bare.len > suffix.len and
+        std.ascii.eqlIgnoreCase(bare[bare.len - suffix.len ..], suffix);
+}
+
+/// Whether `host` is an IP literal in a loopback range.
+///
+/// The whole of 127.0.0.0/8 counts, not just 127.0.0.1 — a local proxy handing
+/// each service its own 127.0.0.x is an ordinary way to keep them apart.
+/// Anything that is not an IP literal at all is not our business: it comes back
+/// false and is judged as a name instead.
+///
+/// Parsed by hand because this Zig has no `std.net`. Both parsers are strict
+/// and reject on anything they do not fully understand, which is the direction
+/// a check like this should fail in: an address we cannot read is an address we
+/// do not trust. That also disposes of the octal trick — `0177.0.0.1` is
+/// 127.0.0.1 to `inet_aton` and a four-digit group to this, so it is refused.
+fn isLoopbackLiteral(host: []const u8) bool {
+    if (parseIp4(host)) |octets| return octets[0] == 127;
+    if (parseIp6(host)) |groups| {
+        for (groups[0..7]) |group| {
+            if (group != 0) return false;
+        }
+        return groups[7] == 1;
+    }
+    return false;
+}
+
+/// Dotted-quad only: exactly four groups of one to three decimal digits, each
+/// no more than 255.
+fn parseIp4(host: []const u8) ?[4]u8 {
+    var octets: [4]u8 = undefined;
+    var parts = std.mem.splitScalar(u8, host, '.');
+    for (&octets) |*octet| {
+        const part = parts.next() orelse return null;
+        if (part.len == 0 or part.len > 3) return null;
+        octet.* = std.fmt.parseInt(u8, part, 10) catch return null;
+    }
+    if (parts.next() != null) return null;
+    return octets;
+}
+
+/// Eight 16-bit groups, with at most one `::` standing in for a run of zeroes.
+fn parseIp6(host: []const u8) ?[8]u16 {
+    if (std.mem.indexOf(u8, host, "::")) |elision| {
+        const head = host[0..elision];
+        const tail = host[elision + 2 ..];
+        // A second `::` is not a shorthand, it is a malformed address.
+        if (std.mem.indexOf(u8, tail, "::") != null) return null;
+
+        var groups: [8]u16 = @splat(0);
+        const head_len = fillGroups(&groups, head, 0) orelse return null;
+        // The elision has to stand for at least one group, so the two halves
+        // together must leave room.
+        const tail_len = countGroups(tail) orelse return null;
+        if (head_len + tail_len >= 8) return null;
+        _ = fillGroups(groups[8 - tail_len ..], tail, 0) orelse return null;
+        return groups;
+    }
+
+    var groups: [8]u16 = @splat(0);
+    const written = fillGroups(&groups, host, 0) orelse return null;
+    if (written != 8) return null;
+    return groups;
+}
+
+/// Write the colon-separated groups of `text` into `out`, returning how many
+/// there were, or null if any group is malformed or there are too many. An
+/// empty `text` is zero groups, which is what each side of a leading or
+/// trailing `::` looks like.
+fn fillGroups(out: []u16, text: []const u8, start: usize) ?usize {
+    if (text.len == 0) return start;
+    var written = start;
+    var parts = std.mem.splitScalar(u8, text, ':');
+    while (parts.next()) |part| {
+        if (part.len == 0 or part.len > 4) return null;
+        if (written == out.len) return null;
+        out[written] = std.fmt.parseInt(u16, part, 16) catch return null;
+        written += 1;
+    }
+    return written;
+}
+
+fn countGroups(text: []const u8) ?usize {
+    var scratch: [8]u16 = undefined;
+    return fillGroups(&scratch, text, 0);
+}
+
+// =============================================================================
+
+const testing = std.testing;
+
+test "the exception is off unless something switches it on" {
+    try testing.expect(!allowedByEnv(null));
+    try testing.expect(!allowedByEnv(""));
+    try testing.expect(!allowedByEnv("0"));
+    try testing.expect(!allowedByEnv("false"));
+    try testing.expect(!allowedByEnv("FALSE"));
+    try testing.expect(!allowedByEnv("no"));
+}
+
+test "anything else in the variable means the developer meant to set it" {
+    try testing.expect(allowedByEnv("1"));
+    try testing.expect(allowedByEnv("true"));
+    try testing.expect(allowedByEnv("yes"));
+    // Not a value anyone would type on purpose, but someone who exported this
+    // variable at all was trying to turn it on, not off.
+    try testing.expect(allowedByEnv("please"));
+}
+
+test "loopback literals and localhost are local" {
+    try testing.expect(isLocalHostName("localhost"));
+    try testing.expect(isLocalHostName("LocalHost"));
+    try testing.expect(isLocalHostName("127.0.0.1"));
+    // A local proxy giving each service its own loopback address.
+    try testing.expect(isLocalHostName("127.0.0.2"));
+    try testing.expect(isLocalHostName("127.255.255.254"));
+    try testing.expect(isLocalHostName("::1"));
+    try testing.expect(isLocalHostName("[::1]"));
+    try testing.expect(isLocalHostName("0:0:0:0:0:0:0:1"));
+}
+
+test "subdomains of the localhost TLD are local" {
+    try testing.expect(isLocalHostName("dashboard.stacks.localhost"));
+    try testing.expect(isLocalHostName("api.localhost"));
+    try testing.expect(isLocalHostName("Dashboard.Stacks.LOCALHOST"));
+}
+
+test "a name that merely looks local is not" {
+    // The whole point of the suffix check: these are ordinary internet hosts
+    // that an attacker controls, and none of them may skip validation.
+    try testing.expect(!isLocalHostName("localhost.evil.com"));
+    try testing.expect(!isLocalHostName("notlocalhost"));
+    try testing.expect(!isLocalHostName("mylocalhost"));
+    try testing.expect(!isLocalHostName("localhost.com"));
+    try testing.expect(!isLocalHostName("evil.com"));
+    try testing.expect(!isLocalHostName(""));
+    // A leading-dot host reaches nothing; matching it would widen the
+    // exception for no one's benefit.
+    try testing.expect(!isLocalHostName(".localhost"));
+}
+
+test "an address the parser cannot fully read is refused" {
+    // `inet_aton` reads a leading zero as octal and makes this 127.0.0.1. The
+    // parser here only speaks decimal dotted-quad, so it declines instead.
+    try testing.expect(!isLocalHostName("0177.0.0.1"));
+    try testing.expect(!isLocalHostName("127.0.0.1.5"));
+    try testing.expect(!isLocalHostName("127.0.0"));
+    try testing.expect(!isLocalHostName("127.0.0.256"));
+    try testing.expect(!isLocalHostName("127..0.1"));
+    // A host with the port still attached is not a host; fail safe rather than
+    // trying to guess where it ends.
+    try testing.expect(!isLocalHostName("127.0.0.1:3000"));
+    // Two elisions is malformed, not doubly convenient.
+    try testing.expect(!isLocalHostName("::1::1"));
+    try testing.expect(!isLocalHostName("0:0:0:0:0:0:1"));
+    try testing.expect(!isLocalHostName("::10000"));
+    // `::` on its own is the unspecified address, which is not loopback.
+    try testing.expect(!isLocalHostName("::"));
+    try testing.expect(!isLocalHostName("1::"));
+}
+
+test "non-loopback addresses are not local" {
+    try testing.expect(!isLocalHostName("128.0.0.1"));
+    try testing.expect(!isLocalHostName("126.255.255.255"));
+    try testing.expect(!isLocalHostName("192.168.1.10"));
+    try testing.expect(!isLocalHostName("10.0.0.1"));
+    try testing.expect(!isLocalHostName("0.0.0.0"));
+    try testing.expect(!isLocalHostName("::2"));
+    // A private-range address is still someone else's machine. `localhost` is
+    // about this process's own loopback, and nothing more.
+    try testing.expect(!isLocalHostName("169.254.1.1"));
+}

--- a/packages/zig/src/macos.zig
+++ b/packages/zig/src/macos.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const javascript = @import("javascript.zig");
 const native_sidebar_bootstrap = @import("native_sidebar_bootstrap.zig");
+const local_tls = @import("local_tls.zig");
 
 // Objective-C runtime types and functions (manual declarations to avoid @cImport issues)
 pub const objc = struct {
@@ -821,6 +822,14 @@ pub fn createWindowWithStyle(title: []const u8, width: u32, height: u32, html: ?
                 std.debug.print("[Media] Failed to setup UI delegate: {}\n", .{err});
         };
     }
+
+    // Not gated on dev_tools: whether the inspector is available and whether a
+    // local certificate is trusted are unrelated questions. Before the load
+    // below, so it is in place for the first request's challenge.
+    setupNavigationDelegate(webview) catch |err| {
+        if (comptime builtin.mode == .debug)
+            std.debug.print("[Nav] Failed to setup navigation delegate: {}\n", .{err});
+    };
 
     if (style.benchmark) {
         // Benchmark mode: minimal setup — just set content view and return
@@ -2076,6 +2085,13 @@ pub fn createWindowWithSidebar(
             std.debug.print("[Media] Failed to setup UI delegate: {}\n", .{err});
     };
 
+    // The HTML below is loaded against a localhost base URL, and anything it
+    // fetches over HTTPS gets the same treatment as a directly loaded URL.
+    setupNavigationDelegate(webview) catch |err| {
+        if (comptime builtin.mode == .debug)
+            std.debug.print("[Nav] Failed to setup navigation delegate: {}\n", .{err});
+    };
+
     // HTML loads unmodified — the scripts are user scripts on the controller.
     const html_cstr = try @import("memory.zig").dupeZ(std.heap.c_allocator, u8, html);
     defer std.heap.c_allocator.free(html_cstr);
@@ -3086,6 +3102,13 @@ pub fn createWindowWithSidebarURL(
     setupUIDelegate(webview) catch |err| {
         if (comptime builtin.mode == .debug)
             std.debug.print("[Media] Failed to setup UI delegate: {}\n", .{err});
+    };
+
+    // This is the path that loads a URL straight into a sidebar window — the
+    // one a local dashboard actually goes through.
+    setupNavigationDelegate(webview) catch |err| {
+        if (comptime builtin.mode == .debug)
+            std.debug.print("[Nav] Failed to setup navigation delegate: {}\n", .{err});
     };
 
     msgSendVoid1(webview, "setAutoresizingMask:", @as(c_ulong, 2 | 16 | 4)); // Width + Height + Left margin flexible
@@ -5093,6 +5116,146 @@ pub fn setupUIDelegate(webview: objc.id) !void {
 
     if (comptime builtin.mode == .debug)
         std.debug.print("[Media] UI delegate set successfully - camera/microphone permissions enabled\n", .{});
+}
+
+// ============================================================================
+// WKNavigationDelegate — local development TLS
+// ============================================================================
+//
+// A development proxy such as rpx fronts local services over HTTPS with a
+// certificate from a local CA (tlsx). That CA is not a public root, so
+// WKWebView rejects the certificate, fails the provisional navigation, and
+// leaves a blank window on something like `https://dashboard.stacks.localhost`
+// with no visible explanation.
+//
+// The exception below is opt-in and narrow: nothing happens at all unless
+// `CRAFT_ALLOW_LOCAL_TLS` is set, and even then only loopback and the
+// `localhost` TLD skip validation. See `local_tls.zig` for both rules and the
+// reasoning behind the environment variable; this file only wires them to
+// AppKit.
+
+/// Read once. A trust exception that could switch itself on part-way through a
+/// process's life would be harder to reason about, not easier.
+var local_tls_allowed: ?bool = null;
+
+fn allowsLocalDevTLS() bool {
+    if (local_tls_allowed) |cached| return cached;
+    const raw = std.c.getenv(local_tls.env_var);
+    const value: ?[]const u8 = if (raw) |v| std.mem.span(v) else null;
+    const allowed = local_tls.allowedByEnv(value);
+    local_tls_allowed = allowed;
+    return allowed;
+}
+
+/// Enough of the Objective-C block ABI to reach `invoke`. The layout is fixed:
+/// isa, flags, reserved, invoke, descriptor. Mirrors the block call in
+/// `handleMediaCapturePermission`, which takes one argument where this takes
+/// two.
+const AuthChallengeBlock = extern struct {
+    isa: ?*anyopaque,
+    flags: c_int,
+    reserved: c_int,
+    invoke: *const fn (*anyopaque, c_long, objc.id) callconv(.c) void,
+};
+
+/// `NSURLSessionAuthChallengeDisposition`.
+const AuthDisposition = enum(c_long) {
+    use_credential = 0,
+    perform_default_handling = 1,
+};
+
+/// Answer the challenge. This must happen exactly once on every path out of
+/// the delegate method: dropping the handler does not fail the load, it hangs
+/// it, and WKWebView will sit on a blank window forever waiting for a reply.
+fn finishAuthChallenge(handler: objc.id, disposition: AuthDisposition, credential: objc.id) void {
+    const h = handler orelse return;
+    const block: *AuthChallengeBlock = @ptrCast(@alignCast(h));
+    block.invoke(h, @intFromEnum(disposition), credential);
+}
+
+fn hostIsLocalDev(host: objc.id) bool {
+    const raw = msgSend0(host, "UTF8String") orelse return false;
+    const cstr: [*:0]const u8 = @ptrCast(@alignCast(raw));
+    return local_tls.isLocalHostName(std.mem.span(cstr));
+}
+
+/// `webView:didReceiveAuthenticationChallenge:completionHandler:`
+///
+/// Accepts the presented server trust for a local host, and takes default
+/// handling for everything else — every host on the internet, and every
+/// challenge that is not a TLS server trust (HTTP basic auth, client
+/// certificates). Default handling is ordinary validation, so falling through
+/// is always the safe answer.
+fn handleAuthChallenge(
+    _: objc.id,
+    _: objc.SEL,
+    _: objc.id,
+    challenge: objc.id,
+    completionHandler: objc.id,
+) callconv(.c) void {
+    const protectionSpace = msgSend0(challenge, "protectionSpace");
+    if (protectionSpace == null)
+        return finishAuthChallenge(completionHandler, .perform_default_handling, null);
+
+    // Non-null only for server-trust challenges.
+    const serverTrust = msgSend0(protectionSpace, "serverTrust");
+    if (serverTrust == null)
+        return finishAuthChallenge(completionHandler, .perform_default_handling, null);
+
+    if (!hostIsLocalDev(msgSend0(protectionSpace, "host")))
+        return finishAuthChallenge(completionHandler, .perform_default_handling, null);
+
+    if (comptime builtin.mode == .debug)
+        std.debug.print("[Nav] Trusting local development certificate\n", .{});
+
+    const NSURLCredential = getClass("NSURLCredential");
+    const credential = msgSend1(NSURLCredential, "credentialForTrust:", serverTrust);
+    finishAuthChallenge(completionHandler, .use_credential, credential);
+}
+
+/// Attach a `WKNavigationDelegate` that trusts local development certificates.
+///
+/// A no-op unless the process opted in: without `CRAFT_ALLOW_LOCAL_TLS` craft
+/// installs no navigation delegate at all, which is exactly the behaviour it
+/// has always had. Implementing only the auth-challenge method leaves every
+/// other navigation decision — policy, redirects, provisional failures — at its
+/// AppKit default.
+///
+/// Call before loading, so the delegate is in place for the first request's
+/// challenge.
+pub fn setupNavigationDelegate(webview: objc.id) !void {
+    if (!allowsLocalDevTLS()) return;
+
+    const superclass = getClass("NSObject");
+    const className = "CraftNavigationDelegate";
+
+    // May already exist: one delegate class serves every window.
+    var delegateClass = objc.objc_getClass(className);
+    if (delegateClass == null) {
+        delegateClass = objc.objc_allocateClassPair(@ptrCast(superclass), className, 0);
+        if (delegateClass == null)
+            return error.ClassAllocationFailed;
+
+        const method_sel = objc.sel_registerName("webView:didReceiveAuthenticationChallenge:completionHandler:");
+        const method_imp: objc.IMP = @ptrCast(@constCast(&handleAuthChallenge));
+        // void; self, _cmd, webView, challenge, completionHandler (block)
+        const method_types: [*c]const u8 = "v@:@@@?";
+        if (!objc.class_addMethod(@ptrCast(@alignCast(delegateClass)), method_sel, method_imp, method_types))
+            return error.MethodAdditionFailed;
+
+        objc.objc_registerClassPair(@ptrCast(delegateClass));
+    }
+
+    // `navigationDelegate` is a weak reference, so the +1 from `alloc`/`init`
+    // is what keeps this alive — one small object per window, deliberately
+    // never released. Balancing it would leave the webview pointing at freed
+    // memory the moment a challenge arrived.
+    const delegate_class_id: objc.id = @ptrCast(@alignCast(delegateClass));
+    const delegate = msgSend0(msgSend0(delegate_class_id, "alloc"), "init");
+    msgSendVoid1(webview, "setNavigationDelegate:", delegate);
+
+    if (comptime builtin.mode == .debug)
+        std.debug.print("[Nav] Local development TLS enabled via {s}\n", .{local_tls.env_var});
 }
 
 // ============================================================================


### PR DESCRIPTION
Replaces #17, whose window-activation half had already landed independently as `activateWindowedApp`.

## The problem

A development proxy such as rpx fronts local services over HTTPS with a certificate from a local CA. That CA is not a public root, so WKWebView rejects the certificate, fails the provisional navigation, and leaves a blank window on `https://dashboard.stacks.localhost` with nothing on screen to say why.

Craft set a `WKUIDelegate` for media permissions but never a `WKNavigationDelegate`, so nothing was there to answer the challenge.

## The fix

A `WKNavigationDelegate` implementing only `webView:didReceiveAuthenticationChallenge:completionHandler:` — every other navigation decision (policy, redirects, provisional failures) keeps its AppKit default.

It is attached at **all three** webview creation paths — `createWindowWithStyle`, `createWindowWithSidebar`, `createWindowWithSidebarURL` — since a local dashboard is as likely to be loaded into a sidebar window as a plain one. (#17 only covered the first.)

## The gate

The exception is opt-in through `CRAFT_ALLOW_LOCAL_TLS` and does nothing without it: no delegate is installed at all, which is exactly the behaviour craft has today.

An environment variable rather than a `WindowStyle` field or a CLI flag, because those travel from `craft.config.ts` into the built app — and a certificate bypass that can be committed to an app's config is one that eventually ships to users who never asked for it. This one is set on the machine doing the development and cannot be baked into the artefact.

Even when enabled it covers loopback (`127.0.0.0/8`, `::1`) and the `localhost` TLD only. Everything else takes default handling, which is ordinary validation — **including a host that resolves to loopback but is not named for it**. The check is on the name the webview was asked to load rather than the address it reached, because WKWebView does not hand over the peer; that gap is precisely why the whole path is behind an opt-in rather than on by default.

## Verification

The rules live in `local_tls.zig` with no AppKit in them, so they are tested directly — 7 tests over the opt-in parsing, the loopback literals, `*.localhost`, and the near-misses that must not match: `localhost.evil.com`, `mylocalhost`, `localhost.com`, `0177.0.0.1` (the octal spelling of 127.0.0.1), `::`, `1::`, and a host with the port still attached.

Then end to end against a self-signed HTTPS server, reading the **server's own request log** so that a trusted load and a rejected handshake are told apart by whether the request arrived at all — an untrusted client aborts before sending anything:

| opt-in | host | result |
| --- | --- | --- |
| absent | `localhost` | no request — unchanged from today |
| `=0` | `localhost` | no request |
| `=1` | `localhost` | **loaded** |
| `=1` | `127.0.0.1` | **loaded** |
| `=1` | `dashboard.stacks.localhost` | **loaded** |
| `=1` | `127.0.0.1.nip.io` | no request — resolves to loopback, not named for it |
| `=1` | `expired.badssl.com` | no request — real remote host, normally validated |

`zig build` and `zig build test` pass, and produce output identical to `main` (`main` emits 5 harmless `failed command` lines from window-spawning tests both before and after). `zig fmt --check` is clean on the new and modified build files; `macos.zig` fails it on `main` already and was not reformatted.

## Note on scope

`std.net` and `std.posix.getenv` are both absent from the pinned Zig, so the address literals are parsed by hand in `local_tls.zig` and the variable is read through `std.c.getenv`, which is what the rest of the repo uses. Both parsers are strict and refuse anything they do not fully understand, which is the direction a check like this should fail in.
