### PR TITLE
fix(ci): let the benchmark job comment on pull requests

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -19,6 +19,16 @@ jobs:
     name: run
     runs-on: ubuntu-latest
 
+    # The last step posts the benchmark comparison as a pull request comment,
+    # and the default token is read-only, so it failed with "Resource not
+    # accessible by integration" — after the build and every benchmark had
+    # succeeded. Only pull requests comment, so main pushes stayed green and
+    # the job looked healthy. binary-size.yml had the identical bug and was
+    # fixed in #22; this workflow was missed.
+    permissions:
+      contents: read
+      pull-requests: write
+
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
The Benchmark job fails on every pull request, at the very last step:

```
RequestError [HttpError]: Resource not accessible by integration
##[error]Unhandled error: HttpError: Resource not accessible by integration
```

It posts its comparison as a PR comment, and the default `GITHUB_TOKEN` is read-only. The build ran, every benchmark ran, the comparison was computed — and then the job went red over permission to leave a comment.

Only pull requests comment, so pushes to `main` stayed green and the job looked healthy. That is why this outlived the identical bug in `binary-size.yml`, fixed in #22 — same cause, same fix, one workflow missed.

`benchmarks.yml` and `binary-size.yml` are the only two workflows here that call `github-script`, and `binary-size.yml` is now the only one that declares the permission. After this they match.

Requested explicitly rather than left to the repository default, for the same reason as #22: the default is what made it invisible.