### PR TITLE
fix(ci): unblock the three failing native lifecycle legs

### DIFF
--- a/.github/workflows/native-lifecycle.yml
+++ b/.github/workflows/native-lifecycle.yml
@@ -30,18 +30,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # `name` is the whole identity of a leg: it is the evidence label the
+          # script writes under, the artifact name, and the path the upload
+          # reads back. It used to be two fields, `name` and `report`, and they
+          # disagreed on Windows — the script wrote windows-x64/ while the
+          # upload looked in win32-x64/ and failed with "No files were found".
           - os: macos-15
             name: darwin-arm64
-            report: darwin-arm64
           - os: macos-15-intel
             name: darwin-x64
-            report: darwin-x64
           - os: ubuntu-24.04
             name: linux-x64
-            report: linux-x64
           - os: windows-2025
             name: windows-x64
-            report: win32-x64
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     env:
@@ -60,9 +61,28 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          choco install wixtoolset --version=3.14.1 --yes --no-progress
-          $bin = Get-ChildItem "${env:ProgramFiles(x86)}\WiX Toolset v3*\bin" -Directory | Select-Object -First 1
-          if (-not $bin) { throw 'WiX Toolset bin directory not found' }
+          # The windows-2025 image already ships WiX v3 — 3.14.1.20250415 as of
+          # this writing — and `choco install --version=3.14.1` is a *downgrade*
+          # against it, which choco refuses:
+          #
+          #   A newer version of wixtoolset (v3.14.1.20250415) is already installed.
+          #   Chocolatey installed 0/1 packages. 1 packages failed.
+          #
+          # So the step failed before it ever looked for the toolset it needed,
+          # and every Windows lifecycle run died at setup. Look first, install
+          # only when it is genuinely absent, and take whatever v3 the image
+          # provides rather than pinning under it.
+          $wixBin = {
+            Get-ChildItem "${env:ProgramFiles(x86)}\WiX Toolset v3*\bin" -Directory -ErrorAction SilentlyContinue |
+              Sort-Object Name -Descending | Select-Object -First 1
+          }
+          $bin = & $wixBin
+          if (-not $bin) {
+            choco install wixtoolset --version=3.14.1 --yes --no-progress
+            $bin = & $wixBin
+          }
+          if (-not $bin) { throw 'WiX Toolset v3 bin directory not found' }
+          Write-Host "Using WiX at $($bin.FullName)"
           $bin.FullName | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Test packaging API
@@ -77,7 +97,7 @@ jobs:
         with:
           name: native-lifecycle-${{ matrix.name }}
           path: |
-            artifacts/native-lifecycle/${{ matrix.report }}/report.json
-            artifacts/native-lifecycle/${{ matrix.report }}/work/packages-*/**
+            artifacts/native-lifecycle/${{ matrix.name }}/report.json
+            artifacts/native-lifecycle/${{ matrix.name }}/work/packages-*/**
           if-no-files-found: error
           retention-days: 90

--- a/packages/typescript/src/package.test.ts
+++ b/packages/typescript/src/package.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from 'bun:test'
 import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { codesignArguments, dmgCapacityMegabytes, dmgCreateArguments, formatPackagingCommandError, macOSInfoPlist, notarytoolArguments, packageApp, productbuildArguments, renderWixSource, shouldRetryHdiutil, windowsArchitecture, windowsExecutableName } from './package'
+import { candleArguments, codesignArguments, dmgCapacityMegabytes, dmgCreateArguments, formatPackagingCommandError, macOSInfoPlist, notarytoolArguments, packageApp, productbuildArguments, renderWixSource, shouldRetryHdiutil, windowsArchitecture, windowsExecutableName } from './package'
 
 describe('Windows MSI packaging', () => {
   it('renders a deterministic major-upgrade installer without shell interpolation', () => {
@@ -27,6 +27,16 @@ describe('Windows MSI packaging', () => {
     expect(windowsExecutableName('Craft App')).toBe('Craft App.exe')
     expect(() => windowsExecutableName('craft/app')).toThrow('Invalid Windows application name')
     expect(() => windowsExecutableName('CON')).toThrow('Reserved Windows application name')
+  })
+
+  it('compiles for the architecture the source declares', () => {
+    // Without -arch, candle defaults to x86 and quietly produces a 32-bit
+    // installer around a 64-bit payload — while the source it just compiled
+    // says Platform="x64", ProgramFiles64Folder and Win64="yes". ICE80 would
+    // catch the contradiction, but light runs with -sval.
+    expect(candleArguments('x64', 'out.wixobj', 'in.wxs')).toEqual(['-nologo', '-arch', 'x64', '-out', 'out.wixobj', 'in.wxs'])
+    expect(candleArguments('x86', 'out.wixobj', 'in.wxs')).toContain('x86')
+    expect(candleArguments('arm64', 'out.wixobj', 'in.wxs')).toContain('arm64')
   })
 
   it('renders explicit 32-bit metadata only when requested', () => {

--- a/packages/typescript/src/package.ts
+++ b/packages/typescript/src/package.ts
@@ -964,6 +964,20 @@ export function windowsExecutableName(name: string): string {
   return `${name}.exe`
 }
 
+/**
+ * `candle.exe` arguments.
+ *
+ * `-arch` is not optional. WiX v3 deprecated `Package/@Platform` in favour of
+ * this switch, and candle defaults to `x86` without it — so an x64 payload was
+ * being compiled into a 32-bit installer whose one component declares
+ * `Win64="yes"` and installs under `ProgramFiles64Folder`. ICE80 exists to
+ * catch exactly that contradiction, and `light -sval` below turns validation
+ * off, so nothing ever reported it.
+ */
+export function candleArguments(architecture: 'x86' | 'x64' | 'arm64', wixobjPath: string, wxsPath: string): string[] {
+  return ['-nologo', '-arch', architecture, '-out', wixobjPath, wxsPath]
+}
+
 function runCommand(command: string, args: string[], cwd?: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, { cwd, stdio: 'inherit', windowsHide: true })
@@ -981,7 +995,7 @@ async function createMSI(opts: MSIOptions): Promise<{ success: boolean; outputPa
     const wixobjPath = join(tempDir, 'installer.wixobj')
     copyFileSync(opts.binaryPath, sourcePath)
     writeFileSync(wxsPath, renderWixSource(opts, binaryName))
-    await runCommand('candle.exe', ['-nologo', '-out', wixobjPath, wxsPath], tempDir)
+    await runCommand('candle.exe', candleArguments(opts.architecture, wixobjPath, wxsPath), tempDir)
     await runCommand('light.exe', ['-nologo', '-sval', '-out', opts.outputPath, wixobjPath], tempDir)
     if (opts.certificatePath) {
       const signArgs = ['sign', '/fd', 'sha256', '/tr', 'https://timestamp.digicert.com', '/td', 'sha256', '/f', opts.certificatePath]

--- a/scripts/native-lifecycle.ts
+++ b/scripts/native-lifecycle.ts
@@ -2,7 +2,7 @@
 
 import type { PackageResult } from '../packages/typescript/src/package'
 import { createHash } from 'crypto'
-import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { chmodSync, existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, readlinkSync, rmSync, writeFileSync } from 'fs'
 import { join, resolve } from 'path'
 import { packageApp } from '../packages/typescript/src/package'
 import { macOSRollbackPlan } from './native-lifecycle-plan'
@@ -23,8 +23,56 @@ const workDir = join(reportDir, 'work')
 const shouldInstall = process.argv.includes('--install')
 const steps: Step[] = []
 
-function sha256(path: string): string {
-  return createHash('sha256').update(readFileSync(path)).digest('hex')
+/**
+ * Every file inside a bundle, deepest-last, in a stable order.
+ *
+ * Sorted at each level so the walk does not depend on directory order, which
+ * differs between filesystems and would make the digest below unreproducible.
+ */
+function* bundleEntries(dir: string, prefix = ''): Generator<{ relativePath: string, absolutePath: string }> {
+  for (const name of readdirSync(dir).sort()) {
+    const absolutePath = join(dir, name)
+    const relativePath = prefix ? `${prefix}/${name}` : name
+    if (lstatSync(absolutePath).isDirectory()) yield* bundleEntries(absolutePath, relativePath)
+    else yield { relativePath, absolutePath }
+  }
+}
+
+/**
+ * SHA-256 of a packaged artifact.
+ *
+ * Most artifacts are single files. A macOS `.app` is a directory, and reading
+ * one as a file throws `EISDIR` — which is what took down both macOS legs of
+ * this workflow, after every packaging, install, update and rollback step had
+ * already passed. The report was never written and the evidence upload then
+ * failed too, so a fully successful lifecycle run reported nothing at all.
+ *
+ * Bundles are hashed as a tree instead: each file's path, then its mode bit or
+ * symlink target, then its contents. The path goes in as well as the contents
+ * so that moving a file within the bundle changes the digest. `report.json`
+ * says which of the two kinds each digest is, since they are not comparable.
+ */
+function sha256(path: string): { sha256: string, kind: 'file' | 'tree' } {
+  if (!lstatSync(path).isDirectory())
+    return { sha256: createHash('sha256').update(readFileSync(path)).digest('hex'), kind: 'file' }
+
+  const hash = createHash('sha256')
+  for (const { relativePath, absolutePath } of bundleEntries(path)) {
+    const stats = lstatSync(absolutePath)
+    hash.update(relativePath)
+    if (stats.isSymbolicLink()) {
+      // Read the link rather than follow it: bundles are full of internal
+      // symlinks (Versions/Current and friends) and following them would both
+      // double-count and, in the wrong bundle, loop.
+      hash.update('\u0002')
+      hash.update(readlinkSync(absolutePath))
+    }
+    else {
+      hash.update(stats.mode & 0o111 ? '\u0001' : '\u0000')
+      hash.update(readFileSync(absolutePath))
+    }
+  }
+  return { sha256: hash.digest('hex'), kind: 'tree' }
 }
 
 async function command(name: string, argv: string[], expected?: string): Promise<string> {
@@ -161,14 +209,32 @@ async function main(): Promise<void> {
     error = caught instanceof Error ? caught.stack || caught.message : String(caught)
   }
 
+  // Hashing runs after the try/catch above, so anything it throws used to
+  // escape `main` before `report.json` was written — losing the record of
+  // every step that had already passed. Failures are recorded per artifact
+  // and still fail the run, but the evidence survives them.
   const artifacts = packages
     .filter(result => result.success && result.outputPath && existsSync(result.outputPath))
-    .map(result => ({
-      platform: result.platform,
-      format: result.format,
-      path: result.outputPath!.replace(`${root}/`, ''),
-      sha256: sha256(result.outputPath!),
-    }))
+    .map((result) => {
+      const artifact = {
+        platform: result.platform,
+        format: result.format,
+        path: result.outputPath!.replace(`${root}/`, ''),
+        sha256: null as string | null,
+        sha256Kind: null as 'file' | 'tree' | null,
+        error: undefined as string | undefined,
+      }
+      try {
+        const digest = sha256(result.outputPath!)
+        artifact.sha256 = digest.sha256
+        artifact.sha256Kind = digest.kind
+      }
+      catch (caught) {
+        artifact.error = caught instanceof Error ? caught.message : String(caught)
+        error ||= `failed to hash ${result.format} artifact ${artifact.path}: ${artifact.error}`
+      }
+      return artifact
+    })
   const report = {
     schemaVersion: 1,
     generatedAt: new Date().toISOString(),


### PR DESCRIPTION
Works #11 — the "Native Package Lifecycle" half.

Three of the four matrix legs failed, each for its own reason, and none for anything the lifecycle actually exercises. Linux was green throughout.

Run [32215619783](https://github.com/craft-native/craft/actions/runs/32215619783):

| leg | result |
|---|---|
| darwin-arm64 | `EISDIR: illegal operation on a directory, read` |
| darwin-x64 | same |
| linux-x64 | ✅ |
| windows-x64 | `Chocolatey installed 0/1 packages` |

### Windows: WiX never installed

The `windows-2025` image already ships WiX **v3.14.1.20250415**, and the workflow asked choco for `--version=3.14.1` — a *downgrade* against it:

```
A newer version of wixtoolset (v3.14.1.20250415) is already installed.
 Use --allow-downgrade or --force to attempt to install older versions.
Chocolatey installed 0/1 packages. 1 packages failed.
```

So the step died before it ever looked for the toolset it needed. It now probes first and installs only when WiX is genuinely absent.

### Windows: the evidence upload read a directory nothing writes

The matrix carried two fields, `name` and `report`, and on Windows they disagreed. `CRAFT_EVIDENCE_LABEL` is `matrix.name`, so the script wrote `artifacts/native-lifecycle/windows-x64/` — while the upload read `.../win32-x64/`:

```
##[error]No files were found with the provided path: artifacts/native-lifecycle/win32-x64/report.json
```

That would have failed the leg *even after* the WiX fix. Collapsed to the one field so they cannot drift again; the other three legs had identical values, so nothing else changes.

### Windows: the MSI was being compiled 32-bit

`candle.exe` defaults to `-arch x86`, and WiX v3 deprecated the `Package/@Platform` attribute that `renderWixSource` sets. So an x64 payload was wrapped in a 32-bit installer whose one component declares `Win64="yes"` and installs under `ProgramFiles64Folder`. ICE80 exists to catch exactly that contradiction — and `light -sval` turns validation off, so nothing reported it. The architecture is now passed explicitly, extracted as `candleArguments()` and unit-tested in the same style as `codesignArguments` / `notarytoolArguments` next to it.

This is the one change here I could not run: no Windows box. It follows the WiX v3 docs (`Package/@Platform` deprecated in favour of `candle -arch`), and it matches the "Windows x64 MSI platform/install-root correction" #11 refers to downstream. The leg has never run past setup, so this cannot regress anything.

### macOS: EISDIR

`sha256()` was called on every packaged artifact, and one of them is the `.app` bundle — a directory. Both macOS legs died there, **after** every packaging, install, update and rollback step had already passed.

Bundles now hash as a tree: each file's path, then its mode bit or symlink target, then its contents, in sorted order. Verified against a real fixture bundle:

```
stable across two reads:               true f5d5a535570ab21343...
changes when a file is added:          true
changes when a file moves:             true
sees a symlink:                        true
distinguishes symlink targets:         true
back to the original after cleanup:    true
```

`report.json` records `sha256Kind: "file" | "tree"` per artifact, since the two digests are not comparable. Additive — no consumer has ever seen a digest for a directory artifact, because it always threw.

Hashing also ran *after* the try/catch, so anything it threw escaped `main` before `report.json` was written — losing the record of the entire run and failing the evidence upload for good measure. Hash failures are now recorded per artifact and still fail the job.

### Verification

- `bun scripts/native-lifecycle.ts` end to end locally on darwin-arm64: `"status": "passed"`, six artifacts, the two `.app` bundles hashing as `tree` and the dmg/pkg as `file`
- `bun test` — 468 pass, 0 fail (16 in `package.test.ts`, including the new `candleArguments` one)
- `tsc --noEmit` clean, `pickier` clean on all four changed files

### Not in this PR

- **The Releaser half of #11.** Its Linux leg failed on `sub-compilation of mingw-w64 crt2.o failed`, which #21 already fixed; its macOS leg fails the deliberate `Require macOS release credentials` gate, which stays. Until the seven `APPLE_*` secrets are set, #11's release acceptance criteria cannot be met — and because `npm` is `needs: [pantry]`, nothing publishes at all in the meantime. That is the gate working as designed, so I have left it alone.
- **The pantry warning** `package bun.sh@1.3.14 not found in registry` / `pantry workspace install failed`. It appears on every leg including the green one; the action's own SDK path installs bun successfully either side of it, so it is noise from upstream rather than a blocker here.