### PR TITLE
fix(build): keep test declarations out of the published SDK

### DIFF
--- a/packages/typescript/tsconfig.build.json
+++ b/packages/typescript/tsconfig.build.json
@@ -11,7 +11,14 @@
   "include": [
     "src"
   ],
+  // Test sources emit declarations too, and `dist/package.test.d.ts` was
+  // shipping in the published package. Excluding the directory is not enough:
+  // `src/package.test.ts` sits beside the module it tests, which is the
+  // convention the rest of the repo uses too. Match ts-maps and exclude by
+  // pattern.
   "exclude": [
-    "src/__tests__/**"
+    "src/__tests__/**",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts"
   ]
 }


### PR DESCRIPTION
`integration` is now the only red job on `main`, and this is why:

```
error: Test declaration leaked into dist:
  /home/runner/work/craft/craft/packages/typescript/dist/package.test.d.ts
```

`tsconfig.build.json` excluded `src/__tests__/**` — a *directory*. But `src/package.test.ts` sits beside the module it tests, so tsc compiled it and emitted `package.test.d.ts` into the published package. Excluded by pattern now, which is what `packages/ts-maps/tsconfig.build.json` already does:

```jsonc
"exclude": ["test", "src/**/*.test.ts", "src/**/*.spec.ts"]
```

### Why now

This has been true since `package.test.ts` was added. It stayed invisible because the `integration` job that runs `verify:packages` is `needs: [zig-core, …]`, and `zig-core (ubuntu-latest)` has been failing — so `integration` was skipped every time. With [zig-utils/zig-js#625](https://github.com/zig-utils/zig-js/pull/625) merged, zig-core went green and `integration` ran for the first time in a while, straight into this.

Same shape as the `run`/`report` mismatch in #37: a check that never executes is not a check.

### Verification

Reproduced it locally first, then fixed it:

- before: `bun run build && bun scripts/verify-packages.ts` → the same leak error
- after: `Verified package publish surfaces (36 checks).`
- `dist/` has no `*.test.d.ts` and still emits `index.d.ts`, `package.d.ts`, `binary-resolver.d.ts` and the rest

I also ran everything else `integration` does that can run off a Mac, since that job's later steps have not executed in a while either:

| step | result |
|---|---|
| `bun run typecheck` (typescript, create-craft, ts-maps) | pass |
| `zig fmt --check src/ build.zig` | pass |
| `bun run verify:cimports` | pass — 2 documented Linux binding exceptions |
| `packages/ts-maps` build + `bun test` | pass — 27 tests |
| `create-craft --version` and `list` | pass |
| `bun scripts/verify-create-craft.ts` | pass — minimal, full-featured, todo-app |
| `bun x --bun pickier .` | pass — 0 errors, 36 pre-existing warnings |

Two steps of `bun run verify` I could not reproduce locally: `bun run build`, because my pantry resolves a different Zig than CI's does, and `pantry publish:commit --dry-run`. CI covers both.