### PR TITLE
ci: pin the first-party Zig dependencies to commits

### DIFF
--- a/.github/actions/first-party-zig-deps/action.yml
+++ b/.github/actions/first-party-zig-deps/action.yml
@@ -2,32 +2,53 @@ name: First-party Zig dependencies
 description: >
   Clone the first-party Zig packages craft depends on by relative path
   (zig-js and its zig-regex / zig-gc) into the directory build.zig.zon
-  resolves to.
+  resolves to, at the revisions pinned in pins.env.
 
 runs:
   using: composite
   steps:
     # These are co-developed first-party packages, so there is no published
-    # tarball to fetch and the dependency is a relative path. The destination is
-    # derived from that same relative path rather than hardcoded, so the two
-    # cannot drift apart.
+    # tarball to fetch and the dependency is a relative path — which means Zig's
+    # package manager has no `.url` + hash to verify and nothing records which
+    # revision a build used.
     #
-    # Unpinned, which is the honest cost of a path dependency: an unrelated push
-    # to zig-js can turn a craft build red. Pinning belongs with a future
-    # `.url` + hash dependency, which first needs zig-js to publish its own
-    # dependencies the same way.
+    # So the revision is recorded here instead, in pins.env. Cloning the default
+    # branch, which this did until now, hands the question of whether craft's CI
+    # is green to whoever last pushed to another repository. See pins.env for
+    # what that cost and for how to bump one.
     #
     # Idempotent, because several jobs call this and some run more than one
-    # build step.
+    # build step. A checkout already at the pinned revision is left alone; one
+    # at any other revision is replaced, so a stale cache cannot silently win.
     - shell: bash
       run: |
         set -euo pipefail
+
+        # shellcheck source=pins.env
+        . "$GITHUB_ACTION_PATH/pins.env"
+
         deps="$GITHUB_WORKSPACE/packages/zig/../../../../Libraries"
         mkdir -p "$deps"
-        for repo in zig-js zig-regex zig-gc; do
-          if [ -d "$deps/$repo/.git" ]; then
-            echo "$repo already present"
-          else
-            git clone --depth 1 "https://github.com/zig-utils/$repo" "$deps/$repo"
+
+        fetch_pinned() {
+          local repo="$1" sha="$2" dest="$deps/$1"
+
+          if [ -d "$dest/.git" ] && [ "$(git -C "$dest" rev-parse HEAD)" = "$sha" ]; then
+            echo "$repo already at $sha"
+            return
           fi
-        done
+
+          rm -rf "$dest"
+          git init --quiet "$dest"
+          git -C "$dest" remote add origin "https://github.com/zig-utils/$repo"
+          # Fetch the one commit rather than the branch: the pin may point at
+          # something that is no longer the tip, and --depth 1 on a branch would
+          # not reach it.
+          git -C "$dest" fetch --quiet --depth 1 origin "$sha"
+          git -C "$dest" checkout --quiet FETCH_HEAD
+          echo "$repo pinned at $sha"
+        }
+
+        fetch_pinned zig-js "$zig_js"
+        fetch_pinned zig-regex "$zig_regex"
+        fetch_pinned zig-gc "$zig_gc"

--- a/.github/actions/first-party-zig-deps/pins.env
+++ b/.github/actions/first-party-zig-deps/pins.env
@@ -1,0 +1,26 @@
+# Commit pins for craft's first-party Zig dependencies.
+#
+# `build.zig.zon` reaches these by relative path, so there is no `.url` + hash
+# for Zig's package manager to verify and nothing else records which revision a
+# build used. Cloning the default branch instead — which is what this action did
+# until now — means an unrelated push to another repository decides whether
+# craft's CI is green. That is not hypothetical: zig-js sized a SIMD loop by
+# `@sizeOf(@Vector(8, u8))`, which is 8 on aarch64 and 16 on x86_64, and every
+# Linux job here failed to compile for three days over it while macOS stayed
+# green.
+#
+# To bump one: put the new SHA here and let CI prove it. That is a reviewable
+# commit that says which revision changed and why, which "whatever main happened
+# to be at 13:32" never was.
+#
+# Local development is unaffected: developers build against their own sibling
+# checkouts, and this file is read only by the CI action next to it.
+
+# fix(lexer): size the SIMD identifier scan by lane count, not byte size (#625)
+zig_js=eba3f7cfb8b32d6d84099b10f0e063fa0e0c53c7
+
+# fix(parser): make class-set construction failure-atomic (#20)
+zig_regex=cfb24da9f1dd9e759cefec7d6e1dfa094998e9d8
+
+# refactor(heap): compare the build mode by tag name, across the Zig rename
+zig_gc=89b6652c81ba892119b7b9ce3b0d07fc78a009ff


### PR DESCRIPTION
The immediate breakage is already fixed upstream ([zig-utils/zig-js#625](https://github.com/zig-utils/zig-js/pull/625), merged). This is so it cannot happen again from a repository nobody here pushed to.

### What went wrong

`build.zig.zon` reaches zig-js and its zig-regex / zig-gc by **relative path**, so Zig's package manager has no `.url` + hash to verify and nothing recorded which revision a build used. This action cloned each default branch — which hands the question of whether craft's CI is green to whoever last pushed to another repo.

That is not hypothetical. zig-js sized a SIMD loop by `@sizeOf(@Vector(8, u8))`, which is **8 on aarch64 and 16 on x86_64**. Every Linux job here failed to compile for three days over a change nobody made in this repo — and because macOS stayed green, it read as a platform problem rather than a dependency one.

The action's own comment already conceded the point ("an unrelated push to zig-js can turn a craft build red") and deferred it to a future `.url` + hash dependency. That still needs zig-js to publish its own dependencies the same way, and this is cheap in the meantime.

### What this does

Revisions live in `pins.env` next to the action:

```
# fix(lexer): size the SIMD identifier scan by lane count, not byte size (#625)
zig_js=eba3f7cfb8b32d6d84099b10f0e063fa0e0c53c7
```

Bumping one becomes a commit that says which revision changed and why, with CI proving it before it lands. "Whatever main happened to be at 13:32" said neither.

Two details that matter:

- The fetch takes the **pinned commit**, not the branch tip. A pin may point at something that is no longer the tip, and `--depth 1` on a branch would not reach it.
- A checkout already at the pin is left alone; one at any *other* revision is replaced. Several jobs call this action and some run it more than once, so a stale tree must not quietly win.

Local development is untouched: developers still build against their own sibling checkouts, and `pins.env` is read only by this CI action.

### Verification

I ran the action's script directly against a simulated workspace rather than only reading it:

| case | result |
|---|---|
| fresh workspace | all three fetched by SHA in ~8s; the checked-out `lexer.zig` has `const lanes = @typeInfo(Block).vector.len` |
| run again unchanged | `zig-js already at eba3f7c…` — no refetch |
| checkout moved to `HEAD~1` | `zig-js pinned at eba3f7c…`, and `rev-parse HEAD` confirms it moved back |

This PR's own Linux jobs are the real test: they exercise the new action on every leg.