### PR TITLE
ci: pin the pantry action to a commit

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,3 +11,23 @@ This folder contains the following GitHub Actions:
 
 [CI]: ./workflows/ci.yml
 [Release]: ./workflows/release.yml
+
+## Pinned actions
+
+`pantry-pm/pantry/packages/action` is pinned to a commit, not to `@main`.
+
+`@main` means an unrelated push to another repository decides whether every
+job here runs, and on 2026-08-20 that happened twice in one night: first the
+action stopped shipping its built `dist/index.js`, so every job failed at step
+one with `File not found`; then, after that was fixed upstream, the setup step
+began hanging — every job on both Linux and macOS sat on **Setup Pantry** until
+GitHub killed it at the six-hour ceiling.
+
+The pin is `ef37fca8440cdb483fb355fefa5ae3cc6e669a69` (pantry 0.11.36), the
+revision the last fully green run on `main` used.
+
+To bump it: change the SHA everywhere it appears under `.github/workflows/`,
+in one commit, and let CI prove the new revision before it lands. The same
+reasoning applies to the first-party Zig dependencies — see
+[`.github/actions/first-party-zig-deps/pins.env`](../actions/first-party-zig-deps/pins.env).
+

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Zig
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@ef37fca8440cdb483fb355fefa5ae3cc6e669a69 # pantry 0.11.36
       - name: Install Linux dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -49,7 +49,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Zig
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@ef37fca8440cdb483fb355fefa5ae3cc6e669a69 # pantry 0.11.36
       - name: Install Linux dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Pantry (provides Bun, Zig, etc.)
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@ef37fca8440cdb483fb355fefa5ae3cc6e669a69 # pantry 0.11.36
 
       - name: Verify Zig installation
         run: eval "$(pantry env | sed -n '/^export /,$p')" && zig version
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Pantry (provides Bun, Zig, etc.)
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@ef37fca8440cdb483fb355fefa5ae3cc6e669a69 # pantry 0.11.36
 
       - name: Install dependencies
         run: bun install
@@ -116,7 +116,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Pantry (provides Bun, Zig, etc.)
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@ef37fca8440cdb483fb355fefa5ae3cc6e669a69 # pantry 0.11.36
 
       - name: Install dependencies
         run: bun install
@@ -132,7 +132,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Pantry (provides Bun, Zig, etc.)
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@ef37fca8440cdb483fb355fefa5ae3cc6e669a69 # pantry 0.11.36
 
       - name: Install dependencies
         run: bun install
@@ -156,7 +156,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Pantry (provides Bun, Zig, etc.)
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@ef37fca8440cdb483fb355fefa5ae3cc6e669a69 # pantry 0.11.36
 
       - name: Install dependencies
         run: bun install
@@ -179,7 +179,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Pantry (provides Bun, Zig, etc.)
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@ef37fca8440cdb483fb355fefa5ae3cc6e669a69 # pantry 0.11.36
 
       - name: Install dependencies
         run: bun install
@@ -228,7 +228,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Pantry (provides Bun, Zig, etc.)
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@ef37fca8440cdb483fb355fefa5ae3cc6e669a69 # pantry 0.11.36
 
       - name: Install Dependencies
         run: bun install

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Zig
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@ef37fca8440cdb483fb355fefa5ae3cc6e669a69 # pantry 0.11.36
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -142,7 +142,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Zig
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@ef37fca8440cdb483fb355fefa5ae3cc6e669a69 # pantry 0.11.36
       - name: Setup Java
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/native-lifecycle.yml
+++ b/.github/workflows/native-lifecycle.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Pantry (provides Bun)
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@ef37fca8440cdb483fb355fefa5ae3cc6e669a69 # pantry 0.11.36
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Pantry (provides Bun, Zig, etc.)
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@ef37fca8440cdb483fb355fefa5ae3cc6e669a69 # pantry 0.11.36
 
       - name: Install System Dependencies
         if: matrix.platform.deps != ''
@@ -199,7 +199,7 @@ jobs:
       # 2. Auto-packages binaries from zig-out/ into platform-named zips
       # 3. Creates/updates GitHub release with all artifacts + changelog
       - name: Publish & Release
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@ef37fca8440cdb483fb355fefa5ae3cc6e669a69 # pantry 0.11.36
         with:
           install: 'false'
           publish: 'zig'
@@ -232,7 +232,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Pantry (provides Bun, Zig, etc.)
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@ef37fca8440cdb483fb355fefa5ae3cc6e669a69 # pantry 0.11.36
       - name: Install Dependencies
         run: bun install
 


### PR DESCRIPTION
**Every job in this repository is hung right now.** Not failing — hung. All of them, Linux and macOS alike, sitting on `Setup Pantry`:

```
lint:                     Setup Pantry (provides Bun, Zig, etc.)
create-craft:             Setup Pantry (provides Bun, Zig, etc.)
ts-maps:                  Setup Pantry (provides Bun, Zig, etc.)
typescript-sdk:           Setup Pantry (provides Bun, Zig, etc.)
zig-core (ubuntu-latest): Setup Pantry (provides Bun, Zig, etc.)
zig-core (macos-latest):  Setup Pantry (provides Bun, Zig, etc.)
```

The earlier "6-hour hangs" on #44 that I put down to overnight infrastructure noise were this same step — GitHub killing it at the ceiling, not a slow Zig build.

### One night, two outages, same action

| time | what |
|---|---|
| 02:36 | pantry `f0772d1` stops shipping `packages/action/dist` |
| 02:48 | every craft job fails at step one — `File not found: .../packages/action/dist/index.js` |
| 03:00 | pantry `e199adab` — *"fix(action): ship the built action, which every workflow using it needs"* |
| 10:49 | every craft job hangs on `Setup Pantry` instead |

craft can fix neither, and should not be exposed to either. This is the **third** time in two days an unpinned `@main` reference to another repository has decided whether CI here runs — zig-js was the first, this action the second and third.

### The pin

All 15 references across six workflows now point at `ef37fca8440cdb483fb355fefa5ae3cc6e669a69` — pantry 0.11.36, which is the revision `@main` resolved to for the **last fully green run on main** (`32266347343`, 14:49):

```
Download action repository 'pantry-pm/pantry@main' (SHA:ef37fca8440cdb483fb355fefa5ae3cc6e669a69)
pantry pantry 0.11.36 (e54f9aca2)
```

Not an arbitrary older commit — the one demonstrably working a few hours ago.

| file | refs |
|---|---|
| `ci.yml` | 7 |
| `release.yml` | 3 |
| `mobile-e2e.yml` | 2 |
| `benchmarks.yml`, `binary-size.yml`, `native-lifecycle.yml` | 1 each |

Bumping it becomes a commit that names the revision, with CI proving it first. Same argument #39 made for the first-party Zig dependencies; `.github/workflows/README.md` now states it once for both.

### Verified

All six workflows parse and keep their jobs; the pinned SHA exists upstream (`chore: update arkade.dev, circleci.com`, 2026-08-19T14:09Z); `pickier` clean.

**This PR's own CI is the test** — if it gets past `Setup Pantry` while `main` is still hanging, the pin is doing exactly what it is for.