### PR TITLE
fix(sdk): ship declarations that resolve under node16/nodenext

### DIFF
--- a/packages/ts-maps/src/FilesystemTileBackend.ts
+++ b/packages/ts-maps/src/FilesystemTileBackend.ts
@@ -33,7 +33,7 @@ import type { Tile, TileCacheBackend } from 'ts-maps'
 // Import the fs helpers directly from their source module rather than from
 // the `craft-native` package root, matching how `MapView` talks to
 // the bridge — keeps the type graph narrow.
-import { fs, readBinaryFile, writeBinaryFile } from '../../typescript/src/api/fs'
+import { fs, readBinaryFile, writeBinaryFile } from '../../typescript/src/api/fs.js'
 
 export interface FilesystemBackendOptions {
   /**

--- a/packages/ts-maps/src/MapView.ts
+++ b/packages/ts-maps/src/MapView.ts
@@ -10,8 +10,8 @@
 // package root, so we don't pull the entire `craft-native` surface
 // (including unrelated stx-templated sidebar files) through the type
 // checker. The public API of the bridge is stable, so this is fine.
-import type { NativeBridge } from '../../typescript/src/bridge/core'
-import { getBridge } from '../../typescript/src/bridge/core'
+import type { NativeBridge } from '../../typescript/src/bridge/core.js'
+import { getBridge } from '../../typescript/src/bridge/core.js'
 import type { TsMap } from 'ts-maps'
 import { createMap, tileLayer } from 'ts-maps'
 import {
@@ -23,12 +23,12 @@ import {
   craftPolylineToPolyline,
   craftRegionToBounds,
   latLngToCraftCoord,
-} from './adapters'
+} from './adapters.js'
 import type {
   MapBridgeEvent,
   TypedMapBridgeRequest,
-} from './bridge-protocol'
-import { BRIDGE_NAMESPACE, mapEventName } from './bridge-protocol'
+} from './bridge-protocol.js'
+import { BRIDGE_NAMESPACE, mapEventName } from './bridge-protocol.js'
 import type {
   Coordinate,
   MapCamera,
@@ -38,8 +38,8 @@ import type {
   MapPolygon,
   MapPolyline,
   MapRegion,
-} from './types'
-import { defaultMapCamera, defaultMapConfiguration } from './types'
+} from './types.js'
+import { defaultMapCamera, defaultMapConfiguration } from './types.js'
 
 // Monotonic counter — same pattern as `components/native.ts` in
 // `craft-native` — so multiple map views created in the same tick

--- a/packages/ts-maps/src/adapters.ts
+++ b/packages/ts-maps/src/adapters.ts
@@ -17,8 +17,8 @@ import type {
   MapPolygon,
   MapPolyline,
   MapRegion,
-} from './types'
-import { markerColorHex, strokePatternDashes } from './types'
+} from './types.js'
+import { markerColorHex, strokePatternDashes } from './types.js'
 
 // ---------------------------------------------------------------------------
 // Coordinates

--- a/packages/ts-maps/src/bridge-protocol.ts
+++ b/packages/ts-maps/src/bridge-protocol.ts
@@ -14,7 +14,7 @@ import type {
   MapPolygon,
   MapPolyline,
   MapRegion,
-} from './types'
+} from './types.js'
 
 /**
  * Namespace used when emitting and listening for bridge messages. Matches

--- a/packages/ts-maps/src/index.ts
+++ b/packages/ts-maps/src/index.ts
@@ -19,7 +19,7 @@ export {
   type ComponentProps,
   type MapViewInstance,
   type MapViewProps,
-} from './MapView'
+} from './MapView.js'
 
 // Type mirrors of the Zig structs.
 export {
@@ -43,7 +43,7 @@ export {
   type MarkerColor,
   type StrokePattern,
   type UserTrackingMode,
-} from './types'
+} from './types.js'
 
 // Adapters (pure fns) for round-tripping between Craft and ts-maps types.
 export {
@@ -60,7 +60,7 @@ export {
   latLngToCraftCoord,
   regionFromBounds,
   type TsMapsCameraOptions,
-} from './adapters'
+} from './adapters.js'
 
 // Bridge protocol constants/types.
 export {
@@ -70,18 +70,18 @@ export {
   type MapBridgeMethod,
   type MapBridgeRequest,
   type TypedMapBridgeRequest,
-} from './bridge-protocol'
+} from './bridge-protocol.js'
 
 // Sandbox-filesystem tile persistence + offline region helpers.
 export {
   createFilesystemBackend,
   type FilesystemBackendOptions,
-} from './FilesystemTileBackend'
+} from './FilesystemTileBackend.js'
 export {
   createFilesystemTileCache,
   saveOfflineRegionToFilesystem,
   type FilesystemOfflineRegionOptions,
-} from './offlineRegion'
+} from './offlineRegion.js'
 
 // Runtime capability probe — tells the host app which renderer the
 // device can realistically drive.
@@ -89,7 +89,7 @@ export {
   probeCapabilities,
   supportsAdvancedRendering,
   type MapRendererCapabilities,
-} from './capabilities'
+} from './capabilities.js'
 
 // createMap is the underlying ts-maps factory; re-export under its original
 // name for parity with the spec which mentions `createMap` as a Craft export.
@@ -105,5 +105,5 @@ export const tsMapsProvider = 'ts_maps' as const
  * Alias preserved for callers that imported the two helpers by spec name.
  * `coordinateFromLatLng(LatLng) -> Coordinate`, `latLngFromCoordinate(Coordinate) -> LatLng`.
  */
-export { latLngToCraftCoord as coordinateFromLatLng } from './adapters'
-export { craftCoordToLatLng as latLngFromCoordinate } from './adapters'
+export { latLngToCraftCoord as coordinateFromLatLng } from './adapters.js'
+export { craftCoordToLatLng as latLngFromCoordinate } from './adapters.js'

--- a/packages/ts-maps/src/offlineRegion.ts
+++ b/packages/ts-maps/src/offlineRegion.ts
@@ -28,7 +28,7 @@ import type {
   TileCacheOptions,
 } from 'ts-maps'
 import { saveOfflineRegion, TileCache } from 'ts-maps'
-import { createFilesystemBackend } from './FilesystemTileBackend'
+import { createFilesystemBackend } from './FilesystemTileBackend.js'
 
 export type OfflineBoundsLike =
   | { west: number, south: number, east: number, north: number }

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -45,12 +45,27 @@
       "default": "./dist/mobile.js"
     },
     "./ios": {
+      "browser": null,
       "types": "./dist/ios/src/index.d.ts",
       "import": "./dist/ios/src/index.js"
     },
     "./android": {
+      "browser": null,
       "types": "./dist/android/src/index.d.ts",
       "import": "./dist/android/src/index.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "mobile": [
+        "./dist/mobile.d.ts"
+      ],
+      "ios": [
+        "./dist/ios/src/index.d.ts"
+      ],
+      "android": [
+        "./dist/android/src/index.d.ts"
+      ]
     }
   },
   "module": "./dist/index.js",

--- a/packages/typescript/src/api/android-advanced.ts
+++ b/packages/typescript/src/api/android-advanced.ts
@@ -5,7 +5,7 @@
  * @module @craft-native/api/android-advanced
  */
 
-import { isCraft, getPlatform } from './process'
+import { isCraft, getPlatform } from './process.js'
 
 // ============================================================================
 // Material You / Dynamic Colors

--- a/packages/typescript/src/api/app.ts
+++ b/packages/typescript/src/api/app.ts
@@ -4,8 +4,8 @@
  * @module @craft-native/api/app
  */
 
-import { getBridge } from '../bridge/core'
-import { isWebKitHost, webkitRequest } from '../bridge/webkit-pending'
+import { getBridge } from '../bridge/core.js'
+import { isWebKitHost, webkitRequest } from '../bridge/webkit-pending.js'
 
 // ============================================================================
 // Types

--- a/packages/typescript/src/api/clipboard.ts
+++ b/packages/typescript/src/api/clipboard.ts
@@ -4,8 +4,8 @@
  * @module @craft-native/api/clipboard
  */
 
-import { getBridge } from '../bridge/core'
-import { isWebKitHost, postWebKit, webkitRequest } from '../bridge/webkit-pending'
+import { getBridge } from '../bridge/core.js'
+import { isWebKitHost, postWebKit, webkitRequest } from '../bridge/webkit-pending.js'
 
 /** Default timeout for callback-style clipboard reads. */
 const CLIPBOARD_READ_TIMEOUT_MS = 5000

--- a/packages/typescript/src/api/crypto.ts
+++ b/packages/typescript/src/api/crypto.ts
@@ -3,7 +3,7 @@
  * Provides cryptographic operations through the Craft bridge
  */
 
-import type { CraftCryptoAPI } from '../types'
+import type { CraftCryptoAPI } from '../types.js'
 
 /**
  * Error type for cryptographic failures (malformed input, decode errors, etc.).

--- a/packages/typescript/src/api/db.ts
+++ b/packages/typescript/src/api/db.ts
@@ -27,8 +27,8 @@
  */
 
 import { EventEmitter } from 'events'
-import { getBridge } from '../bridge/core'
-import type { CraftDatabaseAPI } from '../types'
+import { getBridge } from '../bridge/core.js'
+import type { CraftDatabaseAPI } from '../types.js'
 
 /**
  * Send a request through the unified `NativeBridge`. Replaces the legacy

--- a/packages/typescript/src/api/dialog.ts
+++ b/packages/typescript/src/api/dialog.ts
@@ -4,8 +4,8 @@
  * @module @craft-native/api/dialog
  */
 
-import { getBridge } from '../bridge/core'
-import { isWebKitHost, webkitRequest } from '../bridge/webkit-pending'
+import { getBridge } from '../bridge/core.js'
+import { isWebKitHost, webkitRequest } from '../bridge/webkit-pending.js'
 
 /**
  * Default timeout for *file-system* dialog round-trips (open/save).

--- a/packages/typescript/src/api/fs.ts
+++ b/packages/typescript/src/api/fs.ts
@@ -24,8 +24,8 @@
  * ```
  */
 
-import { getBridge } from '../bridge/core'
-import type { CraftFileSystemAPI } from '../types'
+import { getBridge } from '../bridge/core.js'
+import type { CraftFileSystemAPI } from '../types.js'
 
 /**
  * Get the host-injected legacy file-system bridge, or null. The legacy

--- a/packages/typescript/src/api/http.ts
+++ b/packages/typescript/src/api/http.ts
@@ -4,7 +4,7 @@
  * Bypasses CORS restrictions when running in Craft
  */
 
-import type { CraftHttpAPI } from '../types'
+import type { CraftHttpAPI } from '../types.js'
 
 /**
  * Result of {@link encodeRequestBody}. `kind` lets the caller decide

--- a/packages/typescript/src/api/index.ts
+++ b/packages/typescript/src/api/index.ts
@@ -10,7 +10,7 @@ export {
   window,
   createWindow,
   Window
-} from './window'
+} from './window.js'
 export type {
   WindowPosition,
   WindowSize,
@@ -20,7 +20,7 @@ export type {
   WindowEventType,
   WindowEventMap,
   WindowEventHandler
-} from './window'
+} from './window.js'
 
 // Tray/Menubar API - System tray and menubar apps
 export {
@@ -34,7 +34,7 @@ export {
   menuItem,
   checkbox,
   submenu
-} from './tray'
+} from './tray.js'
 export type {
   MenuItem,
   TrayClickEvent,
@@ -43,7 +43,7 @@ export type {
   TrayEventType,
   TrayEventMap,
   TrayEventHandler
-} from './tray'
+} from './tray.js'
 
 // App API - Application lifecycle and system integration
 export {
@@ -65,7 +65,7 @@ export {
   notify,
   registerShortcut,
   unregisterShortcut
-} from './app'
+} from './app.js'
 export type {
   AppInfo,
   SystemPreferences,
@@ -76,19 +76,19 @@ export type {
   AppEventMap,
   AppEventHandler,
   ShortcutHandler
-} from './app'
+} from './app.js'
 
 // File System API
-export { fs, readBinaryFile, writeBinaryFile, stat, copy, move, watch } from './fs'
-export type { FileStats } from './fs'
+export { fs, readBinaryFile, writeBinaryFile, stat, copy, move, watch } from './fs.js'
+export type { FileStats } from './fs.js'
 
 // Database API
-export { db, openDatabase, Database, KeyValueStore } from './db'
-export type { ExecuteResult, TableColumn } from './db'
+export { db, openDatabase, Database, KeyValueStore } from './db.js'
+export type { ExecuteResult, TableColumn } from './db.js'
 
 // HTTP Client API
-export { http, HttpClient, WebSocketClient, createClient, HttpError } from './http'
-export type { HttpClientOptions, RequestOptions, HttpResponse, WebSocketOptions } from './http'
+export { http, HttpClient, WebSocketClient, createClient, HttpError } from './http.js'
+export type { HttpClientOptions, RequestOptions, HttpResponse, WebSocketOptions } from './http.js'
 
 // Crypto API
 export {
@@ -99,7 +99,7 @@ export {
   timingSafeEqual,
   hashPassword,
   verifyPassword
-} from './crypto'
+} from './crypto.js'
 
 // Process API
 export {
@@ -118,8 +118,8 @@ export {
   exit,
   argv,
   open
-} from './process'
-export type { Platform, SystemInfo, ExecOptions, ExecResult, SpawnOptions } from './process'
+} from './process.js'
+export type { Platform, SystemInfo, ExecOptions, ExecResult, SpawnOptions } from './process.js'
 
 // Mobile API - Unified cross-platform mobile features
 export {
@@ -134,7 +134,7 @@ export {
   lifecycle,
   notifications,
   notifications as notification
-} from './mobile'
+} from './mobile.js'
 export type {
   DeviceInfo,
   DeviceCapabilities,
@@ -150,7 +150,7 @@ export type {
   ShareOptions,
   AppState,
   NotificationOptions as MobileNotificationOptions
-} from './mobile'
+} from './mobile.js'
 
 // iOS Advanced Features
 export {
@@ -162,7 +162,7 @@ export {
   appIntents,
   tipKit,
   focusFilters
-} from './ios-advanced'
+} from './ios-advanced.js'
 export type {
   CarPlayTemplateType,
   CarPlayListItem,
@@ -185,7 +185,7 @@ export type {
   Tip,
   FocusStatus,
   FocusFilter
-} from './ios-advanced'
+} from './ios-advanced.js'
 
 // Android Advanced Features
 export {
@@ -197,7 +197,7 @@ export {
   appLanguage,
   widgets as androidWidgets,
   playBilling
-} from './android-advanced'
+} from './android-advanced.js'
 export type {
   MaterialYouColors,
   PhotoPickerMediaType,
@@ -213,7 +213,7 @@ export type {
   WidgetData,
   PlayProduct,
   PlayPurchase
-} from './android-advanced'
+} from './android-advanced.js'
 
 // macOS Advanced Features
 export {
@@ -226,7 +226,7 @@ export {
   quickActions,
   shareExtension,
   windowManagement
-} from './macos-advanced'
+} from './macos-advanced.js'
 export type {
   TouchBarItemType,
   TouchBarButton,
@@ -247,7 +247,7 @@ export type {
   SpotlightItem,
   QuickAction,
   WindowTabGroup
-} from './macos-advanced'
+} from './macos-advanced.js'
 
 // Windows Advanced Features
 export {
@@ -260,7 +260,7 @@ export {
   shareTarget,
   startupTask,
   secondaryTiles
-} from './windows-advanced'
+} from './windows-advanced.js'
 export type {
   JumpListTask,
   JumpListCategory,
@@ -275,7 +275,7 @@ export type {
   UpdateInfo,
   SharedDataItem,
   SecondaryTile
-} from './windows-advanced'
+} from './windows-advanced.js'
 
 // Dialog API - Native file pickers and alerts
 export {
@@ -286,7 +286,7 @@ export {
   showAlert,
   showConfirm,
   showPrompt
-} from './dialog'
+} from './dialog.js'
 export type {
   FileFilter,
   OpenDialogOptions,
@@ -296,7 +296,7 @@ export type {
   ConfirmOptions,
   OpenDialogResult,
   SaveDialogResult
-} from './dialog'
+} from './dialog.js'
 
 // Clipboard API - System clipboard access
 export {
@@ -305,20 +305,20 @@ export {
   readText,
   writeHTML,
   readHTML
-} from './clipboard'
+} from './clipboard.js'
 export type {
   ClipboardFormat,
   ClipboardData
-} from './clipboard'
+} from './clipboard.js'
 
 // Media API - Camera and microphone access
-export { media } from './media'
+export { media } from './media.js'
 export type {
   MediaDeviceInfo,
   CameraOptions as MediaCameraOptions,
   MicrophoneOptions,
   MediaStreamOptions
-} from './media'
+} from './media.js'
 
 // Cross-Platform Sidebar API (macOS, Windows, Linux)
 export {
@@ -327,7 +327,7 @@ export {
   createFileSidebar,
   createSettingsSidebar,
   sidebar
-} from './sidebar'
+} from './sidebar.js'
 export type {
   SidebarItem,
   SidebarSection,
@@ -337,31 +337,31 @@ export type {
   LinuxSidebarConfig,
   SidebarSelectEvent,
   SidebarSearchEvent
-} from './sidebar'
+} from './sidebar.js'
 
 // Spaces API - native switcher for Arc-style sidebar spaces
 export {
   spaces,
   createSpacesSidebar,
   hasNativeSpaces
-} from './spaces'
+} from './spaces.js'
 export type {
   SpaceDescriptor,
   SpacesSidebarOptions,
   SpacesSidebarHandle,
   NativeUIAPI
-} from './spaces'
+} from './spaces.js'
 
 // Gestures API - real trackpad swipe phases from the host's NSEvent
 export {
   gestures,
   onSwipe,
   hasNativeGestures
-} from './gestures'
+} from './gestures.js'
 export type {
   SwipeAxis,
   SwipePhase,
   SwipeEvent,
   SwipeListener,
   Unsubscribe
-} from './gestures'
+} from './gestures.js'

--- a/packages/typescript/src/api/ios-advanced.ts
+++ b/packages/typescript/src/api/ios-advanced.ts
@@ -5,7 +5,7 @@
  * @module @craft-native/api/ios-advanced
  */
 
-import { isCraft, getPlatform } from './process'
+import { isCraft, getPlatform } from './process.js'
 
 // ============================================================================
 // CarPlay Support

--- a/packages/typescript/src/api/macos-advanced.ts
+++ b/packages/typescript/src/api/macos-advanced.ts
@@ -5,7 +5,7 @@
  * @module @craft-native/api/macos-advanced
  */
 
-import { isCraft, getPlatform } from './process'
+import { isCraft, getPlatform } from './process.js'
 
 // ============================================================================
 // Touch Bar

--- a/packages/typescript/src/api/mobile.ts
+++ b/packages/typescript/src/api/mobile.ts
@@ -23,7 +23,7 @@
  * ```
  */
 
-import { secureUUID } from '../bridge/ids'
+import { secureUUID } from '../bridge/ids.js'
 
 /** localStorage key for the persisted web-fallback device id. */
 const WEB_DEVICE_ID_KEY = '__craft_web_device_id__'

--- a/packages/typescript/src/api/process.ts
+++ b/packages/typescript/src/api/process.ts
@@ -3,7 +3,7 @@
  * Provides process management and system information
  */
 
-import { getBridge } from '../bridge/core'
+import { getBridge } from '../bridge/core.js'
 
 /**
  * Send a request through the unified `NativeBridge`. Replaces the legacy

--- a/packages/typescript/src/api/sidebar.ts
+++ b/packages/typescript/src/api/sidebar.ts
@@ -5,7 +5,7 @@
  * @module @craft-native/api/sidebar
  */
 
-import { getPlatform, type Platform } from './process'
+import { getPlatform, type Platform } from './process.js'
 
 // ============================================================================
 // Types
@@ -13,10 +13,10 @@ import { getPlatform, type Platform } from './process'
 
 // `SidebarItem` and `SidebarSection` are shared with `components/sidebar` —
 // see `../sidebar-types` for why they are no longer declared per-module.
-export type { SidebarItem, SidebarSection } from '../sidebar-types'
-export { isSidebarItemDisabled } from '../sidebar-types'
+export type { SidebarItem, SidebarSection } from '../sidebar-types.js'
+export { isSidebarItemDisabled } from '../sidebar-types.js'
 
-import type { SidebarItem, SidebarSection } from '../sidebar-types'
+import type { SidebarItem, SidebarSection } from '../sidebar-types.js'
 
 export interface SidebarConfig {
   /** Sidebar width in pixels */

--- a/packages/typescript/src/api/tray.ts
+++ b/packages/typescript/src/api/tray.ts
@@ -4,7 +4,7 @@
  * @module @craft-native/api/tray
  */
 
-import { getBridge } from '../bridge/core'
+import { getBridge } from '../bridge/core.js'
 
 // ============================================================================
 // Types

--- a/packages/typescript/src/api/window.ts
+++ b/packages/typescript/src/api/window.ts
@@ -4,8 +4,8 @@
  * @module @craft-native/api/window
  */
 
-import { getBridge } from '../bridge/core'
-import { isWebKitHost, webkitRequest } from '../bridge/webkit-pending'
+import { getBridge } from '../bridge/core.js'
+import { isWebKitHost, webkitRequest } from '../bridge/webkit-pending.js'
 
 // ============================================================================
 // Types

--- a/packages/typescript/src/api/windows-advanced.ts
+++ b/packages/typescript/src/api/windows-advanced.ts
@@ -5,7 +5,7 @@
  * @module @craft-native/api/windows-advanced
  */
 
-import { isCraft, getPlatform } from './process'
+import { isCraft, getPlatform } from './process.js'
 
 // ============================================================================
 // Jump Lists

--- a/packages/typescript/src/bridge/android.ts
+++ b/packages/typescript/src/bridge/android.ts
@@ -3,7 +3,7 @@
  * Complete Android native bridge with WebView, permissions, and platform APIs
  */
 
-import { secureId } from './ids'
+import { secureId } from './ids.js'
 
 // Types
 export interface AndroidWebViewConfig {

--- a/packages/typescript/src/bridge/core.ts
+++ b/packages/typescript/src/bridge/core.ts
@@ -4,7 +4,7 @@
  */
 
 import { EventEmitter } from 'events'
-import { secureUUID } from './ids'
+import { secureUUID } from './ids.js'
 
 // Ambient types for native bridges injected by the host. These globals are
 // defined by WKWebView (iOS), Android WebView, Electron's contextBridge, and

--- a/packages/typescript/src/bridge/ios.ts
+++ b/packages/typescript/src/bridge/ios.ts
@@ -3,7 +3,7 @@
  * Complete iOS native bridge with WebView, permissions, haptics, and platform APIs
  */
 
-import { secureId } from './ids'
+import { secureId } from './ids.js'
 
 // Types
 export interface IOSWebViewConfig {

--- a/packages/typescript/src/components/index.ts
+++ b/packages/typescript/src/components/index.ts
@@ -35,7 +35,7 @@ export {
   tahoeStyle,
   arcStyle,
   orbstackStyle
-} from './sidebar'
+} from './sidebar.js'
 export type {
   SidebarItem,
   SidebarSection,
@@ -48,7 +48,7 @@ export type {
   SidebarEventType,
   SidebarEventMap,
   SidebarEventHandler
-} from './sidebar'
+} from './sidebar.js'
 
 // ============================================================================
 // Native UI Components
@@ -93,7 +93,7 @@ export {
   // Touch Bar
   setTouchBar,
   updateTouchBarItem
-} from './native'
+} from './native.js'
 export type {
   ComponentProps,
   ComponentInstance,
@@ -117,7 +117,7 @@ export type {
   ToolbarConfig,
   TouchBarItem,
   TouchBarConfig
-} from './native'
+} from './native.js'
 
 // ============================================================================
 // Style Types

--- a/packages/typescript/src/components/native.ts
+++ b/packages/typescript/src/components/native.ts
@@ -4,7 +4,7 @@
  * @module @craft-native/components/native
  */
 
-import { getBridge } from '../bridge/core'
+import { getBridge } from '../bridge/core.js'
 
 // Monotonically increasing counter ensures IDs stay unique even when multiple
 // components are created in the same millisecond — `Date.now()` alone collides.

--- a/packages/typescript/src/components/sidebar.ts
+++ b/packages/typescript/src/components/sidebar.ts
@@ -11,16 +11,16 @@
  * @module @craft-native/components/sidebar
  */
 
-import { getBridge } from '../bridge/core'
+import { getBridge } from '../bridge/core.js'
 
 // ============================================================================
 // Types
 // ============================================================================
 
 // Shared with `api/sidebar`; see `../sidebar-types`.
-export type { ContextMenuItem, SidebarItem, SidebarSection } from '../sidebar-types'
+export type { ContextMenuItem, SidebarItem, SidebarSection } from '../sidebar-types.js'
 
-import type { SidebarItem, SidebarSection } from '../sidebar-types'
+import type { SidebarItem, SidebarSection } from '../sidebar-types.js'
 
 export type SidebarStyle = 'tahoe' | 'arc' | 'orbstack' | 'custom'
 

--- a/packages/typescript/src/dev/hot-reload.ts
+++ b/packages/typescript/src/dev/hot-reload.ts
@@ -7,7 +7,7 @@ import { existsSync, readFileSync, watch, type FSWatcher } from 'fs'
 import { extname, join, relative, resolve } from 'path'
 import { EventEmitter } from 'events'
 import type { Server, ServerWebSocket } from 'bun'
-import { secureUUID } from '../bridge/ids'
+import { secureUUID } from '../bridge/ids.js'
 
 /** Per-connection state carried on each Bun WebSocket (set at upgrade). */
 interface HmrSocketData {

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -8,8 +8,8 @@ import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { promisify } from 'node:util'
-import { craftBinaryNotFoundMessage, resolveCraftBinary } from './binary-resolver'
-import type { AppConfig, WindowOptions } from './types'
+import { craftBinaryNotFoundMessage, resolveCraftBinary } from './binary-resolver.js'
+import type { AppConfig, WindowOptions } from './types.js'
 
 const execFileAsync = promisify(execFile)
 
@@ -61,30 +61,30 @@ export function parseCraftVersionOutput(output: string): string {
 }
 
 // Export packaging API
-export { packageApp, pack, type PackageConfig, type PackageResult } from './package'
+export { packageApp, pack, type PackageConfig, type PackageResult } from './package.js'
 
 // Export binary resolution. Craft ships through the pantry registry, and this is
 // the single source of truth for finding the native binary (PATH, or CRAFT_BIN
 // for local builds). Anything that spawns craft itself — the stx desktop
 // package, for instance — must resolve it the same way rather than probing paths
 // of its own.
-export { craftBinaryNotFoundMessage, resolveCraftBinary } from './binary-resolver'
+export { craftBinaryNotFoundMessage, resolveCraftBinary } from './binary-resolver.js'
 
 // Export utilities
-export * from './utils'
+export * from './utils/index.js'
 
 // Export API modules
-export * from './api'
+export * from './api/index.js'
 
-// Namespace export so consumers can also do `import { components } from '...'`
+// Namespace export so consumers can also do `import { components } from '....js'`
 // and reach every symbol from `./components` without name clashes against the
 // API surface. The flat (selective) re-exports below are kept for backwards
 // compatibility, but new code should prefer `components.X` to avoid surprises
 // when new exports are added on either side.
-export * as components from './components'
+export * as components from './components/index.js'
 
 // Export component abstractions (React Native-style primitives)
-// Use explicit exports to avoid conflicts with names from './api':
+// Use explicit exports to avoid conflicts with names from './api/index.js':
 // Excluded duplicates: Sidebar, createSidebar, SidebarItem, SidebarSection,
 // SidebarConfig, TouchBarItem, TableColumn, Platform
 export {
@@ -125,7 +125,7 @@ export {
   // Animated & StyleSheet
   StyleSheet,
   Animated,
-} from './components'
+} from './components/index.js'
 export type {
   // Sidebar types (excluding duplicates with api)
   ContextMenuItem,
@@ -187,29 +187,29 @@ export type {
   // Events
   LayoutEvent,
   ScrollEvent,
-} from './components'
+} from './components/index.js'
 
 // Export styling utilities (Headwind CSS integration + Sidebar styles)
-export * from './styles/headwind'
-export * from './styles'
+export * from './styles/headwind.js'
+export * from './styles/index.js'
 
 // Export framework-specific optimizations
-export * from './optimizations'
+export * from './optimizations/index.js'
 
 // Export auto-updater (delta/differential update support)
-export * as updater from './updater'
+export * as updater from './updater/index.js'
 
 // Also export the updater surface top-level. An app that self-updates needs the
 // class and the manifest builder by name; reaching them only through the
 // namespace left them untyped for anything re-exporting this package.
-export { AutoUpdater, generateUpdateManifest } from './updater'
+export { AutoUpdater, generateUpdateManifest } from './updater/index.js'
 export type {
   UpdateInfo as UpdateManifest,
   UpdateProgress,
   UpdaterConfig,
   UpdaterEvent,
   PlatformUpdate,
-} from './updater'
+} from './updater/index.js'
 
 /**
  * Decide whether to enable dev defaults (hot-reload + devtools). The
@@ -556,4 +556,4 @@ export type {
   WindowsConfig,
   LinuxConfig,
   CraftAppConfig,
-} from './types'
+} from './types.js'

--- a/packages/typescript/src/mobile.ts
+++ b/packages/typescript/src/mobile.ts
@@ -5,4 +5,4 @@
  * application. The root SDK also contains desktop packaging and process APIs,
  * which intentionally target Bun and must not enter a browser bundle.
  */
-export * from './api/mobile'
+export * from './api/mobile.js'

--- a/packages/typescript/src/package.test.ts
+++ b/packages/typescript/src/package.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from 'bun:test'
 import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { candleArguments, codesignArguments, dmgCapacityMegabytes, dmgCreateArguments, formatPackagingCommandError, macOSInfoPlist, notarytoolArguments, packageApp, productbuildArguments, renderWixSource, shouldRetryHdiutil, windowsArchitecture, windowsExecutableName } from './package'
+import { candleArguments, codesignArguments, dmgCapacityMegabytes, dmgCreateArguments, formatPackagingCommandError, macOSInfoPlist, notarytoolArguments, packageApp, productbuildArguments, renderWixSource, shouldRetryHdiutil, windowsArchitecture, windowsExecutableName } from './package.js'
 
 describe('Windows MSI packaging', () => {
   it('renders a deterministic major-upgrade installer without shell interpolation', () => {

--- a/packages/typescript/src/styles/index.ts
+++ b/packages/typescript/src/styles/index.ts
@@ -12,12 +12,12 @@ export {
   style,
   generateConfig,
   buildCSS
-} from './headwind'
+} from './headwind.js'
 export type {
   ClassValue,
   VariantConfig,
   HeadwindConfig
-} from './headwind'
+} from './headwind.js'
 
 // Sidebar styles (Tahoe, Arc, OrbStack)
 export {
@@ -27,7 +27,7 @@ export {
   sidebarUtils,
   sidebarCSSVariables,
   getSidebarStyle
-} from './sidebars'
+} from './sidebars.js'
 
 // Sidebar HTML templates
 export {
@@ -38,20 +38,20 @@ export {
   arcDemoData,
   orbstackDemoData,
   getFullPageHTML
-} from './sidebar-templates'
+} from './sidebar-templates.js'
 export type {
   SidebarItemData,
   SidebarSectionData,
   SidebarData
-} from './sidebar-templates'
+} from './sidebar-templates.js'
 
 // Re-export cx as clsx alias for familiarity
-export { cx as clsx } from './headwind'
+export { cx as clsx } from './headwind.js'
 
 // Re-export sidebar defaults
-import { tahoeStyles, arcStyles, orbstackStyles } from './sidebars'
-import { renderTahoeSidebar, renderArcSidebar, renderOrbStackSidebar } from './sidebar-templates'
-import { tw, cx, variants } from './headwind'
+import { tahoeStyles, arcStyles, orbstackStyles } from './sidebars.js'
+import { renderTahoeSidebar, renderArcSidebar, renderOrbStackSidebar } from './sidebar-templates.js'
+import { tw, cx, variants } from './headwind.js'
 
 export const styles: {
   tw: typeof tw;

--- a/packages/typescript/src/styles/sidebar-templates.ts
+++ b/packages/typescript/src/styles/sidebar-templates.ts
@@ -8,7 +8,7 @@
  * @module @craft-native/styles/sidebar-templates
  */
 
-import { tahoeStyles, arcStyles, orbstackStyles, cx } from './sidebars'
+import { tahoeStyles, arcStyles, orbstackStyles, cx } from './sidebars.js'
 
 // ============================================================================
 // Types

--- a/packages/typescript/src/types.ts
+++ b/packages/typescript/src/types.ts
@@ -1063,7 +1063,7 @@ export interface CraftBridgeAPI {
    * so its presence is not a promise that swipes will arrive. See
    * `api/gestures`.
    */
-  gestures?: import('./api/gestures').GesturesAPI
+  gestures?: import('./api/gestures.js').GesturesAPI
 
   /**
    * System tray control (desktop only)

--- a/packages/typescript/src/utils/index.ts
+++ b/packages/typescript/src/utils/index.ts
@@ -3,10 +3,10 @@
  * Helper functions and classes for common tasks
  */
 
-export * from './audio'
-export * from './native'
-export * from './storage'
-export * from './timer'
+export * from './audio.js'
+export * from './native.js'
+export * from './storage.js'
+export * from './timer.js'
 
 // Framework bindings are exported separately to avoid requiring all dependencies
 // Import them directly:

--- a/packages/typescript/src/utils/native.ts
+++ b/packages/typescript/src/utils/native.ts
@@ -5,7 +5,7 @@
  * have a single seam to mock in tests.
  */
 
-import type { CraftBridgeAPI, CraftEventEmitter } from '../types'
+import type { CraftBridgeAPI, CraftEventEmitter } from '../types.js'
 
 type CraftBridge = CraftBridgeAPI & CraftEventEmitter
 

--- a/packages/typescript/src/utils/react.ts
+++ b/packages/typescript/src/utils/react.ts
@@ -11,9 +11,9 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type RefObject } from 'react';
-import { app as appApi } from '../api/app';
-import { tray as trayApi } from '../api/tray';
-import { windowManager } from '../api/window';
+import { app as appApi } from '../api/app.js';
+import { tray as trayApi } from '../api/tray.js';
+import { windowManager } from '../api/window.js';
 
 // ============================================
 // Types

--- a/packages/typescript/src/utils/svelte.ts
+++ b/packages/typescript/src/utils/svelte.ts
@@ -5,7 +5,7 @@
 
 import { writable, derived, readable, get, type Writable, type Readable } from 'svelte/store';
 import { onMount, onDestroy } from 'svelte';
-import { windowManager } from '../api/window';
+import { windowManager } from '../api/window.js';
 
 // ============================================
 // Types

--- a/packages/typescript/src/utils/vue.ts
+++ b/packages/typescript/src/utils/vue.ts
@@ -19,8 +19,8 @@ import {
   type InjectionKey,
   type Ref,
 } from 'vue';
-import { app as appApi } from '../api/app';
-import { windowManager } from '../api/window';
+import { app as appApi } from '../api/app.js';
+import { windowManager } from '../api/window.js';
 
 // ============================================
 // Types

--- a/scripts/verify-packages.ts
+++ b/scripts/verify-packages.ts
@@ -71,6 +71,49 @@ function assertNoTestDeclarations(packageDir: string): void {
   }
 }
 
+/**
+ * Every relative specifier in a shipped declaration must carry a file
+ * extension.
+ *
+ * TypeScript only enforces this on the *consumer* side, under
+ * `moduleResolution: node16` or `nodenext` — which is what a modern Node
+ * project uses. Emit is happy either way, so `dist/index.d.ts` shipped 15
+ * extensionless re-exports and every such consumer got:
+ *
+ *     error TS2834: Relative import paths need explicit file extensions in
+ *     ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'
+ *
+ * followed by TS2305 on symbols the package genuinely exports. Nothing in the
+ * repo noticed, because the repo builds itself with `moduleResolution:
+ * bundler`, where extensionless is fine.
+ */
+function assertDeclarationsCarryExtensions(packageDir: string): void {
+  const dist = join(packageDir, 'dist')
+  if (!existsSync(dist))
+    return
+
+  // `from './x'` / `import('./x')`, capturing the specifier.
+  const specifier = /(?:from|import)\s*\(?\s*['"](\.[^'"]*)['"]/g
+
+  const stack = [dist]
+  while (stack.length > 0) {
+    const dir = stack.pop()!
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const path = join(dir, entry.name)
+      if (entry.isDirectory()) {
+        stack.push(path)
+        continue
+      }
+      if (!/\.d\.(?:ts|cts|mts)$/.test(path))
+        continue
+      for (const match of readFileSync(path, 'utf-8').matchAll(specifier)) {
+        if (!/\.(?:js|cjs|mjs|json)$/.test(match[1]))
+          fail(`Declaration ${path} imports "${match[1]}" without a file extension, which does not resolve under moduleResolution node16/nodenext`)
+      }
+    }
+  }
+}
+
 function verifyExportTargets(pkg: PackageJson, packageDir: string): void {
   const visit = (value: any): void => {
     if (typeof value === 'string' && value.startsWith('./'))
@@ -103,6 +146,7 @@ function verifyPackage(relativePath: string): void {
   verifyBinTargets(pkg, packageDir)
   verifyExportTargets(pkg, packageDir)
   assertNoTestDeclarations(packageDir)
+  assertDeclarationsCarryExtensions(packageDir)
 }
 
 for (const packagePath of [


### PR DESCRIPTION
Found while auditing #33. Not one of that issue's claims — a bigger one behind them.

### The defect

Install `craft-native` into any TypeScript project using `moduleResolution: node16` or `nodenext` — the modern Node default — and you get:

```
node_modules/craft-native/dist/index.d.ts(5,47): error TS2834: Relative import paths need
  explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'
consumer.ts(1,10): error TS2305: Module '"craft-native/mobile"' has no exported member 'camera'
```

`dist/index.d.ts` shipped 15 extensionless re-exports and `dist/mobile.d.ts` one, so **both the root entry and the browser-facing `craft-native/mobile` subpath resolved to zero types**. The exports map is correct and the JS is fine; the declarations are simply unresolvable.

Nothing in this repo noticed because the repo builds itself with `moduleResolution: bundler`, where extensionless specifiers are legal. tsc enforces the rule only on the *consumer* side, and there was no consumer-side test — so emit stayed happy and every downstream project got nothing.

### The fix

Relative specifiers in `src` now carry `.js`, and `/index.js` for directory imports. Under `bundler` resolution tsc still maps `./api/mobile.js` back to `./api/mobile.ts`, so the build is unchanged — the emitted declarations just become resolvable. 116 specifiers across 35 files, mechanical.

`ts-maps` had the identical defect and gets the identical fix.

### The guard

`verify-packages.ts` now walks every shipped `.d.ts`/`.d.cts`/`.d.mts` and fails on any relative specifier without a file extension. I wrote it before finishing the fix, and it immediately caught `packages/ts-maps/dist/MapView.d.ts` importing `"./types"` — the typescript package alone would have been a half fix. That is the check that was missing, not just the extensions.

### Verification

Not "it compiles" — an actual consumer:

1. `npm pack` the real tarball
2. install it into a scratch project with `"module": "nodenext", "moduleResolution": "nodenext"` and `@types/node`
3. typecheck `import { createApp } from 'craft-native'` and `import { camera, haptics } from 'craft-native/mobile'`

| entry | before | after |
|---|---|---|
| `craft-native` | TS2834 ×15 | clean |
| `craft-native/mobile` | TS2834 + TS2305 | clean |

Plus: root `bun run typecheck` (typescript, create-craft, ts-maps) clean; `bun test` 468 pass in the SDK and 27 in ts-maps; `bun scripts/verify-packages.ts` → 36 checks; `pickier` 0 errors.

### Relationship to #33

#33's own three claims are already fixed in the tree — I'll write that up separately with the evidence. This is the defect that was underneath them, and it is the one that actually stops `@stacksjs/mobile` from consuming the package.