### PR TITLE
fix(deps): finish the TypeScript 7 move across the workspace

### DIFF
--- a/packages/create-craft/tsconfig.json
+++ b/packages/create-craft/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
-    "isolatedDeclarations": true
+    "isolatedDeclarations": true,
+    "types": [
+      "node",
+      "bun"
+    ]
   },
   "include": [
     "bin"

--- a/packages/ios/src/index.ts
+++ b/packages/ios/src/index.ts
@@ -209,7 +209,9 @@ export function renderOrientations(config: CraftConfig): string {
     'landscape-right': 'UIInterfaceOrientationLandscapeRight',
     'portrait-upside-down': 'UIInterfaceOrientationPortraitUpsideDown',
   }
-  const values = config.orientations?.length ? config.orientations : ['portrait']
+  // Annotated, not inferred: the `['portrait']` fallback widens to string[]
+  // on its own, which then cannot index `names`.
+  const values: NonNullable<CraftConfig['orientations']> = config.orientations?.length ? config.orientations : ['portrait']
   return values.map(value => `        <string>${names[value]}</string>`).join('\n')
 }
 

--- a/packages/ts-maps/tsconfig.build.json
+++ b/packages/ts-maps/tsconfig.build.json
@@ -5,6 +5,7 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "declarationMap": true,
+    "rootDir": "..",
     "outDir": "dist"
   },
   "include": [

--- a/packages/typescript/build.ts
+++ b/packages/typescript/build.ts
@@ -25,8 +25,8 @@ async function build(entrypoints: string[], outdir: string): Promise<void> {
 // their implementation and templates instead of importing unpublished peers.
 await build(['../ios/src/index.ts'], 'dist/ios/src')
 await build(['../android/src/index.ts'], 'dist/android/src')
-await Bun.$`bunx tsc ${resolve(root, '../ios/src/index.ts')} --declaration --emitDeclarationOnly --module esnext --target esnext --moduleResolution bundler --types bun --skipLibCheck --outDir ${resolve(dist, 'ios/src')}`
-await Bun.$`bunx tsc ${resolve(root, '../android/src/index.ts')} --declaration --emitDeclarationOnly --module esnext --target esnext --moduleResolution bundler --types bun --skipLibCheck --outDir ${resolve(dist, 'android/src')}`
+await Bun.$`bunx tsc ${resolve(root, '../ios/src/index.ts')} --declaration --emitDeclarationOnly --module esnext --target esnext --moduleResolution bundler --types bun --skipLibCheck --ignoreConfig --outDir ${resolve(dist, 'ios/src')}`
+await Bun.$`bunx tsc ${resolve(root, '../android/src/index.ts')} --declaration --emitDeclarationOnly --module esnext --target esnext --moduleResolution bundler --types bun --skipLibCheck --ignoreConfig --outDir ${resolve(dist, 'android/src')}`
 await cp(resolve(root, '../ios/templates'), resolve(dist, 'ios/templates'), { recursive: true })
 await cp(resolve(root, '../android/templates'), resolve(dist, 'android/templates'), { recursive: true })
 

--- a/packages/typescript/tsconfig.build.json
+++ b/packages/typescript/tsconfig.build.json
@@ -5,6 +5,7 @@
     "emitDeclarationOnly": true,
     "declaration": true,
     "declarationMap": false,
+    "rootDir": "src",
     "outDir": "dist",
     "isolatedDeclarations": false
   },


### PR DESCRIPTION
`main` is red. 2c3b616 bumped react, vue and svelte to `typescript@^7.0.2` — and `bunfig.toml` sets `linker = "hoisted"`, so 7.0.2 hoisted to the workspace root. Every package's `tsc` became 7, including the three that weren't part of the move:

| job | failure |
|---|---|
| `create-craft` | `TS2591: Cannot find name 'node:child_process'` ×4, `TS2304: Cannot find name 'URL'`, `TS2584: Cannot find name 'console'` — 38 in total |
| `ts-maps` | `TS5011: The common source directory of 'tsconfig.build.json' is '..'. The 'rootDir' setting must be explicitly set` |
| `typescript-sdk` | `TS5112: tsconfig.json is present but will not be loaded if files are specified on commandline` |

The commit message is right that "react, vue and svelte all typecheck on 7" — those three do. The hoist is what carried the compiler to everyone else.

### Four fixes, each a real TS7 behaviour change

**create-craft — no `@types` are auto-included.** Under 7, nothing in the hoisted `node_modules/@types` reaches this package, so Node globals and `node:*` modules were all unresolved. I bisected it: *any* explicit `types` list passes — `node`, `bun`, or the full five including react — while the default fails with all 38. So it isn't one poisonous package, it's that automatic inclusion no longer finds the hoisted tree. Now declares `["node", "bun"]`, which is better practice anyway than taking whatever the tree happens to offer.

**ts-maps and the SDK — TS5011.** An implicit common source directory is an error now rather than an inference. ts-maps genuinely emits from `..` — it imports out of `../typescript/src`, which is exactly what `finalize-types.ts` exists to flatten — and the SDK emits from `src`. Both stated explicitly, both emitting what they emitted before: `finalize-types.ts` still flattens ts-maps, and the SDK's `dist/index.d.ts`, `mobile.d.ts`, `ios/src/`, `android/src/` all land where the exports map expects.

**The SDK build — TS5112.** `bunx tsc <file> --flags` alongside a `tsconfig.json` is an error now instead of a silent ignore. `--ignoreConfig` states what was already happening.

**packages/ios — a real bug nothing had ever typechecked.**

```ts
const values = config.orientations?.length ? config.orientations : ['portrait']
return values.map(value => `<string>${names[value]}</string>`)
```

The `['portrait']` fallback widens to `string[]` on its own, so `values` can't index `names`. No package's `typecheck` script covers `packages/ios/src`, and its only compile is the flags-only one above — which never loaded a config strict enough to notice. Annotated rather than cast, so the fallback has to stay a valid orientation.

### Verified

- root `bun run typecheck` clean
- react, vue and svelte still **0 errors** on 7 — Chris's goal preserved
- `bun test`: 468 SDK, 27 ts-maps
- both packages build; `dist` layout unchanged
- `verify-packages` 36 checks; `pickier` 0 errors
- packed tarball still resolves under **nodenext, node16, bundler and node** — the #42 guarantee survives the `rootDir` change

### Worth a follow-up, not in here

The wrappers have no `typecheck` script and aren't in the root `typecheck` chain or CI, so nothing would have caught a type error in react/vue/svelte either — I checked them by invoking `tsc` directly. Same gap that hid the `packages/ios` bug. Adding those to the CI chain is a separate, easy PR if you want it.