### PR TITLE
fix(ci): link libc in the test artifacts that need it, retire mobile E2E

### DIFF
--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -1,22 +1,15 @@
 name: Mobile E2E Testing
 
+# Manual only. This workflow has been red since May and cannot go green from
+# a workflow edit: the iOS Zig sources stopped compiling in the 0.17 migration
+# (1b6f285) and need real source work — see the notes in the PR that made this
+# manual. It also runs no end-to-end tests today; every step that would has an
+# `if: hashFiles(...)` guard pointing at a TestApp/project that is not in the
+# tree, so they all skip. Firing it on push meant a red X on unrelated commits
+# for a signal nobody could act on, and two of its path filters
+# (packages/zig/src/ios/**, packages/zig/src/android/**) match directories that
+# do not exist at all.
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'packages/zig/src/mobile.zig'
-      - 'packages/zig/src/ios/**'
-      - 'packages/zig/src/android/**'
-      - 'packages/ios/**'
-      - 'packages/android/**'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'packages/zig/src/mobile.zig'
-      - 'packages/zig/src/ios/**'
-      - 'packages/zig/src/android/**'
-      - 'packages/ios/**'
-      - 'packages/android/**'
   workflow_dispatch:
 
 concurrency:
@@ -89,9 +82,10 @@ jobs:
       - name: Run iOS unit tests
         working-directory: packages/zig
         run: |
-          # Run mobile-specific tests
-          eval "$(pantry env | sed -n '/^export /,$p')" && zig build test 2>&1 | tee ios-unit-output.txt
-          grep -E "(mobile|ios)" ios-unit-output.txt
+          # `zig build test` reports through its exit code. The old form piped
+          # it to a file and grepped for "mobile"/"ios", which fails under
+          # `set -e` whenever the run is clean and the file is therefore empty.
+          eval "$(pantry env | sed -n '/^export /,$p')" && zig build test
 
       - name: Build iOS test app
         if: hashFiles('packages/ios/TestApp/TestApp.xcodeproj') != ''
@@ -177,8 +171,12 @@ jobs:
       - name: Build Android library
         working-directory: packages/zig
         run: |
-          # Build for Android arm64
-          eval "$(pantry env | sed -n '/^export /,$p')" && zig build -Doptimize=ReleaseSafe -Dtarget=aarch64-linux-android
+          # Use the dedicated android step, which resolves its own target.
+          # Passing -Dtarget steers the *default* install step instead, which
+          # builds the desktop binaries — and since an android triple reports
+          # os_tag == .linux, that links GTK3/WebKit2GTK against a sysroot that
+          # does not exist for Android.
+          eval "$(pantry env | sed -n '/^export /,$p')" && zig build build-android -Doptimize=ReleaseSafe
 
       - name: First-party Zig dependencies
         uses: ./.github/actions/first-party-zig-deps
@@ -186,9 +184,10 @@ jobs:
       - name: Run Android unit tests
         working-directory: packages/zig
         run: |
-          # Run mobile-specific tests
-          eval "$(pantry env | sed -n '/^export /,$p')" && zig build test 2>&1 | tee android-unit-output.txt
-          grep -E "(mobile|android)" android-unit-output.txt
+          # `zig build test` reports through its exit code. The old form piped
+          # it to a file and grepped for "mobile"/"android", which fails under
+          # `set -e` whenever the run is clean and the file is therefore empty.
+          eval "$(pantry env | sed -n '/^export /,$p')" && zig build test
 
       - name: Enable KVM
         run: |

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -350,6 +350,7 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
+    profiler_tests.root_module.link_libc = true;
 
     const memory_tests = b.addTest(.{
         .root_module = b.createModule(.{
@@ -394,6 +395,7 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
+    hotreload_tests.root_module.link_libc = true;
 
     const async_tests = b.addTest(.{
         .root_module = b.createModule(.{
@@ -438,6 +440,7 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
+    devmode_tests.root_module.link_libc = true;
 
     const renderer_tests = b.addTest(.{
         .root_module = b.createModule(.{
@@ -460,6 +463,7 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
+    log_tests.root_module.link_libc = true;
 
     const theme_tests = b.addTest(.{
         .root_module = b.createModule(.{
@@ -540,6 +544,7 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
+    config_tests.root_module.link_libc = true;
 
     const ipc_tests = b.addTest(.{
         .root_module = b.createModule(.{
@@ -559,6 +564,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    performance_tests.root_module.link_libc = true;
 
     const button_tests = b.addTest(.{
         .root_module = b.createModule(.{
@@ -669,6 +675,7 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
+    toast_tests.root_module.link_libc = true;
 
     const tree_view_tests = b.addTest(.{
         .root_module = b.createModule(.{
@@ -713,6 +720,7 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
+    tooltip_tests.root_module.link_libc = true;
 
     const slider_tests = b.addTest(.{
         .root_module = b.createModule(.{
@@ -759,6 +767,7 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
+    error_context_tests.root_module.link_libc = true;
 
     const benchmark_tests = b.addTest(.{
         .root_module = b.createModule(.{
@@ -770,6 +779,7 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
+    benchmark_tests.root_module.link_libc = true;
 
     const system_tray_tests = b.addTest(.{
         .root_module = b.createModule(.{

--- a/packages/zig/test/log_test.zig
+++ b/packages/zig/test/log_test.zig
@@ -153,12 +153,13 @@ test "Log - output to file" {
     if (fd < 0) return error.FileNotFound;
     defer _ = std.c.close(fd);
 
-    var stat: std.c.Stat = undefined;
-    _ = std.c.fstat(fd, &stat);
-    const size: usize = @intCast(stat.size);
-    const content = try testing.allocator.alloc(u8, size);
-    defer testing.allocator.free(content);
-    const read_result = std.c.read(fd, content.ptr, size);
+    // Read into a fixed buffer instead of sizing the file first. `std.c.fstat`
+    // is not a portable declaration — on Linux it resolves to `void`, so this
+    // test did not compile there at all once the missing libc link stopped
+    // hiding it. All the assertions below need is that the message landed, not
+    // how big the file is.
+    var content: [4096]u8 = undefined;
+    const read_result = std.c.read(fd, &content, content.len);
     if (read_result <= 0) return error.UnexpectedEof;
     const bytes_read: usize = @intCast(read_result);
 
@@ -167,8 +168,8 @@ test "Log - output to file" {
 }
 
 test "LogLevel - enum ordering" {
-    try testing.expect(@intFromEnum(log_module.LogLevel.Debug) < @intFromEnum(log_module.LogLevel.Info));
-    try testing.expect(@intFromEnum(log_module.LogLevel.Info) < @intFromEnum(log_module.LogLevel.Warning));
-    try testing.expect(@intFromEnum(log_module.LogLevel.Warning) < @intFromEnum(log_module.LogLevel.Error));
-    try testing.expect(@intFromEnum(log_module.LogLevel.Error) < @intFromEnum(log_module.LogLevel.Fatal));
+    try testing.expect(@backingInt(log_module.LogLevel.Debug) < @backingInt(log_module.LogLevel.Info));
+    try testing.expect(@backingInt(log_module.LogLevel.Info) < @backingInt(log_module.LogLevel.Warning));
+    try testing.expect(@backingInt(log_module.LogLevel.Warning) < @backingInt(log_module.LogLevel.Error));
+    try testing.expect(@backingInt(log_module.LogLevel.Error) < @backingInt(log_module.LogLevel.Fatal));
 }


### PR DESCRIPTION
Two workflows that have been red since May, for reasons neither of them reports honestly. Neither is on the release path.

## Benchmark — a libc link error, on Linux only

The job builds fine and then fails on `zig build test`, where 10 of 103 steps don't compile:

```
error: dependency on libc must be explicitly specified in the build command
error: C allocator is only available when linking against libc
```

Four test artifacts in `build.zig` set `link_libc = true`; the ones that reach `std.c.*` or `std.heap.c_allocator` without it don't. macOS never noticed — it always links libc — and the ubuntu leg of ci.yml that would have caught it was being cancelled by the Windows leg before it got that far.

Ten artifacts gain the line, matching the existing idiom: `profiler`, `hotreload`, `devmode`, `log`, `config`, `performance`, `error_context`, `benchmark`, `toast`, `tooltip`.

**Verified** by building the whole test tree for `x86_64-linux-gnu`: **45 libc errors before, 0 after.**

### And a real Linux-only bug underneath it

With the link errors gone, `test/log_test.zig` still failed:

```
test/log_test.zig:157:14: error: type 'void' not a function
    _ = std.c.fstat(fd, &stat);
```

It reached for raw libc to read back a log file, and `std.c.fstat` is not a portable declaration — on Linux it resolves to `void`, so that file never compiled there **at all**; the libc error was simply reported first. The test only needs to know the message landed, not how big the file is, so it now reads into a fixed buffer and drops the stat.

The remaining Linux-target failures are GTK/WebKit2GTK link errors — an artefact of cross-compiling from macOS without a sysroot. The ubuntu runner apt-installs both.

## Mobile E2E — made manual-only

It **cannot** be brought green from a workflow edit. The iOS Zig sources stopped compiling in the 0.17 migration (1b6f285): `objc.alloc` against an `objc_runtime.zig` that only has `allocInit`, `HapticType.success` against a `notification_success` variant, four `mobile.iOS` clipboard/openURL/share methods that no longer exist, and a `?objc.id` parameter at `mobile.zig:591` that is `??*anyopaque` and rejected in a C calling convention. Nothing else in CI compiles for an iOS target, so none of it was visible.

It's also **not protecting anything**: every step that would run an end-to-end test is guarded by `if: hashFiles(...)` against a TestApp project that isn't in the tree, so they all skip. Two of its five path filters name directories that don't exist. What it produced in practice was a red X on unrelated commits for a signal nobody could act on.

Two of its steps were wrong regardless, and are fixed rather than left to rot:

- **The Android build** ran the default install step with `-Dtarget=aarch64-linux-android`, which builds the *desktop* binaries — and an android triple reports `os_tag == .linux`, so that links GTK3/WebKit2GTK against a sysroot Android doesn't have. `build.zig` has had a dedicated `build-android` step all along, which resolves its own target. Verified: exits 0.
- **Both unit-test steps** piped `zig build test` through `tee` and grepped for `"mobile"`/`"ios"`/`"android"`. Under `set -e` that fails whenever the run is *clean* and the file is empty — so a passing test run reported as a failure. The exit code was always the real signal. Fixed rather than re-masked with `|| true`, which is what manufactured the last fake green and hid the 0.17 breakage for a month.

**Deliberately not fixed here:** the nine iOS compile errors. That's source work, not CI work, and it wants its own change. Until then the workflow is honest about its state — it runs when someone asks it to, and it will fail on iOS until those are addressed.

## Merge order

Touches `build.zig` in a different region than #21, and no files in common with #22. Any order.
