### PR TITLE
fix(build): keep unwind tables on Windows so the release can cross-compile

### DIFF
--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -103,7 +103,15 @@ pub fn build(b: *std.Build) void {
             // runtime, rather than giving it up for everyone.
             .single_threaded = !js_runtime_enabled,
             .strip = if (optimize != .debug) true else null,
-            .unwind_tables = if (optimize != .debug) .none else null,
+            // Never `.none` on Windows. The x64 ABI requires unwind data for
+            // non-leaf functions, and zig passes this module option down into
+            // the mingw-w64 CRT it builds for the target — where crtexe.c's
+            // inline `.seh_handler` has no active `.seh_proc` frame to attach
+            // to and the cross-compile dies on ".seh_ directive must appear
+            // within an active frame". The release workflow cross-compiles
+            // x86_64-windows from Linux, so this is the difference between a
+            // release happening and not.
+            .unwind_tables = if (optimize != .debug and target_os != .windows) .none else null,
             .omit_frame_pointer = if (optimize == .small) true else null,
             .error_tracing = if (optimize != .debug) false else null,
             .imports = &.{

--- a/pantry.lock
+++ b/pantry.lock
@@ -10,7 +10,7 @@
       },
       "system": {
         "bun.sh": "1.3.14",
-        "ziglang.org": "0.17.0-dev.1770_5d7cf3f34"
+        "ziglang.org": "0.17.0-dev.1509_bb296ab9b"
       }
     },
     "benchmarks": {
@@ -360,11 +360,11 @@
         "typescript"
       ]
     },
-    "ziglang.org@0.17.0-dev.1770_5d7cf3f34": {
+    "ziglang.org@0.17.0-dev.1509_bb296ab9b": {
       "name": "ziglang.org",
-      "version": "0.17.0-dev.1770_5d7cf3f34",
+      "version": "0.17.0-dev.1509_bb296ab9b",
       "source": "pantry",
-      "resolved": "registry:ziglang.org@0.17.0-dev.1770_5d7cf3f34"
+      "resolved": "registry:ziglang.org@0.17.0-dev.1509_bb296ab9b"
     }
   }
 }


### PR DESCRIPTION
**Releases have not been shipping.** Tags `v0.0.38` through `v0.0.66` all exist on the remote with no GitHub release behind them — the last one that landed was `v0.0.37`, in May. Nothing in the red CI is responsible: `main` has no branch protection, there are no required status checks, and `release.yml` has no `needs:` on any other workflow. It fails on its own.

## The Linux leg

```
error: sub-compilation of mingw-w64 crt2.o failed
  lib/libc/mingw/crt/crtexe.c:167:19: note: .seh_ directive must appear within an active frame
```

`build.zig` asked for `.unwind_tables = .none` on every non-debug build of the `craft` executable. Releases are `ReleaseSafe`, so that reached the mingw-w64 CRT zig builds for `x86_64-windows`, and `crtexe.c`'s inline `.seh_handler` had no `.seh_proc` frame to attach to.

The Windows x64 ABI requires unwind data for non-leaf functions, so `.none` was never valid for that target. The tell is that `craft-demo.exe`, which doesn't set the option, builds fine in the very same invocation.

### Verified against the compiler CI actually installs

Controlled, on `0.17.0-dev.1509+bb296ab9b`:

| | `zig build -Doptimize=ReleaseSafe -Dtarget=x86_64-windows` |
| --- | --- |
| without this change | `.seh_ directive must appear within an active frame` |
| with this change | `craft.exe`, 2,377,728 bytes |

Also checked on `0.17.0-dev.1770` (same result), and that the native host build is unaffected.

## The pantry.lock revert

5930464 moved the lock to `0.17.0-dev.1770` on the theory that the newer compiler built the mingw CRT cleanly. **It does not** — the error reproduces there too. And the commit was inert regardless: `deps.yaml:10` and `pantry.jsonc:10` still pin `.1509`, and pantry resolves the spec over the lock, saying so in every job:

```
ziglang.org: pantry.lock pins 0.17.0-dev.1770_5d7cf3f34 but deps spec is
0.17.0-dev.1509_bb296ab9b — lockfile is stale, resolving spec instead.
```

So CI has been on `.1509` throughout. Putting the lock back agrees the three files again without changing a single byte of what gets installed. The real bug was never the compiler — going the other way (bumping the spec to `.1770`) would have introduced a new failure, since the first-party zig-js does not compile there.

## ⚠️ Do not tag on the strength of this alone

This unblocks the **Linux** leg only. The darwin leg still fails at "Require macOS release credentials" (`release.yml:100`): the repo has exactly two secrets, `NPM_TOKEN` and `PANTRY_TOKEN`, and none of the seven `APPLE_*` values that gate requires. That gate was added in 1e50f98 on 2026-07-19 — after the last green release — so it has never once passed.

Because `fail-fast: false`, landing this alone would let the Linux leg reach "Publish & Release" and cut a GitHub release containing linux-x64 and windows-x64 binaries and **no macOS binaries**, while the `npm` job (`needs: [pantry]`) stays skipped. That is worse than a clean failure. The signing credentials are a decision, not a CI fix — restore them, drop macOS from the release matrix, or explicitly opt into unsigned builds.

**Separate operational note:** the tag trigger is not firing either. ~29 tags went up in a single bulk `git push --tags`, and GitHub suppresses workflow events past the first few in one push — there are zero tag-push runs of `release.yml` in that whole window. Push the next tag on its own and confirm a run actually starts, or use `workflow_dispatch`.
