### PR TITLE
docs(menu): delete the dead NativeMenus class, document the real menu API

### DIFF
--- a/docs/BRIDGE_API.md
+++ b/docs/BRIDGE_API.md
@@ -7,6 +7,7 @@ The Craft JavaScript Bridge provides a seamless interface for your web applicati
 - [Overview](#overview)
 - [Getting Started](#getting-started)
 - [System Tray API](#system-tray-api)
+- [Application Menu (macOS)](#application-menu-macos)
 - [Window API](#window-api)
 - [App API](#app-api)
 - [TypeScript Support](#typescript-support)
@@ -156,6 +157,134 @@ interface MenuItem {
   submenu?: MenuItem[]
 }
 ```
+
+## Application Menu (macOS)
+
+The menu bar across the top of the screen, distinct from the tray menu above.
+macOS only — on Linux and Windows these calls are accepted and ignored.
+
+Craft installs a default bar at startup, so an app that never touches this API
+still gets the standard shortcuts. Calling `set()` replaces that bar
+**entirely** — if your app has text input anywhere, declare an Edit menu
+yourself, or Cmd+X/C/V stop reaching it.
+
+### `window.craft.menu.set(options: { menus: MenuDefinition[] }): Promise<void>`
+
+Replace the whole bar.
+
+```javascript
+await window.craft.menu.set({
+  menus: [
+    {
+      label: 'File',
+      items: [
+        { id: 'new', label: 'New', shortcut: 'cmd+n' },
+        { id: 'open', label: 'Open...', shortcut: 'cmd+o' },
+        { separator: true },
+        { role: 'close', label: 'Close Window', shortcut: 'cmd+w' },
+      ],
+    },
+    {
+      label: 'Edit',
+      items: [
+        { role: 'undo', label: 'Undo', shortcut: 'cmd+z' },
+        { role: 'redo', label: 'Redo', shortcut: 'cmd+shift+z' },
+        { separator: true },
+        { role: 'cut', label: 'Cut', shortcut: 'cmd+x' },
+        { role: 'copy', label: 'Copy', shortcut: 'cmd+c' },
+        { role: 'paste', label: 'Paste', shortcut: 'cmd+v' },
+        { role: 'selectAll', label: 'Select All', shortcut: 'cmd+a' },
+      ],
+    },
+  ],
+});
+```
+
+The returned promise resolves once the message has been posted, not once the
+menu exists — native acknowledges nothing on success. A failure arrives on the
+console rather than as a rejection.
+
+### `window.craft.menu.onAction(handler: (event: { id: string }) => void): () => void`
+
+Menu clicks arrive here. Without it there is no way to respond to a menu at all.
+Returns an unsubscribe function.
+
+```javascript
+const off = window.craft.menu.onAction(({ id }) => {
+  if (id === 'new') createDocument();
+  if (id === 'open') openDocument();
+});
+```
+
+Only items with an `id` fire this. Role items are performed by the system and
+never reach your handler.
+
+### Items and roles
+
+```typescript
+interface MenuDefinition {
+  label: string
+  items: MenuItemDefinition[]
+}
+
+interface MenuItemDefinition {
+  /** Echoed back by `onAction` when this item is clicked. */
+  id?: string
+  label?: string
+  /** Accelerator, e.g. `cmd+n`, `cmd+shift+r`. */
+  shortcut?: string
+  /** Icon name (SF Symbol, resolved through Craft's cross-platform icon table). */
+  icon?: string
+  /** Renders a divider; every other field is ignored when this is set. */
+  separator?: boolean
+  /** A standard behavior the system performs — see the table below. */
+  role?: string
+}
+```
+
+This is the whole of it. The native decoder parses exactly these fields and
+ignores anything else, so extra keys are dropped in silence rather than
+rejected. Two consequences worth knowing:
+
+- a separator is `{ separator: true }`, not `{ type: 'separator' }`
+- there are no nested submenus yet; the bar is one level deep
+
+Checkmarks and enablement are set after the fact, with `checkItem()` /
+`enableItem()`, not with a field here.
+
+**Roles.** A role item is wired to an AppKit selector through the responder
+chain, exactly as a hand-built Mac menu would be. Use one wherever the system
+already knows how to do the job:
+
+| role | performs | role | performs |
+|---|---|---|---|
+| `about` | About panel | `selectAll` | select all |
+| `hide` | hide app | `close` | close window |
+| `hideOthers` | hide other apps | `minimize` | minimize |
+| `showAll` | unhide all | `zoom` | zoom |
+| `quit` | quit | `front` | bring all to front |
+| `undo` / `redo` | undo, redo | `fullscreen` | toggle full screen |
+| `cut` / `copy` / `paste` | clipboard | `reload` | reload the webview |
+| `delete` | delete selection | `forceReload` | reload ignoring cache |
+
+Cut, copy and paste **must** be roles. A round trip through JavaScript cannot
+reach the field editor inside a text field or the WKWebView's own clipboard
+handling, so an `id` item named "Copy" will not copy anything.
+
+An unrecognized role degrades to an ordinary `id` item, which fires `onAction` —
+a newer bridge surface therefore fails soft on an older binary.
+
+### The rest of the surface
+
+| method | effect |
+|---|---|
+| `setDock({ items })` | replace the Dock menu (right-click the Dock icon) |
+| `clearDock()` | remove it |
+| `addItem(menuId, item)` | append one item to an existing menu; `menuId` is the menu's **label**, e.g. `'File'`. Pass `index` on the item to insert instead of append |
+| `removeItem(itemId)` | remove by id |
+| `enableItem(itemId)` / `disableItem(itemId)` | greyed out or not |
+| `checkItem(itemId)` / `uncheckItem(itemId)` | checkmark |
+| `setItemLabel(itemId, label)` | rename in place |
 
 ## Window API
 

--- a/docs/advanced/cross-platform.md
+++ b/docs/advanced/cross-platform.md
@@ -59,7 +59,55 @@ const platformFeatures = await import(
 
 ## Platform-Specific Features
 
-### macOS
+### macOS: the application menu bar
+
+The top-of-screen menu bar is reached through the injected bridge, not through
+an import. It is available on `window` in any Craft window, with no setup:
+
+```typescript
+// Replaces the whole bar, including the default one Craft installs.
+await window.craft.menu.set({
+  menus: [
+    {
+      label: 'File',
+      items: [
+        { id: 'new', label: 'New', shortcut: 'cmd+n' },
+        { separator: true },
+        { role: 'close', label: 'Close Window', shortcut: 'cmd+w' },
+      ],
+    },
+    {
+      label: 'Edit',
+      items: [
+        { role: 'undo', label: 'Undo', shortcut: 'cmd+z' },
+        { separator: true },
+        { role: 'cut', label: 'Cut', shortcut: 'cmd+x' },
+        { role: 'copy', label: 'Copy', shortcut: 'cmd+c' },
+        { role: 'paste', label: 'Paste', shortcut: 'cmd+v' },
+      ],
+    },
+  ],
+})
+
+// Items with an `id` come back here when clicked. Items with a `role` do not —
+// the system performs those.
+window.craft.menu.onAction(({ id }) => {
+  if (id === 'new') openNewDocument()
+})
+```
+
+Use `role` for anything the system already knows how to do, and `id` for your
+own commands. See [Bridge API](../BRIDGE_API.md#application-menu-macos) for the
+full surface and the list of roles.
+
+### Planned platform namespaces
+
+The `craft-native/platform` namespaces below are **not implemented yet** — they
+describe the intended shape of the API, not something you can call today. The
+menu bar above and the [tray API](../BRIDGE_API.md) are the platform surfaces
+that exist now.
+
+#### macOS
 
 ```typescript
 import { mac } from 'craft-native/platform'
@@ -75,14 +123,11 @@ mac.touchBar.setItems([
   { type: 'slider', min: 0, max: 100, value: 50 },
 ])
 
-// Menu Bar
-mac.systemMenu.setApplicationMenu(menu)
-
 // Vibrancy
 window.setVibrancy('under-window')
 ```
 
-### Windows
+#### Windows
 
 ```typescript
 import { win } from 'craft-native/platform'
@@ -109,7 +154,7 @@ win.thumbnailToolbar.setButtons([
 ])
 ```
 
-### Linux
+#### Linux
 
 ```typescript
 import { linux } from 'craft-native/platform'

--- a/packages/typescript/src/bridge/core.ts
+++ b/packages/typescript/src/bridge/core.ts
@@ -859,51 +859,14 @@ export function createTypedBridge<T extends Record<string, BridgeMethod<any, any
   }
 }
 
-// Native Menu System
-export interface MenuItem {
-  id: string
-  label: string
-  accelerator?: string
-  type?: 'normal' | 'separator' | 'checkbox' | 'radio'
-  checked?: boolean
-  enabled?: boolean
-  visible?: boolean
-  icon?: string
-  submenu?: MenuItem[]
-}
-
-export class NativeMenus {
-  constructor(private bridge: NativeBridge) {}
-
-  /**
-   * Set application menu
-   */
-  async setApplicationMenu(menu: MenuItem[]): Promise<void> {
-    await this.bridge.request('menu.setApplicationMenu', { menu })
-  }
-
-  /**
-   * Show context menu
-   */
-  async showContextMenu(menu: MenuItem[], position?: { x: number; y: number }): Promise<string | null> {
-    return this.bridge.request('menu.showContextMenu', { menu, position })
-  }
-
-  /**
-   * Update menu item
-   */
-  async updateMenuItem(id: string, updates: Partial<MenuItem>): Promise<void> {
-    await this.bridge.request('menu.updateMenuItem', { id, updates })
-  }
-
-  /**
-   * Listen for menu item clicks
-   */
-  onMenuClick(callback: (id: string) => void): () => void {
-    this.bridge.on('menu.click', callback)
-    return () => this.bridge.off('menu.click', callback)
-  }
-}
+// There is deliberately no menu class here. The application menu bar is a
+// fire-and-forget action bridge (`menu` / `setAppMenu`), not a request/response
+// method, and it is reached through the injected `window.craft.menu` — see
+// packages/zig/src/js/craft-bridge.js and its types in
+// packages/zig/types/craft-bridge.d.ts. A `NativeMenus` class used to sit here
+// calling `bridge.request('menu.setApplicationMenu')`, a transport no zig
+// handler serves; nothing noticed because `bridge/core` is not re-exported from
+// the package index, so it was unreachable through the public API either way.
 
 // Native Dialogs
 export interface OpenDialogOptions {
@@ -1177,10 +1140,6 @@ export function resetGlobalBridge(): void {
 }
 
 // Export convenience instances
-export function getMenus(): NativeMenus {
-  return new NativeMenus(getBridge())
-}
-
 export function getDialogs(): NativeDialogs {
   return new NativeDialogs(getBridge())
 }
@@ -1194,12 +1153,10 @@ const bridgeCore: {
   BridgeError: typeof BridgeError
   BridgeErrorCodes: typeof BridgeErrorCodes
   createTypedBridge: typeof createTypedBridge
-  NativeMenus: typeof NativeMenus
   NativeDialogs: typeof NativeDialogs
   NativeComponentBridge: typeof NativeComponentBridge
   getBridge: typeof getBridge
   createBridge: typeof createBridge
-  getMenus: typeof getMenus
   getDialogs: typeof getDialogs
   getComponents: typeof getComponents
 } = {
@@ -1207,12 +1164,10 @@ const bridgeCore: {
   BridgeError,
   BridgeErrorCodes,
   createTypedBridge,
-  NativeMenus,
   NativeDialogs,
   NativeComponentBridge,
   getBridge,
   createBridge,
-  getMenus,
   getDialogs,
   getComponents,
 }


### PR DESCRIPTION
Closes #32.

`NativeMenus.setApplicationMenu()` in `bridge/core.ts` sent `bridge.request('menu.setApplicationMenu', { menu })` — a request-style call **no zig handler serves**. The menu bridge dispatches fire-and-forget actions (`setAppMenu`, `addMenuItem`, …); there is no `menu.setApplicationMenu` method on the native side at all. `showContextMenu` and `updateMenuItem` on the same class were dead the same way.

Nobody had hit the dead transport because nobody could: `bridge/core` is not re-exported from `src/index.ts` and `package.json` has no `./bridge` export subpath, so the class was unreachable through the public API. Deleting it is not a breaking change — there was no way to import it.

### Docs were pointing the other direction

**`docs/advanced/cross-platform.md`** showed:

```typescript
mac.systemMenu.setApplicationMenu(menu)
```

Neither `systemMenu` nor the `craft-native/platform` module it's imported from exists anywhere in this repo. Replaced with the real surface (`window.craft.menu.set({ menus })` / `onAction`).

While in there: the rest of that section — `mac.dock`, `mac.touchBar`, `win.taskbar`, `win.jumpList`, `linux.unity`, `linux.desktop` — is fiction too, all of it under the same nonexistent `craft-native/platform` import. I did **not** delete it, since it plainly describes an intended API, but I moved it under a "Planned platform namespaces" heading that says so, so nobody else spends an afternoon looking for the module. Flagging rather than fixing, since designing that API is not this issue.

**`docs/BRIDGE_API.md`** documented only the tray menu. The application menubar — the thing #27 and #29 made actually work — had no documentation at all. It has a section now:

- `set()` and `onAction()`, with the caveat that `set()` replaces the default bar entirely, so an app with text input needs to declare Edit itself
- the real item shape (`{ id, label, shortcut, icon, separator, role }`) and the two things people get wrong: a separator is `{ separator: true }` not `{ type: 'separator' }`, and there are no nested submenus
- the full role table, and why cut/copy/paste **must** be roles — a JS round trip cannot reach the field editor inside a text field, so an `id` item labelled "Copy" copies nothing

### Verification

- `tsc --noEmit` clean
- `bun test` — 467 pass, 0 fail
- `bunx --bun pickier` clean on both changed docs (the 36 warnings it reports repo-wide are all pre-existing, in files this PR does not touch)