### PR TITLE
fix(menu): align the injected bridge with the contract native parses

### DIFF
--- a/packages/zig/src/js/craft-bridge.js
+++ b/packages/zig/src/js/craft-bridge.js
@@ -40,18 +40,43 @@
 
   // Catastrophic native-side failure: drop every pending promise with the
   // same error so callers don't hang forever.
+  // Native calls this when an action fails. The payload names the action that
+  // failed, so only that action's callers are rejected — this used to empty the
+  // whole pending table, so one bridge failing took down every unrelated call
+  // in flight at the time.
+  //
+  // Fire-and-forget calls (`_send`) never register a pending entry: native
+  // acknowledges nothing on success, so there is nothing to wait on and the
+  // promise has already resolved by the time a failure comes back. Those have
+  // no caller left to reject, so they are reported to the console instead —
+  // otherwise the only trace is in the native log, which is not where anyone
+  // writing a web page is looking.
   window.__craftBridgeError = function (err) {
-    const p = window.__craftBridgePending || {}
-    Object.keys(p).forEach(function (k) {
-      const q = p[k]
-      if (Array.isArray(q)) {
-        while (q.length > 0) {
-          const e = q.shift()
-          if (e && e.reject) e.reject(err)
-        }
+    const pending = window.__craftBridgePending || {}
+    const action = err && err.action
+    let rejected = 0
+
+    const drain = function (key) {
+      const q = pending[key]
+      if (!Array.isArray(q)) return
+      while (q.length > 0) {
+        const e = q.shift()
+        if (e && e.reject) { e.reject(err); rejected++ }
       }
-    })
-    window.__craftBridgePending = {}
+      delete pending[key]
+    }
+
+    if (action) drain(action)
+    // An error that does not name its action cannot be targeted; the
+    // conservative reading is that the bridge itself is in trouble.
+    else Object.keys(pending).forEach(drain)
+
+    if (rejected === 0 && typeof console !== 'undefined' && console.error) {
+      console.error(
+        '[craft] bridge call failed: ' + (action || '(unnamed action)'),
+        (err && err.code) || '', (err && err.message) || '',
+      )
+    }
   }
 
   function _post(t, a, d) {
@@ -137,6 +162,24 @@
       window.addEventListener(name, h)
       return function () { window.removeEventListener(name, h) }
     }
+  }
+
+  // `menu.addItem` takes the item in the shape the rest of the menu API uses
+  // — `{ id, label, shortcut }` — while the native side reads a flat payload
+  // keyed `itemId`/`menuId` with the index alongside. Translate here rather
+  // than asking callers to know both spellings.
+  function _menuItemPayload(menuId, item) {
+    const it = item || {}
+    const payload = {
+      menuId: String(menuId),
+      itemId: String(it.id == null ? '' : it.id),
+      label: String(it.label == null ? '' : it.label),
+      // -1 appends, which is what a caller who did not say where means.
+      index: typeof it.index === 'number' ? it.index : -1,
+    }
+    if (it.shortcut != null) payload.shortcut = String(it.shortcut)
+    if (it.icon != null) payload.icon = String(it.icon)
+    return payload
   }
 
   function _stringify(d) {
@@ -639,16 +682,23 @@
   // -------------------------------------------------------------------------
   // menu — application menubar (the macOS top-of-screen menu)
   // -------------------------------------------------------------------------
+  //
+  // Every payload here is keyed the way `bridge_menu.zig` reads it, which is
+  // `itemId` and `menuId` — not `id` and `parent`. The two drifted apart, and
+  // because the native item handlers scan for their key and fall back to an
+  // empty string, a wrong key does not raise anything: the lookup just misses
+  // and the call returns as if it had worked. Same reason the action below is
+  // `setAppMenu` and not `setApplicationMenu`, which no dispatcher ever had.
   window.craft.menu = {
-    set:                  function (items)             { return _send('menu', 'setApplicationMenu', _stringify(items || [])) },
-    setDock:              function (items)             { return _send('menu', 'setDockMenu', _stringify(items || [])) },
-    addItem:              function (parent, item)      { return _send('menu', 'addMenuItem', _stringify({ parent: String(parent), item: item })) },
-    removeItem:           function (id)                { return _send('menu', 'removeMenuItem', _stringify({ id: String(id) })) },
-    enableItem:           function (id)                { return _send('menu', 'enableMenuItem', _stringify({ id: String(id) })) },
-    disableItem:          function (id)                { return _send('menu', 'disableMenuItem', _stringify({ id: String(id) })) },
-    checkItem:            function (id)                { return _send('menu', 'checkMenuItem', _stringify({ id: String(id) })) },
-    uncheckItem:          function (id)                { return _send('menu', 'uncheckMenuItem', _stringify({ id: String(id) })) },
-    setItemLabel:         function (id, label)         { return _send('menu', 'setMenuItemLabel', _stringify({ id: String(id), label: String(label) })) },
+    set:                  function (options)           { return _send('menu', 'setAppMenu', _stringify(options || {})) },
+    setDock:              function (options)           { return _send('menu', 'setDockMenu', _stringify(options || {})) },
+    addItem:              function (menuId, item)      { return _send('menu', 'addMenuItem', _stringify(_menuItemPayload(menuId, item))) },
+    removeItem:           function (itemId)            { return _send('menu', 'removeMenuItem', _stringify({ itemId: String(itemId) })) },
+    enableItem:           function (itemId)            { return _send('menu', 'enableMenuItem', _stringify({ itemId: String(itemId) })) },
+    disableItem:          function (itemId)            { return _send('menu', 'disableMenuItem', _stringify({ itemId: String(itemId) })) },
+    checkItem:            function (itemId)            { return _send('menu', 'checkMenuItem', _stringify({ itemId: String(itemId) })) },
+    uncheckItem:          function (itemId)            { return _send('menu', 'uncheckMenuItem', _stringify({ itemId: String(itemId) })) },
+    setItemLabel:         function (itemId, label)     { return _send('menu', 'setMenuItemLabel', _stringify({ itemId: String(itemId), label: String(label) })) },
     clearDock:            function ()                  { return _send('menu', 'clearDockMenu') },
     onAction:             _evt('craft:menu:action'),
   }

--- a/packages/zig/types/craft-bridge.d.ts
+++ b/packages/zig/types/craft-bridge.d.ts
@@ -193,17 +193,34 @@ export interface NotificationAction {
 // Menu Bridge Types
 // ============================================
 
+/**
+ * The macOS application menubar, as `window.craft.menu` actually exposes it.
+ *
+ * These names are the ones on the injected bridge. An earlier version of this
+ * file declared the *wire* action names instead (`setAppMenu`, `addMenuItem`,
+ * ...), which are what the bridge sends to native, not what it offers to a
+ * page — so every declared method typechecked and then threw at runtime.
+ */
 export interface MenuBridge {
-  setAppMenu(options: { menus: MenuDefinition[] }): Promise<void>;
-  setDockMenu(options: { items: MenuItemDefinition[] }): Promise<void>;
-  addMenuItem(options: AddMenuItemOptions): Promise<void>;
-  removeMenuItem(options: { id: string }): Promise<void>;
-  enableMenuItem(options: { id: string }): Promise<void>;
-  disableMenuItem(options: { id: string }): Promise<void>;
-  checkMenuItem(options: { id: string }): Promise<void>;
-  uncheckMenuItem(options: { id: string }): Promise<void>;
-  setMenuItemLabel(options: { id: string; label: string }): Promise<void>;
-  clearDockMenu(): Promise<void>;
+  /** Replace the whole menubar. */
+  set(options: { menus: MenuDefinition[] }): Promise<void>;
+  /** Replace the Dock menu (right-click the Dock icon). */
+  setDock(options: { items: MenuItemDefinition[] }): Promise<void>;
+  /** Append an item to an existing menu. Omit `index` on the item to append. */
+  addItem(menuId: string, item: MenuItemDefinition & { index?: number }): Promise<void>;
+  removeItem(itemId: string): Promise<void>;
+  enableItem(itemId: string): Promise<void>;
+  disableItem(itemId: string): Promise<void>;
+  /** Add a checkmark. */
+  checkItem(itemId: string): Promise<void>;
+  uncheckItem(itemId: string): Promise<void>;
+  setItemLabel(itemId: string, label: string): Promise<void>;
+  clearDock(): Promise<void>;
+  /**
+   * Menu clicks arrive here — without it there is no way to respond to a menu
+   * at all. Returns an unsubscribe function.
+   */
+  onAction(handler: (event: { id: string }) => void): () => void;
 }
 
 export interface MenuDefinition {
@@ -211,22 +228,31 @@ export interface MenuDefinition {
   items: MenuItemDefinition[];
 }
 
+/**
+ * One menu item.
+ *
+ * This is the whole of it. The native decoder parses exactly these fields and
+ * is set to ignore anything else, so extra keys are dropped in silence rather
+ * than rejected — which is why `type`, `checked`, `enabled`, `action` and
+ * `submenu` used to be declared here despite never having had an effect.
+ *
+ * Two consequences worth knowing:
+ *   - a separator is `{ separator: true }`, not `{ type: 'separator' }`
+ *   - there are no nested submenus yet; a menubar is one level deep
+ *
+ * Toggling a checkmark or enablement is done after the fact, through
+ * `checkItem` / `enableItem`, not by a field here.
+ */
 export interface MenuItemDefinition {
-  id: string;
-  label: string;
-  type?: 'normal' | 'separator' | 'checkbox' | 'radio';
-  checked?: boolean;
-  enabled?: boolean;
-  action?: string;
+  /** Echoed back by `onAction` when this item is clicked. */
+  id?: string;
+  label?: string;
+  /** Accelerator, e.g. `cmd+n`. */
   shortcut?: string;
-  icon?: string; // Icon name from icons.zig
-  submenu?: MenuItemDefinition[];
-}
-
-export interface AddMenuItemOptions {
-  menuId: string;
-  item: MenuItemDefinition;
-  position?: number;
+  /** Icon name from icons.zig. */
+  icon?: string;
+  /** Renders a divider; every other field is ignored when this is set. */
+  separator?: boolean;
 }
 
 // ============================================


### PR DESCRIPTION
Closes #24. Closes #25.

`craft.menu.set()` never worked: the bridge sent the action `setApplicationMenu` and `bridge_menu.zig` has only ever dispatched `setAppMenu`, so every call fell through to `BridgeError.UnknownAction`.

## Pulling that thread found the rest of the namespace is wrong the same way

And worse, because it fails *quietly*. The native item handlers scan the payload for `"itemId":"` and fall back to an empty string when it's absent; `findMenuItemById("")` then matches nothing and the handler returns **successfully**. The bridge was sending `id`.

So `removeItem`, `enableItem`, `disableItem`, `checkItem`, `uncheckItem` and `setItemLabel` all did nothing at all, and raised nothing while doing it. `addItem` sent `{parent, item}` against a decoder reading a flat `{menuId, itemId, label, shortcut, index}`.

### Verified with the issue's own reproduction, stock build vs. patched

| | before | after |
|---|---|---|
| `menu.set` | `setApplicationMenu` → `NATIVE_CALL_FAILED` | `setAppMenu` → `Created app menu with 1 menus` |
| `menu.setItemLabel('close', …)` | `setMenuItemLabel:  = Close Window` | `setMenuItemLabel: close = Close Window` |
| `menu.disableItem('close')` | `disableMenuItem: ` | `disableMenuItem: close` |

The empty ids in the *before* column are the silent half — those calls were accepted, logged, and discarded.

## The typings described a third naming scheme again (#25)

`MenuBridge` declared the **wire** action names — `setAppMenu`, `addMenuItem`, `removeMenuItem` — which are what the bridge sends *to native*, not what it offers to a page. Every declared method typechecked and then threw `is not a function`. `onAction`, the only way to learn that a menu was clicked, wasn't declared at all.

They now match what `Object.keys(window.craft.menu)` actually returns.

`MenuItemDefinition` was similarly aspirational. `type`, `checked`, `enabled`, `action` and `submenu` are not in `ParsedItem`, and the decoder runs with `ignore_unknown_fields`, so they were accepted and dropped. In particular a separator has to be `{ separator: true }` — written the declared way, `{ type: 'separator' }`, it rendered as an ordinary item with no label. Removed, with both surprises documented on the type rather than left for the next person to hit at runtime.

## And the error channel that hid all of this

`__craftBridgeError` emptied the **entire** pending table on any failure, so one bridge failing rejected every unrelated call in flight. It now rejects only the action named in the payload.

And because fire-and-forget calls never register a pending entry — native acknowledges nothing on success, so `_send` resolves as soon as the message is posted — a failed one had no caller left to reject and left no trace outside the native log. That's exactly what the issue describes as "resolves `null`, looks like success". Those now report to the console.

**Deliberately not done:** making `_send` itself reject. That needs native to acknowledge success for fire-and-forget actions, which is a protocol change across every bridge rather than a menu fix. Worth its own issue if you want it.

## Checks

`zig build` clean, the 111 bridge integration tests pass (they already asserted `setAppMenu`, so they were encoding the correct contract all along), the `.d.ts` typechecks, and pickier reports 0 errors on the changed JS.
