### PR TITLE
fix(cli): tell the user when `craft` on PATH is the CLI, not the binary

### DIFF
--- a/packages/typescript/bin/cli.ts
+++ b/packages/typescript/bin/cli.ts
@@ -8,8 +8,17 @@ import { CLI } from '@stacksjs/clapp'
 import { spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import process from 'node:process'
-import { craftBinaryNotFoundMessage, resolveCraftBinary } from '../src/binary-resolver'
+import { CRAFT_CLI_SPAWN_MARKER, craftBinaryIsCliShimMessage, craftBinaryNotFoundMessage, resolveCraftBinary } from '../src/binary-resolver'
 import { version } from '../package.json'
+
+// If this marker is already set we were spawned by a craft CLI that meant to
+// spawn the native binary — so `craft` on PATH resolves to this script. Say so
+// now, rather than letting the arg parser reject a flag the user never typed.
+const spawnedFrom = process.env[CRAFT_CLI_SPAWN_MARKER]
+if (spawnedFrom) {
+  console.error(craftBinaryIsCliShimMessage(spawnedFrom))
+  process.exit(1)
+}
 
 const cli = new CLI('craft')
 
@@ -24,7 +33,12 @@ async function runCraftBinary(args: string[]): Promise<void> {
   const craftPath = resolveCraftBinary()
 
   return new Promise((resolve, reject) => {
-    const proc = spawn(craftPath, args, { stdio: 'inherit' })
+    const proc = spawn(craftPath, args, {
+      stdio: 'inherit',
+      // Marks the child so that, if it turns out to be this CLI rather than
+      // the native binary, it can recognise the loop and explain it.
+      env: { ...process.env, [CRAFT_CLI_SPAWN_MARKER]: craftPath },
+    })
 
     proc.on('exit', (code) => {
       if (code === 0 || code === null) resolve()

--- a/packages/typescript/src/__tests__/binary-resolver.test.ts
+++ b/packages/typescript/src/__tests__/binary-resolver.test.ts
@@ -13,7 +13,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { craftBinaryNotFoundMessage, resolveCraftBinary } from '../binary-resolver'
+import { craftBinaryIsCliShimMessage, craftBinaryNotFoundMessage, resolveCraftBinary } from '../binary-resolver'
 
 describe('resolveCraftBinary', () => {
   let savedEnv: string | undefined
@@ -128,5 +128,36 @@ describe('SDK and CLI both delegate to the shared resolver', () => {
     const cli = await Bun.file(new URL('../../bin/cli.ts', import.meta.url)).text()
     expect(idx).toContain('craftBinaryNotFoundMessage')
     expect(cli).toContain('craftBinaryNotFoundMessage')
+  })
+})
+
+describe('CLI shim re-entry', () => {
+  it('marks spawned children so a re-entered CLI can recognise itself', async () => {
+    const cli = await Bun.file(new URL('../../bin/cli.ts', import.meta.url)).text()
+    // The marker has to be set on the spawn and checked at startup; either
+    // half alone leaves the loop undiagnosed.
+    expect(cli).toContain('CRAFT_CLI_SPAWN_MARKER')
+    expect(cli).toContain('craftBinaryIsCliShimMessage')
+    expect(cli.indexOf('craftBinaryIsCliShimMessage')).toBeLessThan(cli.indexOf('const cli = new CLI'))
+  })
+
+  it('names the offending PATH entry, since nothing else points at PATH', () => {
+    const message = craftBinaryIsCliShimMessage('/Users/me/.bun/bin/craft')
+    expect(message).toContain('/Users/me/.bun/bin/craft')
+    expect(message).toContain('CRAFT_BIN')
+    expect(message).toContain('pantry install craft')
+    // Explains the symptom the user actually saw, not just the cause.
+    expect(message).toContain('--url')
+  })
+
+  it('still resolves to the bare PATH name — the guard adds no probing', () => {
+    const previous = process.env.CRAFT_BIN
+    delete process.env.CRAFT_BIN
+    try {
+      expect(resolveCraftBinary()).toBe('craft')
+    }
+    finally {
+      if (previous !== undefined) process.env.CRAFT_BIN = previous
+    }
   })
 })

--- a/packages/typescript/src/binary-resolver.ts
+++ b/packages/typescript/src/binary-resolver.ts
@@ -51,6 +51,50 @@ export function resolveCraftBinary(explicit?: string): string {
 }
 
 /**
+ * Set on the child environment whenever the CLI spawns what it believes is
+ * the native binary.
+ *
+ * `resolveCraftBinary()` returns the bare string `'craft'` and lets the OS
+ * resolve it, which is the pantry contract and stays that way. But `craft` on
+ * PATH is not always the native binary: install the SDK with a package manager
+ * that publishes a `bin` entry and PATH may resolve `craft` to this very CLI
+ * (`~/.bun/bin/craft`, a `#!/usr/bin/env bun` script). Spawning that re-enters
+ * the TypeScript entry point with native-binary flags, and the user sees
+ * `Unknown option --url` for an option they never typed.
+ *
+ * Probing for the binary elsewhere would answer it, but that is exactly the
+ * path-matrix behaviour the pantry contract exists to remove. So instead the
+ * spawn is marked, and a CLI that starts up already marked knows it *is* the
+ * thing that was spawned, and says so.
+ */
+export const CRAFT_CLI_SPAWN_MARKER = 'CRAFT_CLI_SPAWNED_FROM'
+
+/**
+ * The message for that case. Names the offending PATH entry, because the whole
+ * difficulty of the original report was that nothing pointed at PATH at all.
+ */
+export function craftBinaryIsCliShimMessage(spawnedFrom: string): string {
+  return [
+    `"${spawnedFrom}" on PATH is the Craft CLI, not the native binary.`,
+    '',
+    'The CLI spawned it expecting the native build, and re-entered itself —',
+    'which is why an option you never typed (--url) came back as unknown.',
+    '',
+    'Fix it in one of two ways:',
+    '',
+    '  1. Install the native binary and make sure it comes first on PATH:',
+    '',
+    '       pantry install craft',
+    '',
+    '  2. Point CRAFT_BIN at a build directly:',
+    '',
+    '       CRAFT_BIN=/path/to/craft craft <url>',
+    '',
+    'For monorepo development, CRAFT_BIN is the supported way in.',
+  ].join('\n')
+}
+
+/**
  * Build a deterministic, pantry-aware error for the case where the
  * spawn errored with ENOENT (binary not found on PATH). Used as the
  * `process.on('error', …)` handler in both the SDK and the CLI.


### PR DESCRIPTION
Closes #26.

`craft <url>` — the first example in `craft --help` — fails with `Unknown option --url`, an option the user never typed. The CLI adds it when building argv for the native binary, then spawns whatever PATH resolves `craft` to. Where the SDK was installed by a package manager that publishes a `bin` entry, that *is* this CLI: `~/.bun/bin/craft`, a `#!/usr/bin/env bun` script. So it re-enters itself, and its own parser has no `--url`. The arg check is what stops it, which is why the symptom is a usage error rather than a fork bomb.

## Why not just resolve the binary properly

That's the obvious repair, and it's the path-probing matrix the pantry contract exists to remove — CLAUDE.md says so in as many words, and there are existing tests asserting `binary-resolver.ts` contains no `zig-out` path.

So **the resolver is untouched** and still returns a bare `'craft'`. Instead the spawn marks the child environment, and a CLI that starts up already marked knows it is the thing that was spawned. It names the PATH entry responsible and exits, rather than letting the arg parser produce a message about the wrong subject entirely.

## Verified by reproducing it

With a shim first on PATH:

**before**
```
ClappError: Unknown option `--url`
    at checkUnknownOptions (@stacksjs/clapp/dist/index.js:740:17)
```

**after**
```
"craft" on PATH is the Craft CLI, not the native binary.

The CLI spawned it expecting the native build, and re-entered itself —
which is why an option you never typed (--url) came back as unknown.

Fix it in one of two ways:

  1. Install the native binary and make sure it comes first on PATH:
       pantry install craft

  2. Point CRAFT_BIN at a build directly:
       CRAFT_BIN=/path/to/craft craft <url>
```

And the working path is unaffected: with the same shim still on PATH and `CRAFT_BIN` pointing at a real build, the window opens (`⚡ Loading URL in native window`) and the guard does not fire.

## Tests

Three added, including one asserting the resolver still answers a bare `'craft'` — the guard must not quietly become the probing it replaced. 16 pass in that file; `tsc` clean. The one failure in the full SDK run is the pre-existing `UDZO`/`ULMO` assertion that #22 fixes.

## Note

`craftBinaryNotFoundMessage` (the ENOENT path) is unchanged — this is a different failure with a different cause, and merging the two messages would make both vaguer.
