### PR TITLE
feat(macos): give the default menu bar an Edit, App and Window menu

### DIFF
--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -542,6 +542,17 @@ pub fn build(b: *std.Build) void {
         }),
     });
 
+    // The role -> AppKit selector table, shared by the bridge and by the
+    // default menu bar. Pure data and pure lookups, so it is tested here
+    // instead of by launching an app and reading the menus.
+    const menu_roles_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/menu_roles.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
     const config_tests = b.addTest(.{
         .root_module = b.createModule(.{
             .root_source_file = b.path("test/config_test.zig"),
@@ -877,6 +888,7 @@ pub fn build(b: *std.Build) void {
     const run_native_sidebar_tests = b.addRunArtifact(native_sidebar_tests);
     const run_space_list_tests = b.addRunArtifact(space_list_tests);
     const run_local_tls_tests = b.addRunArtifact(local_tls_tests);
+    const run_menu_roles_tests = b.addRunArtifact(menu_roles_tests);
     const run_config_tests = b.addRunArtifact(config_tests);
     const run_ipc_tests = b.addRunArtifact(ipc_tests);
     const run_performance_tests = b.addRunArtifact(performance_tests);
@@ -969,6 +981,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_native_sidebar_tests.step);
     test_step.dependOn(&run_space_list_tests.step);
     test_step.dependOn(&run_local_tls_tests.step);
+    test_step.dependOn(&run_menu_roles_tests.step);
     test_step.dependOn(&run_config_tests.step);
     test_step.dependOn(&run_ipc_tests.step);
     test_step.dependOn(&run_performance_tests.step);
@@ -1064,6 +1077,9 @@ pub fn build(b: *std.Build) void {
 
     const test_local_tls_step = b.step("test:local-tls", "Run local development TLS tests");
     test_local_tls_step.dependOn(&run_local_tls_tests.step);
+
+    const test_menu_roles_step = b.step("test:menu-roles", "Run menu role table tests");
+    test_menu_roles_step.dependOn(&run_menu_roles_tests.step);
 
     const test_config_step = b.step("test:config", "Run Config tests");
     test_config_step.dependOn(&run_config_tests.step);

--- a/packages/zig/src/bridge_menu.zig
+++ b/packages/zig/src/bridge_menu.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const bridge_error = @import("bridge_error.zig");
 const icons = @import("icons.zig");
+const menu_roles = @import("menu_roles.zig");
 const logging = @import("logging.zig");
 
 const BridgeError = bridge_error.BridgeError;
@@ -549,33 +550,11 @@ var global_dock_menu: ?*anyopaque = null;
 /// The AppKit selector a role stands for, or null for a role this build does
 /// not know. Names follow Electron's role vocabulary where one exists — the
 /// audience for this API has usually met it there first.
-fn roleSelector(role: []const u8) ?[*:0]const u8 {
-    const roles = [_]struct { name: []const u8, selector: [*:0]const u8 }{
-        .{ .name = "about", .selector = "orderFrontStandardAboutPanel:" },
-        .{ .name = "hide", .selector = "hide:" },
-        .{ .name = "hideOthers", .selector = "hideOtherApplications:" },
-        .{ .name = "showAll", .selector = "unhideAllApplications:" },
-        .{ .name = "quit", .selector = "terminate:" },
-        .{ .name = "undo", .selector = "undo:" },
-        .{ .name = "redo", .selector = "redo:" },
-        .{ .name = "cut", .selector = "cut:" },
-        .{ .name = "copy", .selector = "copy:" },
-        .{ .name = "paste", .selector = "paste:" },
-        .{ .name = "delete", .selector = "delete:" },
-        .{ .name = "selectAll", .selector = "selectAll:" },
-        .{ .name = "close", .selector = "performClose:" },
-        .{ .name = "minimize", .selector = "performMiniaturize:" },
-        .{ .name = "zoom", .selector = "performZoom:" },
-        .{ .name = "front", .selector = "arrangeInFront:" },
-        .{ .name = "fullscreen", .selector = "toggleFullScreen:" },
-        .{ .name = "reload", .selector = "reload:" },
-        .{ .name = "forceReload", .selector = "reloadFromOrigin:" },
-    };
-    for (roles) |entry| {
-        if (std.ascii.eqlIgnoreCase(role, entry.name)) return entry.selector;
-    }
-    return null;
-}
+///
+/// The table moved to `menu_roles.zig` so the default menu bar in `macos.zig`
+/// resolves roles the same way an app-declared one does; an app that overrides
+/// the bar should not get a different idea of what "copy" means.
+const roleSelector = menu_roles.selectorFor;
 
 /// One target for every id item in every bridge-built menu. A single retained
 /// NSObject is enough: the clicked item arrives as `sender`, carrying its own

--- a/packages/zig/src/macos.zig
+++ b/packages/zig/src/macos.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 const javascript = @import("javascript.zig");
 const native_sidebar_bootstrap = @import("native_sidebar_bootstrap.zig");
 const local_tls = @import("local_tls.zig");
+const menu_roles = @import("menu_roles.zig");
 
 // Objective-C runtime types and functions (manual declarations to avoid @cImport issues)
 pub const objc = struct {
@@ -6052,88 +6053,193 @@ pub fn setApplicationIcon(path: []const u8) void {
     msgSendVoid1(app, "setApplicationIconImage:", image);
 }
 
-/// Create a minimal application menu with standard shortcuts (CMD+H, CMD+Q, etc.)
-/// plus a View menu wired into WKWebView's responder chain for Reload (Cmd+R)
-/// and Force Reload (Cmd+Shift+R). Dev consoles can be opened via right-click
-/// when `dev_tools` is enabled (the webview sets `setInspectable:YES`).
+// NSEventModifierFlags. A key equivalent implies Command already, so these
+// name only what gets added on top of it.
+const modifier_shift: c_ulong = 1 << 17;
+const modifier_control: c_ulong = 1 << 18;
+const modifier_option: c_ulong = 1 << 19;
+const modifier_command: c_ulong = 1 << 20;
+
+/// The AppKit selector for a role, resolved where the menu is declared.
+///
+/// A role `menu_roles.zig` does not define produces an item with a nil action,
+/// which AppKit renders permanently greyed out — a failure you find by
+/// launching the app and looking at it. The tables below are comptime-known, so
+/// a typo is a build error instead.
+fn menuRole(comptime name: []const u8) [*:0]const u8 {
+    return comptime menu_roles.selectorFor(name) orelse
+        @compileError("menu role \"" ++ name ++ "\" has no AppKit selector in menu_roles.zig");
+}
+
+/// One entry in the default menu bar.
+///
+/// Declaring the bar as data rather than as ~40 lines of msgSend per menu is
+/// what keeps it readable at this size — and it keeps the default bar and an
+/// app-declared one resolving roles through the same table.
+const DefaultItem = struct {
+    title: []const u8 = "",
+    /// What the item performs. Null is a separator.
+    selector: ?[*:0]const u8 = null,
+    /// Key equivalent, lowercase. Empty means no shortcut.
+    key: []const u8 = "",
+    /// Modifiers beyond the Command a key equivalent already implies.
+    extra_modifiers: c_ulong = 0,
+    /// Append the app name to the title, as the App menu does: "Quit Craft".
+    with_app_name: bool = false,
+};
+
+const DefaultMenu = struct {
+    /// Fallback title, used when `use_app_name` is set but the name could not
+    /// be read.
+    title: []const u8,
+    items: []const DefaultItem,
+    /// Title this menu with the app's name. AppKit is documented to show the
+    /// application name over the first menu whatever we title it, but setting
+    /// it explicitly costs nothing and does not depend on that.
+    use_app_name: bool = false,
+    /// Hand this menu to `-[NSApplication setWindowsMenu:]`, which makes AppKit
+    /// maintain the list of open windows underneath it.
+    is_windows_menu: bool = false,
+};
+
+/// The App menu. AppKit renders the first menu in the bar under the app's own
+/// name in bold, and everything here is what a Mac user expects to find there.
+const app_menu_items = [_]DefaultItem{
+    .{ .title = "About", .selector = menuRole("about"), .with_app_name = true },
+    .{},
+    .{ .title = "Hide", .selector = menuRole("hide"), .key = "h", .with_app_name = true },
+    .{ .title = "Hide Others", .selector = menuRole("hideOthers"), .key = "h", .extra_modifiers = modifier_option },
+    .{ .title = "Show All", .selector = menuRole("showAll") },
+    .{},
+    .{ .title = "Quit", .selector = menuRole("quit"), .key = "q", .with_app_name = true },
+};
+
+/// The Edit menu, and the reason this function grew.
+///
+/// On macOS a menu item's key equivalent is how Cmd+X/C/V/A reach the responder
+/// chain at all. Without these items an app that never calls `craft.menu.set()`
+/// has no menu-driven clipboard: text fields get only whatever the WKWebView
+/// intercepts for itself, and Cmd+C over a native control does nothing.
+const edit_menu_items = [_]DefaultItem{
+    .{ .title = "Undo", .selector = menuRole("undo"), .key = "z" },
+    .{ .title = "Redo", .selector = menuRole("redo"), .key = "z", .extra_modifiers = modifier_shift },
+    .{},
+    .{ .title = "Cut", .selector = menuRole("cut"), .key = "x" },
+    .{ .title = "Copy", .selector = menuRole("copy"), .key = "c" },
+    .{ .title = "Paste", .selector = menuRole("paste"), .key = "v" },
+    .{ .title = "Delete", .selector = menuRole("delete") },
+    .{ .title = "Select All", .selector = menuRole("selectAll"), .key = "a" },
+};
+
+/// Reload and Force Reload land on the focused WKWebView, which implements
+/// `reload:` and `reloadFromOrigin:` as action selectors. Dev consoles stay
+/// reachable by right-click when `dev_tools` is enabled (the webview sets
+/// `setInspectable:YES`).
+const view_menu_items = [_]DefaultItem{
+    .{ .title = "Reload", .selector = menuRole("reload"), .key = "r" },
+    .{ .title = "Force Reload", .selector = menuRole("forceReload"), .key = "r", .extra_modifiers = modifier_shift },
+    .{},
+    .{ .title = "Enter Full Screen", .selector = menuRole("fullscreen"), .key = "f", .extra_modifiers = modifier_control },
+};
+
+const window_menu_items = [_]DefaultItem{
+    .{ .title = "Minimize", .selector = menuRole("minimize"), .key = "m" },
+    .{ .title = "Zoom", .selector = menuRole("zoom") },
+    .{},
+    .{ .title = "Close Window", .selector = menuRole("close"), .key = "w" },
+    .{},
+    .{ .title = "Bring All to Front", .selector = menuRole("front") },
+};
+
+const default_menus = [_]DefaultMenu{
+    .{ .title = "App", .items = &app_menu_items, .use_app_name = true },
+    .{ .title = "Edit", .items = &edit_menu_items },
+    .{ .title = "View", .items = &view_menu_items },
+    .{ .title = "Window", .items = &window_menu_items, .is_windows_menu = true },
+};
+
+/// The app's display name: `-[NSProcessInfo processName]`, which is the
+/// executable name for a bare binary and CFBundleName inside a `.app`.
+///
+/// Copied into `buf` because the titles built from it are formatted, and a
+/// name too long to fit is reported as absent rather than truncated — a cut
+/// mid-codepoint would make `stringWithUTF8String:` return nil and the menu
+/// item lose its title entirely.
+fn appDisplayName(buf: []u8) ?[]const u8 {
+    const NSProcessInfo = getClass("NSProcessInfo");
+    const info = msgSend0(NSProcessInfo, "processInfo");
+    if (info == null) return null;
+    const name = msgSend0(info, "processName");
+    if (name == null) return null;
+    const utf8 = msgSend0(name, "UTF8String");
+    if (utf8 == null) return null;
+    const span = std.mem.span(@as([*:0]const u8, @ptrCast(utf8)));
+    if (span.len == 0 or span.len > buf.len) return null;
+    @memcpy(buf[0..span.len], span);
+    return buf[0..span.len];
+}
+
+/// Create the default application menu bar: App, Edit, View and Window.
+///
+/// Every item is a role with a **nil target**, so AppKit walks the responder
+/// chain to perform it — exactly as a nib-built menu would. That is what makes
+/// Cmd+C reach the focused field editor or the WKWebView rather than a handler
+/// of ours, which can see neither.
+///
+/// Replaced wholesale the moment an app calls `craft.menu.set()`.
 pub fn createApplicationMenu() void {
     const NSApplication = getClass("NSApplication");
     const NSMenu = getClass("NSMenu");
     const NSMenuItem = getClass("NSMenuItem");
-    const NSString = getClass("NSString");
 
     const app = msgSend0(NSApplication, "sharedApplication");
-
-    // Create main menu bar
     const main_menu = msgSend0(msgSend0(NSMenu, "alloc"), "init");
 
-    // Create app menu (first menu in menu bar)
-    const app_menu_item = msgSend0(msgSend0(NSMenuItem, "alloc"), "init");
-    const app_menu = msgSend0(msgSend0(NSMenu, "alloc"), "init");
+    var name_buf: [128]u8 = undefined;
+    const app_name = appDisplayName(&name_buf);
 
-    // Add "Hide" item with CMD+H
-    const hide_title = msgSend1(NSString, "stringWithUTF8String:", "Hide");
-    const hide_item = msgSend0(msgSend0(NSMenuItem, "alloc"), "init");
-    msgSendVoid1(hide_item, "setTitle:", hide_title);
-    const h_key = msgSend1(NSString, "stringWithUTF8String:", "h");
-    msgSendVoid1(hide_item, "setKeyEquivalent:", h_key);
-    const hide_sel = sel("hide:");
-    msgSendVoid1(hide_item, "setAction:", hide_sel);
-    msgSendVoid1(app_menu, "addItem:", hide_item);
+    for (default_menus) |menu_def| {
+        const menu_title = createNSString(if (menu_def.use_app_name) (app_name orelse menu_def.title) else menu_def.title);
+        const menu_item = msgSend0(msgSend0(NSMenuItem, "alloc"), "init");
+        msgSendVoid1(menu_item, "setTitle:", menu_title);
+        const menu = msgSend1(msgSend0(NSMenu, "alloc"), "initWithTitle:", menu_title);
 
-    // Add separator
-    const sep1 = msgSend0(NSMenuItem, "separatorItem");
-    msgSendVoid1(app_menu, "addItem:", sep1);
+        for (menu_def.items) |item| {
+            const selector = item.selector orelse {
+                msgSendVoid1(menu, "addItem:", msgSend0(NSMenuItem, "separatorItem"));
+                continue;
+            };
 
-    // Add "Quit" item with CMD+Q
-    const quit_title = msgSend1(NSString, "stringWithUTF8String:", "Quit");
-    const quit_item = msgSend0(msgSend0(NSMenuItem, "alloc"), "init");
-    msgSendVoid1(quit_item, "setTitle:", quit_title);
-    const q_key = msgSend1(NSString, "stringWithUTF8String:", "q");
-    msgSendVoid1(quit_item, "setKeyEquivalent:", q_key);
-    const quit_sel = sel("terminate:");
-    msgSendVoid1(quit_item, "setAction:", quit_sel);
-    msgSendVoid1(app_menu, "addItem:", quit_item);
+            // "Quit" becomes "Quit Craft" when we could read a name, and stays
+            // "Quit" when we could not — a bare verb is a worse label than the
+            // full one, but it is still the right item.
+            var title_buf: [160]u8 = undefined;
+            const title = if (item.with_app_name) blk: {
+                const name = app_name orelse break :blk item.title;
+                break :blk std.fmt.bufPrint(&title_buf, "{s} {s}", .{ item.title, name }) catch item.title;
+            } else item.title;
 
-    // Set submenu
-    msgSendVoid1(app_menu_item, "setSubmenu:", app_menu);
-    msgSendVoid1(main_menu, "addItem:", app_menu_item);
+            const native_item = msgSend3(
+                msgSend0(NSMenuItem, "alloc"),
+                "initWithTitle:action:keyEquivalent:",
+                createNSString(title),
+                sel(selector),
+                createNSString(item.key),
+            );
+            if (item.extra_modifiers != 0) {
+                msgSendVoid1Ulong(native_item, "setKeyEquivalentModifierMask:", modifier_command | item.extra_modifiers);
+            }
+            msgSendVoid1(menu, "addItem:", native_item);
+        }
 
-    // ── View menu ─────────────────────────────────────────────────────
-    // Items leave target as nil so AppKit walks the responder chain. The
-    // focused WKWebView responds to `reload:` and `reloadFromOrigin:` as
-    // IBAction-style selectors (defined on WKWebView).
-    const view_menu_item = msgSend0(msgSend0(NSMenuItem, "alloc"), "init");
-    const view_menu_title = msgSend1(NSString, "stringWithUTF8String:", "View");
-    msgSendVoid1(view_menu_item, "setTitle:", view_menu_title);
-    const view_menu = msgSend1(msgSend0(NSMenu, "alloc"), "initWithTitle:", view_menu_title);
+        msgSendVoid1(menu_item, "setSubmenu:", menu);
+        msgSendVoid1(main_menu, "addItem:", menu_item);
 
-    // Reload — Cmd+R
-    const reload_title = msgSend1(NSString, "stringWithUTF8String:", "Reload");
-    const reload_item = msgSend0(msgSend0(NSMenuItem, "alloc"), "init");
-    msgSendVoid1(reload_item, "setTitle:", reload_title);
-    const r_key = msgSend1(NSString, "stringWithUTF8String:", "r");
-    msgSendVoid1(reload_item, "setKeyEquivalent:", r_key);
-    msgSendVoid1(reload_item, "setAction:", sel("reload:"));
-    msgSendVoid1(view_menu, "addItem:", reload_item);
+        // Told about the Window menu, AppKit keeps the list of open windows in
+        // it and adds the checkmark for the active one.
+        if (menu_def.is_windows_menu) msgSendVoid1(app, "setWindowsMenu:", menu);
+    }
 
-    // Force Reload — Cmd+Shift+R. NSEventModifierFlagShift = 1<<17,
-    // NSEventModifierFlagCommand = 1<<20; key equivalents add Command
-    // implicitly so we only OR Shift in here.
-    const NSEventModifierFlagShift: c_ulong = 1 << 17;
-    const NSEventModifierFlagCommand: c_ulong = 1 << 20;
-    const force_reload_title = msgSend1(NSString, "stringWithUTF8String:", "Force Reload");
-    const force_reload_item = msgSend0(msgSend0(NSMenuItem, "alloc"), "init");
-    msgSendVoid1(force_reload_item, "setTitle:", force_reload_title);
-    msgSendVoid1(force_reload_item, "setKeyEquivalent:", r_key);
-    msgSendVoid1(force_reload_item, "setKeyEquivalentModifierMask:", NSEventModifierFlagShift | NSEventModifierFlagCommand);
-    msgSendVoid1(force_reload_item, "setAction:", sel("reloadFromOrigin:"));
-    msgSendVoid1(view_menu, "addItem:", force_reload_item);
-
-    msgSendVoid1(view_menu_item, "setSubmenu:", view_menu);
-    msgSendVoid1(main_menu, "addItem:", view_menu_item);
-
-    // Set as main menu
     msgSendVoid1(app, "setMainMenu:", main_menu);
 }
 

--- a/packages/zig/src/menu_roles.zig
+++ b/packages/zig/src/menu_roles.zig
@@ -1,0 +1,104 @@
+//! Standard menu behaviors, by name.
+//!
+//! A *role* is the portable name for a menu item that the operating system
+//! already knows how to perform: "copy", "quit", "minimize". Items built from a
+//! role get the matching AppKit selector and a **nil target**, so AppKit walks
+//! the responder chain to find something that implements it.
+//!
+//! That indirection is the whole point for the clipboard items. `cut:`,
+//! `copy:` and `paste:` have to land on whatever is focused — the field editor
+//! inside a text field, or the WKWebView itself — and neither is reachable from
+//! a handler of ours. A menu item that posts an event to the page instead can
+//! only ever paste into a page that implemented pasting, which is not what a
+//! user pressing Cmd+V is asking for.
+//!
+//! Two callers share this table:
+//!
+//!  - `bridge_menu.zig`, for `role` on items an app declares through
+//!    `craft.menu.set()`.
+//!  - `macos.zig`, for the default menu bar an app gets when it declares
+//!    nothing at all.
+//!
+//! Keeping it here rather than in either of them means the default bar and the
+//! bridge can't disagree about what "copy" means, and the table can be tested
+//! without an NSApplication.
+
+const std = @import("std");
+
+/// Every role, with the AppKit selector it performs.
+///
+/// The receiver is left to the responder chain, so the selectors span several
+/// classes: NSApplication (`terminate:`, `hide:`), NSWindow (`performClose:`,
+/// `performMiniaturize:`), NSResponder / the field editor (`cut:`, `undo:`),
+/// and WKWebView (`reload:`, `reloadFromOrigin:`).
+pub const table = [_]struct { name: []const u8, selector: [*:0]const u8 }{
+    .{ .name = "about", .selector = "orderFrontStandardAboutPanel:" },
+    .{ .name = "hide", .selector = "hide:" },
+    .{ .name = "hideOthers", .selector = "hideOtherApplications:" },
+    .{ .name = "showAll", .selector = "unhideAllApplications:" },
+    .{ .name = "quit", .selector = "terminate:" },
+    .{ .name = "undo", .selector = "undo:" },
+    .{ .name = "redo", .selector = "redo:" },
+    .{ .name = "cut", .selector = "cut:" },
+    .{ .name = "copy", .selector = "copy:" },
+    .{ .name = "paste", .selector = "paste:" },
+    .{ .name = "delete", .selector = "delete:" },
+    .{ .name = "selectAll", .selector = "selectAll:" },
+    .{ .name = "close", .selector = "performClose:" },
+    .{ .name = "minimize", .selector = "performMiniaturize:" },
+    .{ .name = "zoom", .selector = "performZoom:" },
+    .{ .name = "front", .selector = "arrangeInFront:" },
+    .{ .name = "fullscreen", .selector = "toggleFullScreen:" },
+    .{ .name = "reload", .selector = "reload:" },
+    .{ .name = "forceReload", .selector = "reloadFromOrigin:" },
+};
+
+/// The selector for `role`, or null if the role is not one we know.
+///
+/// Case-insensitive, because the role arrives as JSON written by hand and
+/// "selectAll" / "selectall" are the same intent. Usable at comptime, which is
+/// how `macos.zig` proves its default menu bar only names roles that exist.
+pub fn selectorFor(role: []const u8) ?[*:0]const u8 {
+    for (table) |entry| {
+        if (std.ascii.eqlIgnoreCase(role, entry.name)) return entry.selector;
+    }
+    return null;
+}
+
+test "roles resolve regardless of how they were cased" {
+    try std.testing.expectEqualStrings("copy:", std.mem.span(selectorFor("copy").?));
+    try std.testing.expectEqualStrings("selectAll:", std.mem.span(selectorFor("selectall").?));
+    try std.testing.expectEqualStrings("terminate:", std.mem.span(selectorFor("QUIT").?));
+}
+
+test "an unknown role resolves to nothing rather than to something wrong" {
+    // The bridge relies on this: an unrecognized role falls back to an id item
+    // that forwards to the page, so a newer JS surface degrades to an event
+    // rather than to a dead menu item.
+    try std.testing.expect(selectorFor("") == null);
+    try std.testing.expect(selectorFor("paste-and-match-style") == null);
+    // A prefix must not match — "cut" is a role, "cutlery" is not.
+    try std.testing.expect(selectorFor("cutlery") == null);
+}
+
+test "every selector is a one-argument action selector" {
+    // AppKit action selectors take the sender, so each must end in exactly one
+    // colon. A selector missing it is dispatched with the wrong signature and
+    // the item is auto-disabled — the failure mode #29 was.
+    for (table) |entry| {
+        const selector = std.mem.span(entry.selector);
+        try std.testing.expect(selector.len > 1);
+        try std.testing.expectEqual(@as(u8, ':'), selector[selector.len - 1]);
+        try std.testing.expectEqual(@as(?usize, selector.len - 1), std.mem.indexOfScalar(u8, selector, ':'));
+    }
+}
+
+test "role names are unique" {
+    // A duplicate would silently shadow, and the second spelling would never
+    // be reachable.
+    for (table, 0..) |a, i| {
+        for (table[i + 1 ..]) |b| {
+            try std.testing.expect(!std.ascii.eqlIgnoreCase(a.name, b.name));
+        }
+    }
+}


### PR DESCRIPTION
Closes #30.

`createApplicationMenu()` built four items: Hide, Quit, Reload, Force Reload. No Edit menu, and no `cut:`/`copy:`/`paste:`/`selectAll:`/`undo:` anywhere in the live path.

On macOS a menu item's key equivalent is how Cmd+X/C/V/A reach the responder chain at all. So an app that never calls `craft.menu.set()` had **no menu-driven clipboard** — text fields got only whatever the WKWebView intercepted for itself, and Cmd+C over a native control did nothing.

### The bar now

| menu | items |
|---|---|
| **App** | About, Hide, Hide Others (⌥⌘H), Show All, Quit — titled with the process name, so it reads "Quit Fooby" |
| **Edit** | Undo ⌘Z, Redo ⇧⌘Z, Cut ⌘X, Copy ⌘C, Paste ⌘V, Delete, Select All ⌘A |
| **View** | Reload ⌘R, Force Reload ⇧⌘R (unchanged), Enter Full Screen ⌃⌘F |
| **Window** | Minimize ⌘M, Zoom, Close Window ⌘W, Bring All to Front — and handed to `setWindowsMenu:`, so AppKit maintains the window list underneath it |

Every item is a role with a **nil target**, exactly as the existing View items were. AppKit walks the responder chain to perform it, which is the only way `copy:` reaches the focused field editor or the WKWebView — a handler of ours can see neither.

An app that calls `craft.menu.set()` still replaces the whole bar, unchanged.

### Shared role table

The role→selector table moves out of `bridge_menu.zig` into `menu_roles.zig`, imported by both. The default bar and an app-declared one now resolve "copy" through the same code rather than through two tables that can drift.

Roles are resolved **where the menus are declared**:

```zig
.{ .title = "Select All", .selector = menuRole("selectAll"), .key = "a" },
```

A role `menu_roles.zig` doesn't define produces an item with a nil action, which AppKit renders permanently greyed out — the kind of thing you find by launching the app and squinting. Since the tables are comptime-known, that's now a build error instead:

```
src/macos.zig:6071:9: error: menu role "selectAlll" has no AppKit selector in menu_roles.zig
    .{ .title = "Select All", .selector = menuRole("selectAlll"), .key = "a" },
```

I confirmed that by actually introducing the typo, not by reading the code.

The bar is also data now instead of ~40 lines of `msgSend` per menu, which is what makes it reviewable at this size.

### Verification

On the pinned CI compiler (`0.17.0-dev.1509+bb296ab9b`):

- `zig build` and `zig build -Doptimize=ReleaseSafe` clean; binary 12.96 MB, well under the 14.5 MB warn threshold
- `zig build test` green
- `zig build test:menu-roles` — 4 new tests, confirmed really running by breaking an assertion (3 pass / 1 fail) rather than by watching green
- `zig fmt --check` clean

What I could **not** verify from here is the runtime behaviour — that Cmd+C in a focused text field now goes through the Edit item — since that needs a launched app with a webview. The mechanism is the same nil-target responder-chain dispatch the View menu has been using, and `roleSelector`'s selectors are unchanged bytes, but it is worth a manual check before release.