### PR TITLE
fix(ci): get the CI workflow green again

### DIFF
--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -104,7 +104,13 @@ jobs:
         id: baseline
         run: |
           git fetch origin main
-          trap 'git restore --source=HEAD -- packages/zig' EXIT
+          # Anchored at the workspace and `|| true`-guarded on purpose: the trap
+          # fires at the end of the step, by which point `cd packages/zig` below
+          # has moved us, so a relative pathspec resolves against the wrong
+          # directory and fails. Under `set -e` that failing restore became the
+          # step's exit status, so every pull request got a red Binary Size
+          # check for a cleanup step rather than for its binary size.
+          trap 'git -C "$GITHUB_WORKSPACE" restore --staged --worktree --source=HEAD -- packages/zig || true' EXIT
           git checkout origin/main -- packages/zig
 
           cd packages/zig

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -34,6 +34,15 @@ jobs:
   track:
     runs-on: ubuntu-latest
 
+    # The last step posts the size report as a pull request comment, and the
+    # default token here is read-only, so it failed with "Resource not
+    # accessible by integration" — after the build and the measuring had all
+    # succeeded. Requested explicitly rather than left to the repository
+    # default, which is what made this invisible.
+    permissions:
+      contents: read
+      pull-requests: write
+
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,12 @@ defaults:
 jobs:
   zig-core:
     strategy:
+      # Without this, one red leg cancels the others mid-step and nobody sees a
+      # result for the platforms that were fine. release.yml and
+      # native-lifecycle.yml both already set it.
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}
 

--- a/bun.lock
+++ b/bun.lock
@@ -83,7 +83,7 @@
       "version": "0.0.66",
       "devDependencies": {
         "@types/bun": "^1.2.0",
-        "ts-maps": "^0.2.7",
+        "ts-maps": "^0.3.1",
         "very-happy-dom": "^0.1.4",
       },
     },
@@ -91,8 +91,7 @@
       "name": "craft-native",
       "version": "0.0.66",
       "bin": {
-        "craft": "./bin/cli.ts",
-        "craft-sdk": "./bin/cli.ts",
+        "craft-sdk": "./dist/cli.js",
       },
       "devDependencies": {
         "@stacksjs/clapp": "^0.2.0",
@@ -113,6 +112,9 @@
         "vue": "^3.0.0",
       },
     },
+  },
+  "patchedDependencies": {
+    "ts-maps@0.3.1": "patches/ts-maps@0.3.1.patch",
   },
   "packages": {
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
@@ -621,7 +623,7 @@
 
     "ts-jpeg": ["ts-jpeg@0.3.1", "", {}, "sha512-KIGTJj4UIlkGoCFEofx8jHHQEkJfSLFJY0MHz60Mu4Scjrcj7K/0UJGCbL9QvfIaFGAOGdf0xNFpYSuzUpimwA=="],
 
-    "ts-maps": ["ts-maps@0.2.7", "", {}, "sha512-Acfyp2TfHqrycAS+fy09t/XjPdcnY3cIjdSxRCaeI41HBANGrIQZ0I0/cL+nVRtgLg0cK3Hw0pkRoZIT6hW6sw=="],
+    "ts-maps": ["ts-maps@0.3.1", "", {}, "sha512-/ree3wHYTEsVTf0vOvNBeqDCLjkT2VejVrycNd2y8ev8LbP7fPxvEcoau8a3AuY+E6wcLRgJy2YruMy6bmBC2Q=="],
 
     "ts-pantry": ["ts-pantry@0.9.37", "", { "dependencies": { "@stacksjs/ts-cloud": "^0.2.19", "bunfig": "^0.15.6", "ts-web-scraper": "^0.1.1" }, "bin": { "ts-pantry": "./dist/bin/cli.js" } }, "sha512-mEm/uxcxroKGZTRwXRpvFBs47wLR2djN3zO627Yy/42cmjtY74OuUewhgh1Th9qXhPPHS3zEkE+dMK6RK0rXfw=="],
 

--- a/package.json
+++ b/package.json
@@ -66,5 +66,8 @@
     },
     "pre-push": "bun run typecheck",
     "commit-msg": "bun x gitlint --edit .git/COMMIT_EDITMSG"
+  },
+  "patchedDependencies": {
+    "ts-maps@0.3.1": "patches/ts-maps@0.3.1.patch"
   }
 }

--- a/packages/ts-maps/package.json
+++ b/packages/ts-maps/package.json
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@types/bun": "^1.2.0",
-    "ts-maps": "^0.2.7",
+    "ts-maps": "^0.3.1",
     "very-happy-dom": "^0.1.4"
   }
 }

--- a/packages/ts-maps/scripts/finalize-types.ts
+++ b/packages/ts-maps/scripts/finalize-types.ts
@@ -1,12 +1,47 @@
 #!/usr/bin/env bun
-import { cpSync, existsSync, rmSync } from 'node:fs'
+import { cpSync, existsSync, readdirSync, rmSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 
-const nested = join('dist', 'Tools', 'craft', 'packages', 'ts-maps', 'src')
+// tsc derives rootDir from the common ancestor of every file it compiles, and
+// this package deliberately imports a few modules straight out of
+// ../typescript/src (see MapView.ts and FilesystemTileBackend.ts). That pushes
+// the ancestor up to `packages/`, so the declarations land in a nested tree
+// rather than in dist/ — and exactly how deep that tree is depends on where the
+// checkout happens to live.
+//
+// So find it rather than assume it. The previous version of this script looked
+// for `dist/Tools/craft/packages/ts-maps/src`, which existed only on the
+// machine it was written on and failed everywhere else, CI included.
 
-if (!existsSync(nested))
-  throw new Error(`Expected TypeScript declarations at ${nested}`)
+const DIST = 'dist'
 
-cpSync(nested, 'dist', { recursive: true })
-rmSync(join('dist', 'Tools'), { recursive: true, force: true })
-rmSync(join('dist', 'Libraries'), { recursive: true, force: true })
+/** The emitted declarations for *this* package: a `.../ts-maps/src` holding index.d.ts. */
+function findDeclarationRoot(dir: string): string | null {
+  if (dir.endsWith(join('ts-maps', 'src')) && existsSync(join(dir, 'index.d.ts')))
+    return dir
+
+  for (const entry of readdirSync(dir)) {
+    const child = join(dir, entry)
+    if (!statSync(child).isDirectory())
+      continue
+    const found = findDeclarationRoot(child)
+    if (found)
+      return found
+  }
+  return null
+}
+
+// Nothing to flatten if tsc already emitted at the top level — which is what
+// happens the moment those cross-package imports go away.
+if (!existsSync(join(DIST, 'index.d.ts'))) {
+  const declarations = findDeclarationRoot(DIST)
+  if (!declarations)
+    throw new Error(`No TypeScript declarations found anywhere under ${DIST}/`)
+
+  // Every top-level directory here is part of the nested emit: the bundler
+  // writes only files to dist/. Capture them before the copy adds more.
+  const nested = readdirSync(DIST).filter(entry => statSync(join(DIST, entry)).isDirectory())
+
+  cpSync(declarations, DIST, { recursive: true })
+  for (const dir of nested) rmSync(join(DIST, dir), { recursive: true, force: true })
+}

--- a/packages/typescript/src/package.test.ts
+++ b/packages/typescript/src/package.test.ts
@@ -62,7 +62,7 @@ describe('macOS packaging diagnostics', () => {
       '-srcfolder', '/tmp/Craft.app',
       '-size', '157m',
       '-ov',
-      '-format', 'UDZO',
+      '-format', 'ULMO',
       '/tmp/Craft.dmg',
     ])
   })

--- a/packages/zig/src/api_http.zig
+++ b/packages/zig/src/api_http.zig
@@ -76,7 +76,7 @@ pub const HttpClient = struct {
         }
 
         return Response{
-            .status = @intFromEnum(req.response.status),
+            .status = @backingInt(req.response.status),
             .headers = if (have_headers) response_headers else blk: {
                 response_headers.deinit();
                 break :blk null;

--- a/packages/zig/src/bluetooth.zig
+++ b/packages/zig/src/bluetooth.zig
@@ -92,7 +92,7 @@ pub const CharacteristicProperty = enum(u8) {
     extended_properties = 0x80,
 
     pub fn toValue(self: CharacteristicProperty) u8 {
-        return @intFromEnum(self);
+        return @backingInt(self);
     }
 };
 

--- a/packages/zig/src/bridge_api.zig
+++ b/packages/zig/src/bridge_api.zig
@@ -54,7 +54,7 @@ pub const BridgeAPI = struct {
     /// Generate JavaScript injection code
     pub fn generateInjectionScript(self: *Self) ![]const u8 {
         _ = self;
-        return 
+        return
         \\(function() {
         \\  window.craft = {
         \\    tray: {

--- a/packages/zig/src/bridge_async.zig
+++ b/packages/zig/src/bridge_async.zig
@@ -35,7 +35,7 @@ pub const MessageHeader = packed struct {
         var buffer: [14]u8 = undefined;
         std.mem.writeInt(u32, buffer[0..4], self.magic, .little);
         buffer[4] = self.version;
-        buffer[5] = @intFromEnum(self.type);
+        buffer[5] = @backingInt(self.type);
         std.mem.writeInt(u32, buffer[6..10], self.id, .little);
         std.mem.writeInt(u32, buffer[10..14], self.payload_len, .little);
         return buffer;
@@ -50,7 +50,7 @@ pub const MessageHeader = packed struct {
         return MessageHeader{
             .magic = magic,
             .version = buffer[4],
-            .type = @enumFromInt(buffer[5]),
+            .type = @fromBackingInt(@intCast(buffer[5])),
             .id = std.mem.readInt(u32, buffer[6..10], .little),
             .payload_len = std.mem.readInt(u32, buffer[10..14], .little),
         };

--- a/packages/zig/src/bridge_focus.zig
+++ b/packages/zig/src/bridge_focus.zig
@@ -215,7 +215,7 @@ pub const FocusBridge = struct {
         };
         const exit_code: i32 = switch (term) {
             .exited => |code| @intCast(code),
-            .signal => |sig| -@as(i32, @intCast(@intFromEnum(sig))),
+            .signal => |sig| -@as(i32, @intCast(@backingInt(sig))),
             else => -1,
         };
 

--- a/packages/zig/src/bridge_sdk.zig
+++ b/packages/zig/src/bridge_sdk.zig
@@ -112,8 +112,8 @@ const InternalError = enum {
 
     fn code(self: InternalError) i32 {
         return switch (self) {
-            .invalid_json_id_unavailable, .missing_method => @intFromEnum(ErrorCode.protocol_mismatch),
-            .handler_failed => @intFromEnum(ErrorCode.unknown),
+            .invalid_json_id_unavailable, .missing_method => @backingInt(ErrorCode.protocol_mismatch),
+            .handler_failed => @backingInt(ErrorCode.unknown),
         };
     }
 };

--- a/packages/zig/src/bridge_shell.zig
+++ b/packages/zig/src/bridge_shell.zig
@@ -253,7 +253,7 @@ pub const ShellBridge = struct {
 
         const exit_code: i32 = switch (term) {
             .exited => |code| @intCast(code),
-            .signal => |sig| -@as(i32, @intCast(@intFromEnum(sig))),
+            .signal => |sig| -@as(i32, @intCast(@backingInt(sig))),
             else => -1,
         };
 

--- a/packages/zig/src/cast.zig
+++ b/packages/zig/src/cast.zig
@@ -677,7 +677,7 @@ pub const CastController = struct {
     }
 
     pub fn setProtocolEnabled(self: *CastController, protocol: CastProtocol, enabled: bool) void {
-        const bit = @as(u8, 1) << @intFromEnum(protocol);
+        const bit = @as(u8, 1) << @backingInt(protocol);
         if (enabled) {
             self.supported_protocols |= bit;
         } else {
@@ -686,7 +686,7 @@ pub const CastController = struct {
     }
 
     pub fn isProtocolEnabled(self: CastController, protocol: CastProtocol) bool {
-        const bit = @as(u8, 1) << @intFromEnum(protocol);
+        const bit = @as(u8, 1) << @backingInt(protocol);
         return (self.supported_protocols & bit) != 0;
     }
 };

--- a/packages/zig/src/components/native_split_view.zig
+++ b/packages/zig/src/components/native_split_view.zig
@@ -34,7 +34,7 @@ pub const NativeSplitView = struct {
 
         // Configure split view
         _ = macos.msgSend1(split_view, "setVertical:", @as(c_int, 1)); // Vertical split (side-by-side)
-        _ = macos.msgSend1(split_view, "setDividerStyle:", @intFromEnum(config.divider_style));
+        _ = macos.msgSend1(split_view, "setDividerStyle:", @backingInt(config.divider_style));
 
         // Set autosave name for divider position persistence
         const autosave_name = macos.createNSString("CraftSplitView");

--- a/packages/zig/src/database.zig
+++ b/packages/zig/src/database.zig
@@ -450,7 +450,7 @@ pub const Statement = struct {
         const handle = self.stmt_handle orelse return DatabaseError.InvalidQuery;
         const rc = sqlite3_step(handle);
         if (rc != SQLITE_DONE and rc != SQLITE_ROW) {
-            const result: SqliteResult = @enumFromInt(rc);
+            const result: SqliteResult = @fromBackingInt(@intCast(rc));
             return result.toError() orelse DatabaseError.StepFailed;
         }
     }
@@ -472,7 +472,7 @@ pub const Statement = struct {
             const rc = sqlite3_step(handle);
             if (rc == SQLITE_DONE) break;
             if (rc != SQLITE_ROW) {
-                const result: SqliteResult = @enumFromInt(rc);
+                const result: SqliteResult = @fromBackingInt(@intCast(rc));
                 return result.toError() orelse DatabaseError.StepFailed;
             }
 
@@ -735,7 +735,7 @@ pub const Database = struct {
         const rc = sqlite3_exec(handle, sql_z.ptr, null, null, &errmsg);
         if (rc != SQLITE_OK) {
             if (errmsg) |msg| sqlite3_free(@ptrCast(msg));
-            const result: SqliteResult = @enumFromInt(rc);
+            const result: SqliteResult = @fromBackingInt(@intCast(rc));
             return result.toError() orelse DatabaseError.QueryFailed;
         }
     }

--- a/packages/zig/src/error_context.zig
+++ b/packages/zig/src/error_context.zig
@@ -125,7 +125,7 @@ pub const ErrorCode = enum(u32) {
     shader_compilation_failed = 1902,
 
     pub fn getCategory(self: ErrorCode) ErrorCategory {
-        const code = @intFromEnum(self);
+        const code = @backingInt(self);
         return switch (code / 100) {
             10 => .memory,
             11 => .io,
@@ -270,7 +270,7 @@ pub const ErrorContext = struct {
         const header = try std.fmt.allocPrint(allocator, "[{s}] {s} (Code: {d})\n", .{
             self.severity.toString(),
             self.code.getCategory().toString(),
-            @intFromEnum(self.code),
+            @backingInt(self.code),
         });
         defer allocator.free(header);
         try buf.appendSlice(allocator, header);

--- a/packages/zig/src/http.zig
+++ b/packages/zig/src/http.zig
@@ -142,22 +142,22 @@ pub const StatusCode = enum(u16) {
     _,
 
     pub fn isSuccess(self: StatusCode) bool {
-        const code = @intFromEnum(self);
+        const code = @backingInt(self);
         return code >= 200 and code < 300;
     }
 
     pub fn isRedirect(self: StatusCode) bool {
-        const code = @intFromEnum(self);
+        const code = @backingInt(self);
         return code >= 300 and code < 400;
     }
 
     pub fn isClientError(self: StatusCode) bool {
-        const code = @intFromEnum(self);
+        const code = @backingInt(self);
         return code >= 400 and code < 500;
     }
 
     pub fn isServerError(self: StatusCode) bool {
-        const code = @intFromEnum(self);
+        const code = @backingInt(self);
         return code >= 500 and code < 600;
     }
 
@@ -767,7 +767,7 @@ pub const WebSocket = struct {
         self.request = request;
         request.sendBodiless() catch return HttpError.NetworkError;
         const response = request.receiveHead(&.{}) catch return HttpError.InvalidResponse;
-        if (@intFromEnum(response.head.status) != 101) return HttpError.InvalidResponse;
+        if (@backingInt(response.head.status) != 101) return HttpError.InvalidResponse;
 
         var sha1 = std.crypto.hash.Sha1.init(.{});
         sha1.update(key);
@@ -1007,8 +1007,8 @@ pub const HttpClient = struct {
         const body = try body_list.toOwnedSlice(self.allocator);
         errdefer self.allocator.free(body);
         var response = Response{
-            .status = @intFromEnum(incoming.head.status),
-            .status_code = @enumFromInt(@intFromEnum(incoming.head.status)),
+            .status = @backingInt(incoming.head.status),
+            .status_code = @fromBackingInt(@intCast(@backingInt(incoming.head.status))),
             .headers = response_headers,
             .body = body,
             .url = full_url,

--- a/packages/zig/src/js/craft-gestures.js
+++ b/packages/zig/src/js/craft-gestures.js
@@ -17,7 +17,7 @@
   window.craft = window.craft || {}
   if (window.craft.gestures) return
 
-  var listeners = []
+  const listeners = []
 
   window.craft.gestures = {
     /**
@@ -37,7 +37,7 @@
       if (typeof callback !== 'function') return function () {}
       listeners.push(callback)
       return function off() {
-        var at = listeners.indexOf(callback)
+        const at = listeners.indexOf(callback)
         if (at !== -1) listeners.splice(at, 1)
       }
     },
@@ -47,7 +47,7 @@
       // Iterate a copy: a listener that unsubscribes itself mid-dispatch
       // would otherwise shift the array out from under the loop and skip the
       // next listener.
-      var current = listeners.slice()
+      const current = listeners.slice()
       for (var i = 0; i < current.length; i++) {
         try {
           current[i](swipe)

--- a/packages/zig/src/linux/dbus.zig
+++ b/packages/zig/src/linux/dbus.zig
@@ -208,7 +208,7 @@ pub const Connection = struct {
         user_data: ?*anyopaque,
     ) c_uint {
         return c.g_bus_own_name(
-            @intFromEnum(bus_type),
+            @backingInt(bus_type),
             name,
             flags,
             bus_acquired,
@@ -243,7 +243,7 @@ pub const Proxy = struct {
     ) !Self {
         var err: ?*GError = null;
         const proxy = c.g_dbus_proxy_new_for_bus_sync(
-            @intFromEnum(bus_type),
+            @backingInt(bus_type),
             c.G_DBUS_PROXY_FLAGS_NONE,
             null,
             name,
@@ -822,7 +822,7 @@ pub const NetworkManager = struct {
         if (@constCast(&proxy).getProperty("Connectivity")) |variant| {
             defer c.g_variant_unref(variant);
             const state = c.g_variant_get_uint32(variant);
-            return @enumFromInt(state);
+            return @fromBackingInt(@intCast(state));
         }
         return .unknown;
     }
@@ -1160,11 +1160,11 @@ pub const FlatpakPortal = struct {
 // ============================================
 
 test "BusType enum values" {
-    try std.testing.expectEqual(@as(c_int, c.G_BUS_TYPE_SESSION), @intFromEnum(BusType.session));
-    try std.testing.expectEqual(@as(c_int, c.G_BUS_TYPE_SYSTEM), @intFromEnum(BusType.system));
+    try std.testing.expectEqual(@as(c_int, c.G_BUS_TYPE_SESSION), @backingInt(BusType.session));
+    try std.testing.expectEqual(@as(c_int, c.G_BUS_TYPE_SYSTEM), @backingInt(BusType.system));
 }
 
 test "NetworkManager ConnectivityState" {
-    try std.testing.expectEqual(@as(u32, 0), @intFromEnum(NetworkManager.ConnectivityState.unknown));
-    try std.testing.expectEqual(@as(u32, 4), @intFromEnum(NetworkManager.ConnectivityState.full));
+    try std.testing.expectEqual(@as(u32, 0), @backingInt(NetworkManager.ConnectivityState.unknown));
+    try std.testing.expectEqual(@as(u32, 4), @backingInt(NetworkManager.ConnectivityState.full));
 }

--- a/packages/zig/src/linux/gtk4.zig
+++ b/packages/zig/src/linux/gtk4.zig
@@ -224,7 +224,7 @@ pub const Box = struct {
     widget: *GtkBox,
 
     pub fn init(orientation: Orientation, spacing: c_int) Self {
-        const box = c.gtk_box_new(@intFromEnum(orientation), spacing);
+        const box = c.gtk_box_new(@backingInt(orientation), spacing);
         return Self{ .widget = @ptrCast(box) };
     }
 
@@ -565,7 +565,7 @@ pub const Paned = struct {
     widget: *GtkPaned,
 
     pub fn init(orientation: Orientation) Self {
-        const paned = c.gtk_paned_new(@intFromEnum(orientation));
+        const paned = c.gtk_paned_new(@backingInt(orientation));
         return Self{ .widget = @ptrCast(paned) };
     }
 
@@ -695,8 +695,8 @@ pub fn setExpand(widget: *GtkWidget, hexpand: bool, vexpand: bool) void {
 
 /// Set widget alignment
 pub fn setAlign(widget: *GtkWidget, halign: Align, valign: Align) void {
-    c.gtk_widget_set_halign(widget, @intFromEnum(halign));
-    c.gtk_widget_set_valign(widget, @intFromEnum(valign));
+    c.gtk_widget_set_halign(widget, @backingInt(halign));
+    c.gtk_widget_set_valign(widget, @backingInt(valign));
 }
 
 /// Show widget
@@ -1320,7 +1320,7 @@ pub const Scale = struct {
     user_data: ?*anyopaque,
 
     pub fn init(orientation: Orientation, min: f64, max: f64, step: f64) Self {
-        const scale = c.gtk_scale_new_with_range(@intFromEnum(orientation), min, max, step);
+        const scale = c.gtk_scale_new_with_range(@backingInt(orientation), min, max, step);
         return Self{
             .widget = @ptrCast(scale),
             .on_value_changed = null,

--- a/packages/zig/src/log.zig
+++ b/packages/zig/src/log.zig
@@ -93,14 +93,14 @@ pub fn getLevel() LogLevel {
 pub fn shouldLog(level: LogLevel) bool {
     log_mutex.lock();
     defer log_mutex.unlock();
-    return @intFromEnum(level) >= @intFromEnum(current_config.min_level);
+    return @backingInt(level) >= @backingInt(current_config.min_level);
 }
 
 /// Internal, lock-free variant used by `log()` while it already holds
 /// `log_mutex`. Keeping the public `shouldLog` locked means callers that
 /// call it outside `log()` still observe consistent state.
 fn shouldLogLocked(level: LogLevel) bool {
-    return @intFromEnum(level) >= @intFromEnum(current_config.min_level);
+    return @backingInt(level) >= @backingInt(current_config.min_level);
 }
 
 pub fn log(

--- a/packages/zig/src/logging.zig
+++ b/packages/zig/src/logging.zig
@@ -111,7 +111,7 @@ fn logInternal(
     src: std.builtin.SourceLocation,
 ) void {
     // Check if we should log at this level
-    if (@intFromEnum(level) < @intFromEnum(global_config.level)) {
+    if (@backingInt(level) < @backingInt(global_config.level)) {
         return;
     }
 
@@ -297,11 +297,11 @@ pub const shortcuts = scoped("Shortcuts");
 // ============================================
 
 test "log level ordering" {
-    try std.testing.expect(@intFromEnum(LogLevel.trace) < @intFromEnum(LogLevel.debug));
-    try std.testing.expect(@intFromEnum(LogLevel.debug) < @intFromEnum(LogLevel.info));
-    try std.testing.expect(@intFromEnum(LogLevel.info) < @intFromEnum(LogLevel.warn));
-    try std.testing.expect(@intFromEnum(LogLevel.warn) < @intFromEnum(LogLevel.err));
-    try std.testing.expect(@intFromEnum(LogLevel.err) < @intFromEnum(LogLevel.fatal));
+    try std.testing.expect(@backingInt(LogLevel.trace) < @backingInt(LogLevel.debug));
+    try std.testing.expect(@backingInt(LogLevel.debug) < @backingInt(LogLevel.info));
+    try std.testing.expect(@backingInt(LogLevel.info) < @backingInt(LogLevel.warn));
+    try std.testing.expect(@backingInt(LogLevel.warn) < @backingInt(LogLevel.err));
+    try std.testing.expect(@backingInt(LogLevel.err) < @backingInt(LogLevel.fatal));
 }
 
 test "scoped logger" {

--- a/packages/zig/src/macos.zig
+++ b/packages/zig/src/macos.zig
@@ -801,7 +801,6 @@ pub fn createWindowWithStyle(title: []const u8, width: u32, height: u32, html: ?
         }
     }
 
-
     // Cosmetic and lazily-needed setup, now overlapping the fetch.
     const wants_translucent_surface = style.transparent or style.titlebar_hidden or style.native_sidebar or style.web_sidebar_material;
     if (!style.benchmark and wants_translucent_surface) {
@@ -5170,7 +5169,7 @@ const AuthDisposition = enum(c_long) {
 fn finishAuthChallenge(handler: objc.id, disposition: AuthDisposition, credential: objc.id) void {
     const h = handler orelse return;
     const block: *AuthChallengeBlock = @ptrCast(@alignCast(h));
-    block.invoke(h, @intFromEnum(disposition), credential);
+    block.invoke(h, @backingInt(disposition), credential);
 }
 
 fn hostIsLocalDev(host: objc.id) bool {

--- a/packages/zig/src/macos/advanced_features.zig
+++ b/packages/zig/src/macos/advanced_features.zig
@@ -289,7 +289,7 @@ pub const Menu = struct {
                     // Set properties
                     _ = objc.objc_msgSend(mi, objc.sel_registerName("setTag:"), item_config.tag);
                     _ = objc.objc_msgSend(mi, objc.sel_registerName("setEnabled:"), @as(i8, if (item_config.enabled) 1 else 0));
-                    _ = objc.objc_msgSend(mi, objc.sel_registerName("setState:"), @intFromEnum(item_config.state));
+                    _ = objc.objc_msgSend(mi, objc.sel_registerName("setState:"), @backingInt(item_config.state));
 
                     if (item_config.image) |img| {
                         _ = objc.objc_msgSend(mi, objc.sel_registerName("setImage:"), img);

--- a/packages/zig/src/macos/memory_management.zig
+++ b/packages/zig/src/macos/memory_management.zig
@@ -31,7 +31,7 @@ pub fn setAssociatedObject(
     const objc_setAssociatedObject = @extern(*const fn (objc.id, [*:0]const u8, ?objc.id, usize) callconv(.c) void, .{
         .name = "objc_setAssociatedObject",
     });
-    objc_setAssociatedObject(object, key, value, @intFromEnum(policy));
+    objc_setAssociatedObject(object, key, value, @backingInt(policy));
 }
 
 /// Get an associated object from an ObjC object

--- a/packages/zig/src/macos/sf_symbols.zig
+++ b/packages/zig/src/macos/sf_symbols.zig
@@ -204,7 +204,7 @@ fn createSymbolConfiguration(config: SymbolConfiguration) objc.id {
         NSImageSymbolConfiguration,
         "configurationWithPointSize:weight:",
         config.point_size,
-        @intFromEnum(config.weight),
+        @backingInt(config.weight),
     );
 
     return symbol_config;

--- a/packages/zig/src/menubar.zig
+++ b/packages/zig/src/menubar.zig
@@ -527,7 +527,7 @@ pub const Linux = struct {
             self.status = status;
             // In a real implementation:
             // app_indicator_set_status(self.app_indicator, status);
-            log.debug("Linux AppIndicator status set: {}", .{@intFromEnum(status)});
+            log.debug("Linux AppIndicator status set: {}", .{@backingInt(status)});
         }
 
         pub fn setIcon(self: *Indicator, icon_name: []const u8) void {
@@ -1162,11 +1162,11 @@ test "windows tray icon creation" {
 }
 
 test "windows balloon icon types" {
-    try std.testing.expectEqual(@as(u32, 0), @intFromEnum(Windows.BalloonIconType.none));
-    try std.testing.expectEqual(@as(u32, 1), @intFromEnum(Windows.BalloonIconType.info));
-    try std.testing.expectEqual(@as(u32, 2), @intFromEnum(Windows.BalloonIconType.warning));
-    try std.testing.expectEqual(@as(u32, 3), @intFromEnum(Windows.BalloonIconType.@"error"));
-    try std.testing.expectEqual(@as(u32, 4), @intFromEnum(Windows.BalloonIconType.user));
+    try std.testing.expectEqual(@as(u32, 0), @backingInt(Windows.BalloonIconType.none));
+    try std.testing.expectEqual(@as(u32, 1), @backingInt(Windows.BalloonIconType.info));
+    try std.testing.expectEqual(@as(u32, 2), @backingInt(Windows.BalloonIconType.warning));
+    try std.testing.expectEqual(@as(u32, 3), @backingInt(Windows.BalloonIconType.@"error"));
+    try std.testing.expectEqual(@as(u32, 4), @backingInt(Windows.BalloonIconType.user));
 }
 
 test "click action types" {

--- a/packages/zig/src/message_queue.zig
+++ b/packages/zig/src/message_queue.zig
@@ -19,7 +19,7 @@ pub const Priority = enum(u8) {
     Critical = 3,
 
     pub fn compare(a: Priority, b: Priority) std.math.Order {
-        return std.math.order(@intFromEnum(a), @intFromEnum(b));
+        return std.math.order(@backingInt(a), @backingInt(b));
     }
 };
 
@@ -254,7 +254,7 @@ pub const MessageQueue = struct {
 
     fn comparePriority(_: void, a: QueuedMessage, b: QueuedMessage) bool {
         // Higher priority first
-        return @intFromEnum(a.priority) > @intFromEnum(b.priority);
+        return @backingInt(a.priority) > @backingInt(b.priority);
     }
 };
 

--- a/packages/zig/src/mobile.zig
+++ b/packages/zig/src/mobile.zig
@@ -1286,7 +1286,7 @@ pub const Android = struct {
         const permission_jstring = jni.NewStringUTF(env, permission_z.ptr);
 
         // Use a unique request code based on permission type
-        const request_code: u32 = 1001 + @intFromEnum(permission);
+        const request_code: u32 = 1001 + @backingInt(permission);
 
         // Store callback to be invoked in onRequestPermissionsResult
         if (callback) |cb| {

--- a/packages/zig/src/reminders.zig
+++ b/packages/zig/src/reminders.zig
@@ -29,7 +29,7 @@ pub const TaskPriority = enum(u8) {
     high = 9,
 
     pub fn toValue(self: TaskPriority) u8 {
-        return @intFromEnum(self);
+        return @backingInt(self);
     }
 
     pub fn toString(self: TaskPriority) []const u8 {
@@ -105,12 +105,12 @@ pub const DayOfWeek = enum(u8) {
     saturday = 6,
 
     pub fn toValue(self: DayOfWeek) u8 {
-        return @intFromEnum(self);
+        return @backingInt(self);
     }
 
     pub fn fromValue(value: u8) ?DayOfWeek {
         if (value > 6) return null;
-        return @enumFromInt(value);
+        return @fromBackingInt(@intCast(value));
     }
 
     pub fn toString(self: DayOfWeek) []const u8 {
@@ -958,7 +958,7 @@ pub const DateUtils = struct {
     pub fn getDayOfWeek(timestamp: i64) DayOfWeek {
         const days_since_epoch = @divFloor(timestamp, day_ms);
         const dow = @mod(days_since_epoch + 4, 7);
-        return @enumFromInt(@as(u8, @intCast(dow)));
+        return @fromBackingInt(@intCast(@as(u8, @intCast(dow))));
     }
 
     pub fn isWeekend(timestamp: i64) bool {

--- a/packages/zig/src/screen_sharing.zig
+++ b/packages/zig/src/screen_sharing.zig
@@ -156,7 +156,7 @@ pub const Digest = struct {
         // FNV-1a per entry, XOR-combined so poll-to-poll window reordering
         // (which CGWindowList does freely) doesn't look like a state change.
         var h: u64 = 0xcbf29ce484222325;
-        h = mix(h, @intFromEnum(kind));
+        h = mix(h, @backingInt(kind));
         for (app) |c| h = mix(h, lower(c));
         h = mix(h, 0x1f);
         for (window) |c| h = mix(h, lower(c));

--- a/packages/zig/src/startup_timing.zig
+++ b/packages/zig/src/startup_timing.zig
@@ -60,7 +60,7 @@ pub fn start() void {
     enabled = true;
     origin_ns = compat.nanoTimestamp();
     stamps = @splat(null);
-    stamps[@intFromEnum(Phase.process_start)] = origin_ns;
+    stamps[@backingInt(Phase.process_start)] = origin_ns;
 }
 
 /// Record a phase. A no-op unless `start()` ran, so call sites need no guard.
@@ -70,14 +70,14 @@ pub fn start() void {
 /// question is always when a phase *first* happened.
 pub fn mark(phase: Phase) void {
     if (!enabled) return;
-    const index = @intFromEnum(phase);
+    const index = @backingInt(phase);
     if (stamps[index] != null) return;
     stamps[index] = compat.nanoTimestamp();
 }
 
 /// Milliseconds from process start to a phase, or null if it never happened.
 pub fn millisSince(phase: Phase) ?f64 {
-    const at = stamps[@intFromEnum(phase)] orelse return null;
+    const at = stamps[@backingInt(phase)] orelse return null;
     return @as(f64, @floatFromInt(at - origin_ns)) / 1_000_000.0;
 }
 
@@ -91,7 +91,7 @@ pub fn report() void {
     std.debug.print("\n  craft startup\n", .{});
     var previous: ?f64 = null;
     inline for (0..count) |index| {
-        const phase: Phase = @enumFromInt(info.field_values[index]);
+        const phase: Phase = @fromBackingInt(@intCast(info.field_values[index]));
         if (millisSince(phase)) |elapsed| {
             // Phases that never ran are skipped rather than shown as zero: a
             // menubar-only app has no window, and a fabricated 0.0 there would

--- a/packages/zig/src/wallet.zig
+++ b/packages/zig/src/wallet.zig
@@ -476,12 +476,12 @@ pub const PaymentRequest = struct {
 
     pub fn allowNetwork(self: PaymentRequest, network: CardNetwork) PaymentRequest {
         var req = self;
-        req.allowed_networks |= @as(u16, 1) << @intFromEnum(network);
+        req.allowed_networks |= @as(u16, 1) << @backingInt(network);
         return req;
     }
 
     pub fn isNetworkAllowed(self: PaymentRequest, network: CardNetwork) bool {
-        return (self.allowed_networks & (@as(u16, 1) << @intFromEnum(network))) != 0;
+        return (self.allowed_networks & (@as(u16, 1) << @backingInt(network))) != 0;
     }
 };
 
@@ -664,14 +664,14 @@ pub const WalletController = struct {
         self.available_providers = 0;
 
         // Simulate checking availability
-        self.available_providers |= @as(u16, 1) << @intFromEnum(WalletProvider.apple_pay);
-        self.available_providers |= @as(u16, 1) << @intFromEnum(WalletProvider.google_pay);
-        self.available_providers |= @as(u16, 1) << @intFromEnum(WalletProvider.stripe);
-        self.available_providers |= @as(u16, 1) << @intFromEnum(WalletProvider.paypal);
+        self.available_providers |= @as(u16, 1) << @backingInt(WalletProvider.apple_pay);
+        self.available_providers |= @as(u16, 1) << @backingInt(WalletProvider.google_pay);
+        self.available_providers |= @as(u16, 1) << @backingInt(WalletProvider.stripe);
+        self.available_providers |= @as(u16, 1) << @backingInt(WalletProvider.paypal);
     }
 
     pub fn isProviderAvailable(self: WalletController, provider: WalletProvider) bool {
-        return (self.available_providers & (@as(u16, 1) << @intFromEnum(provider))) != 0;
+        return (self.available_providers & (@as(u16, 1) << @backingInt(provider))) != 0;
     }
 
     pub fn setDefaultProvider(self: *WalletController, provider: WalletProvider) bool {

--- a/packages/zig/src/windows/system.zig
+++ b/packages/zig/src/windows/system.zig
@@ -983,8 +983,8 @@ pub const Shell = struct {
 // ============================================
 
 test "TaskbarProgressState enum" {
-    try std.testing.expectEqual(@as(c_int, 0), @intFromEnum(TaskbarProgressState.no_progress));
-    try std.testing.expectEqual(@as(c_int, 2), @intFromEnum(TaskbarProgressState.normal));
+    try std.testing.expectEqual(@as(c_int, 0), @backingInt(TaskbarProgressState.no_progress));
+    try std.testing.expectEqual(@as(c_int, 2), @backingInt(TaskbarProgressState.normal));
 }
 
 test "ToastNotification init" {
@@ -1014,5 +1014,5 @@ test "JumpList init" {
 }
 
 test "WindowsTheme BackdropType" {
-    try std.testing.expectEqual(@as(c_int, 2), @intFromEnum(WindowsTheme.BackdropType.main_window));
+    try std.testing.expectEqual(@as(c_int, 2), @backingInt(WindowsTheme.BackdropType.main_window));
 }

--- a/packages/zig/src/windows/webview2.zig
+++ b/packages/zig/src/windows/webview2.zig
@@ -1011,8 +1011,8 @@ test "WebView2 init" {
 }
 
 test "WebErrorStatus enum" {
-    try std.testing.expectEqual(@as(c_int, 0), @intFromEnum(WebErrorStatus.unknown));
-    try std.testing.expectEqual(@as(c_int, 7), @intFromEnum(WebErrorStatus.timeout));
+    try std.testing.expectEqual(@as(c_int, 0), @backingInt(WebErrorStatus.unknown));
+    try std.testing.expectEqual(@as(c_int, 7), @backingInt(WebErrorStatus.timeout));
 }
 
 test "utf8ToUtf16 basic" {

--- a/patches/ts-maps@0.3.1.patch
+++ b/patches/ts-maps@0.3.1.patch
@@ -1,0 +1,42 @@
+diff --git a/package.json b/package.json
+index cf2ec1349bc2d7f9b9d0658e5c988d3ec85e4ae5..e517bf929c9ddeb41620844d2317a0b396dc59c9 100644
+--- a/package.json
++++ b/package.json
+@@ -28,37 +28,30 @@
+   "exports": {
+     ".": {
+       "types": "./dist/index.d.ts",
+-      "bun": "./src/index.ts",
+       "import": "./dist/index.js"
+     },
+     "./services": {
+       "types": "./dist/core-map/services/index.d.ts",
+-      "bun": "./src/core-map/services/index.ts",
+       "import": "./dist/core-map/services/index.js"
+     },
+     "./style-spec": {
+       "types": "./dist/core-map/style-spec/index.d.ts",
+-      "bun": "./src/core-map/style-spec/index.ts",
+       "import": "./dist/core-map/style-spec/index.js"
+     },
+     "./storage": {
+       "types": "./dist/core-map/storage/index.d.ts",
+-      "bun": "./src/core-map/storage/index.ts",
+       "import": "./dist/core-map/storage/index.js"
+     },
+     "./geo": {
+       "types": "./dist/core-map/geo/index.d.ts",
+-      "bun": "./src/core-map/geo/index.ts",
+       "import": "./dist/core-map/geo/index.js"
+     },
+     "./geometry": {
+       "types": "./dist/core-map/geometry/index.d.ts",
+-      "bun": "./src/core-map/geometry/index.ts",
+       "import": "./dist/core-map/geometry/index.js"
+     },
+     "./symbols": {
+       "types": "./dist/core-map/symbols/index.d.ts",
+-      "bun": "./src/core-map/symbols/index.ts",
+       "import": "./dist/core-map/symbols/index.js"
+     },
+     "./styles.css": "./src/core-map/ts-maps.css",


### PR DESCRIPTION
Four of CI's jobs have been red, and **none of them for the reason the job name suggests**.

## `lint` — never reached pickier

It dies on its first step, `zig fmt --check src/ build.zig`: 29 files under `packages/zig/src` are not fmt-clean. The entire rewrite is `zig fmt`'s own sanctioned deprecated-builtin migration — `@intFromEnum` → `@backingInt` (79 sites), `@enumFromInt(x)` → `@fromBackingInt(@intCast(x))` (9 sites), plus one trailing space. Formatted with **0.17.0-dev.1509**, the compiler CI actually installs, after confirming it and 0.17.0-dev.1770 produce byte-identical output.

With that fixed the job reaches the two steps nobody had ever seen run. The C import audit passes. Pickier reports 3 errors — all `prefer-const` in `src/js/craft-gestures.js` — now fixed. The 36 remaining warnings are markdown style and don't fail the job; left alone rather than sweeping unrelated files in here.

## `typescript-sdk` — not a type-check failure at all

`tsc --noEmit` passes, and always did. The job fails one step later on a single stale assertion: **463 pass / 1 fail**.

f49b11c switched DMG compression from zlib to LZMA on purpose, with a comment explaining why, and `package.test.ts:65` was never updated. Followed the code, not the test — `UDZO` → `ULMO`. 464 pass now.

## `ts-maps` — three broken steps, only the first of which CI had seen

The sources are written against the external package's newer `core-map` API, but `package.json` pinned `^0.2.7`, which predates it: 20 `TS2614 has no exported member` errors, and the bundler fails identically on `Circle`, `Marker`, `Polygon` and friends. **Bumped to `^0.3.1`.**

That alone trades one failure for another. 0.3.x ships an exports map whose `bun` condition points at `./src/index.ts`, while the tarball contains only `dist/` and one CSS file — so under Bun the package does not resolve at all (`Cannot find package 'ts-maps'`). Patched via bun's own `patchedDependencies` to drop the seven unresolvable `bun` conditions. **Remove the patch when upstream fixes them.**

The build step then failed on `scripts/finalize-types.ts`, which looked for declarations at a hardcoded `dist/Tools/craft/packages/ts-maps/src` — a path that only ever existed on the machine it was written on. tsc derives `rootDir` from the common ancestor of its inputs, and this package deliberately imports out of `../typescript/src`, so the nesting depends on where the checkout lives. It now finds the emitted tree instead of assuming it.

All three steps pass: typecheck clean, 27 tests, build emits a flat `dist`.

## `zig-core` — one leg that never worked, blinding two that did

The `windows-latest` leg has not passed in any of the last 60 runs. Pantry can't create symlinks on Windows so it materialises a real `pantry\.bin\zig.exe`, and zig finds its `lib/` by walking up from its own resolved path — so the lookup fails before any repo code is involved:

```
error: unable to find zig installation directory from executable path
"D:\a\craft\craft\pantry\.bin\zig.exe": FileNotFound
```

Nothing in this repo can fix that (it belongs upstream in pantry), and craft doesn't ship a natively-built Windows binary anyway — `release.yml` cross-compiles `x86_64-windows` from Linux. Leg dropped.

**The more damaging half:** the matrix had no `fail-fast: false`, so that permanently-broken leg cancelled ubuntu and macos *mid-step* on every run. Neither has been allowed to finish since May. Added, matching `release.yml` and `native-lifecycle.yml` which both already set it.

## `binary-size` — red on every PR, for its cleanup step

Passes on main, fails on every pull request with:

```
error: pathspec 'packages/zig' did not match any file(s) known to git
```

The EXIT trap uses a repo-root-relative pathspec, but the step `cd`s into `packages/zig` before the trap ever fires — and under `set -e` the failing restore becomes the step's exit status. Anchored with `git -C "$GITHUB_WORKSPACE"`, given `--staged` so the index is restored too, and guarded so cleanup can never decide the step's result.

## Verification

Every CI job's own commands, run locally, all exiting 0:

| command | |
|---|---|
| `zig fmt --check src/ build.zig` | 0 |
| `zig build` / `zig build test` | 0 |
| `bun run verify:cimports` | 0 |
| `bun run lint` | 0 |
| SDK `typecheck` / `bun test` | 0 / 464 pass |
| ts-maps `typecheck` / `test` / `build` | 0 / 27 pass / 0 |

## Merge order

Independent of #21 (release path) — no overlapping files. **#20 will need a trivial rebase after this lands**, since the fmt pass touches `macos.zig`; conflicts there are formatting-only and I'll handle it.
