### PR TITLE
fix(packaging): stop macOS packages relocating themselves elsewhere

### DIFF
--- a/.github/workflows/native-lifecycle.yml
+++ b/.github/workflows/native-lifecycle.yml
@@ -96,8 +96,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: native-lifecycle-${{ matrix.name }}
-          path: |
-            artifacts/native-lifecycle/${{ matrix.name }}/report.json
-            artifacts/native-lifecycle/${{ matrix.name }}/work/packages-*/**
+          # Everything, not just report.json and the packages directory. The
+          # macOS relocation bug took a workflow dispatch to diagnose because
+          # the compiled fixtures at work/craft-lifecycle-* were outside the
+          # uploaded subtree, so the artifact alone could not answer what the
+          # runner had actually built.
+          path: artifacts/native-lifecycle/${{ matrix.name }}/**
           if-no-files-found: error
           retention-days: 90

--- a/packages/typescript/src/package.test.ts
+++ b/packages/typescript/src/package.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from 'bun:test'
 import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { candleArguments, codesignArguments, dmgCapacityMegabytes, dmgCreateArguments, formatPackagingCommandError, macOSInfoPlist, notarytoolArguments, packageApp, productbuildArguments, renderWixSource, shouldRetryHdiutil, windowsArchitecture, windowsExecutableName } from './package.js'
+import { candleArguments, codesignArguments, dmgCapacityMegabytes, dmgCreateArguments, formatPackagingCommandError, macOSInfoPlist, notarytoolArguments, packageApp, pkgbuildArguments, pkgbuildComponentPlist, productbuildArguments, renderWixSource, shouldRetryHdiutil, windowsArchitecture, windowsExecutableName } from './package.js'
 
 describe('Windows MSI packaging', () => {
   it('renders a deterministic major-upgrade installer without shell interpolation', () => {
@@ -48,6 +48,61 @@ describe('Windows MSI packaging', () => {
     expect(windowsArchitecture('x64')).toBe('x64')
     expect(windowsArchitecture('arm64')).toBe('arm64')
     expect(() => windowsArchitecture('mips')).toThrow('Unsupported Windows package architecture')
+  })
+})
+
+describe('macOS pkg relocation', () => {
+  it('pins the install path instead of letting the bundle be relocated', () => {
+    const plist = pkgbuildComponentPlist('Applications/Craft App.app')
+
+    // The one that matters. Left to pkgbuild, this is true, and the package
+    // then carries <relocate><bundle id="..."/></relocate> — which lets
+    // `installer` write the payload over any copy of that bundle the system
+    // has registered elsewhere and still exit 0. "The install was successful"
+    // with nothing at /Applications is that, and it is intermittent because it
+    // depends on what the system has indexed.
+    expect(plist).toContain('<key>BundleIsRelocatable</key>\n        <false/>')
+
+    // Off so that installing an older version over a newer one is not skipped;
+    // with it on, a rollback silently becomes a no-op.
+    expect(plist).toContain('<key>BundleIsVersionChecked</key>\n        <false/>')
+
+    expect(plist).toContain('<string>Applications/Craft App.app</string>')
+    expect(plist).toContain('<?xml version="1.0" encoding="UTF-8"?>')
+  })
+
+  it('escapes the bundle path rather than emitting broken XML', () => {
+    expect(pkgbuildComponentPlist('Applications/Ben & Co.app')).toContain('Applications/Ben &amp; Co.app')
+  })
+
+  it('always passes the component plist to pkgbuild', () => {
+    const args = pkgbuildArguments({
+      root: '/tmp/stage/root',
+      componentPlistPath: '/tmp/stage/component.plist',
+      identifier: 'dev.craft.lifecycle',
+      version: '1.0.0',
+      outputPath: '/tmp/out.pkg',
+    })
+    expect(args).toEqual([
+      '--root', '/tmp/stage/root',
+      '--component-plist', '/tmp/stage/component.plist',
+      '--identifier', 'dev.craft.lifecycle',
+      '--version', '1.0.0',
+      '--install-location', '/',
+      '/tmp/out.pkg',
+    ])
+
+    // Signing is additive and must not displace the component plist.
+    const signed = pkgbuildArguments({
+      root: '/tmp/stage/root',
+      componentPlistPath: '/tmp/stage/component.plist',
+      identifier: 'dev.craft.lifecycle',
+      version: '1.0.0',
+      outputPath: '/tmp/out.pkg',
+      installerIdentity: '3rd Party Mac Developer Installer: Example',
+    })
+    expect(signed).toContain('--component-plist')
+    expect(signed.slice(-3, -1)).toEqual(['--sign', '3rd Party Mac Developer Installer: Example'])
   })
 })
 

--- a/packages/typescript/src/package.ts
+++ b/packages/typescript/src/package.ts
@@ -844,6 +844,74 @@ async function createDMG(opts: {
  * - a signed `productbuild` submission package for the Mac App Store, which is
  *   the only form App Store Connect accepts.
  */
+/**
+ * The component property list `pkgbuild` is given for the app bundle.
+ *
+ * Written out rather than left to `pkgbuild`'s inference, because its default
+ * for a bundle is `BundleIsRelocatable = true`, which puts this in the package:
+ *
+ *     <relocate><bundle id="dev.example.app"/></relocate>
+ *
+ * That directive tells `installer` the payload path is only a suggestion: it
+ * looks the bundle identifier up on the target volume and, if the system has a
+ * copy of that bundle registered anywhere, writes the payload over *that* copy
+ * instead — and exits 0. The user sees "The install was successful" and finds
+ * nothing at /Applications.
+ *
+ * It is intermittent by nature, since it turns on whether the system has
+ * indexed some other copy yet, which is exactly how it behaved: the native
+ * lifecycle workflow's macOS legs failed only on slow runs, on both
+ * architectures, with `installer` reporting success and the app absent.
+ *
+ * `BundleIsVersionChecked` is off for a related reason — with it on, installing
+ * an *older* version over a newer one is skipped, which silently turns a
+ * rollback into a no-op.
+ *
+ * The `pkg-info` attribute `relocatable="false"` that appears either way is not
+ * this setting and does not govern it; only the `<relocate>` element does.
+ */
+export function pkgbuildComponentPlist(rootRelativeBundlePath: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+    <dict>
+        <key>BundleHasStrictIdentifier</key>
+        <true/>
+        <key>BundleIsRelocatable</key>
+        <false/>
+        <key>BundleIsVersionChecked</key>
+        <false/>
+        <key>BundleOverwriteAction</key>
+        <string>upgrade</string>
+        <key>RootRelativeBundlePath</key>
+        <string>${xml(rootRelativeBundlePath)}</string>
+    </dict>
+</array>
+</plist>
+`
+}
+
+/** Build the `pkgbuild` argument list for a non-App-Store package. */
+export function pkgbuildArguments(opts: {
+  root: string
+  componentPlistPath: string
+  identifier: string
+  version: string
+  outputPath: string
+  installerIdentity?: string
+}): string[] {
+  return [
+    '--root', opts.root,
+    '--component-plist', opts.componentPlistPath,
+    '--identifier', opts.identifier,
+    '--version', opts.version,
+    '--install-location', '/',
+    ...(opts.installerIdentity ? ['--sign', opts.installerIdentity] : []),
+    opts.outputPath,
+  ]
+}
+
 async function createPKG(opts: {
   appBundlePath: string
   outputPath: string
@@ -879,18 +947,29 @@ async function createPKG(opts: {
   // path it should land in.
   const tempDir = mkdtempSync(join(tmpdir(), 'craft-pkg-'))
   try {
-    const appsDir = join(tempDir, 'Applications')
-    mkdirSync(appsDir, { recursive: true })
-    cpSync(opts.appBundlePath, join(appsDir, basename(opts.appBundlePath)), { recursive: true })
+    // A `root` child rather than tempDir itself, created 0755. mkdtemp makes
+    // its directory 0700, pkgbuild records the --root directory's own mode as
+    // the mode of `.`, and `.` under `--install-location /` is the target
+    // volume's root. Shipping a package that asks for `/` to be 0700 is not
+    // something to leave to the installer's discretion.
+    const root = join(tempDir, 'root')
+    const appsDir = join(root, 'Applications')
+    mkdirSync(appsDir, { recursive: true, mode: 0o755 })
+    chmodSync(root, 0o755)
+    const bundleName = basename(opts.appBundlePath)
+    cpSync(opts.appBundlePath, join(appsDir, bundleName), { recursive: true })
 
-    const built = await runTool('pkgbuild', [
-      '--root', tempDir,
-      '--identifier', opts.identifier,
-      '--version', opts.version,
-      '--install-location', '/',
-      ...(opts.installerIdentity ? ['--sign', opts.installerIdentity] : []),
-      opts.outputPath,
-    ])
+    const componentPlistPath = join(tempDir, 'component.plist')
+    writeFileSync(componentPlistPath, pkgbuildComponentPlist(`Applications/${bundleName}`))
+
+    const built = await runTool('pkgbuild', pkgbuildArguments({
+      root,
+      componentPlistPath,
+      identifier: opts.identifier,
+      version: opts.version,
+      outputPath: opts.outputPath,
+      installerIdentity: opts.installerIdentity,
+    }))
     return built.success
       ? { success: true, outputPath: opts.outputPath }
       : { success: false, error: built.error }

--- a/scripts/native-lifecycle.ts
+++ b/scripts/native-lifecycle.ts
@@ -155,10 +155,21 @@ async function exerciseMacOS(v1: PackageResult[], v2: PackageResult[]): Promise<
   const second = requireArtifact(v2, 'pkg')
   const app = '/Applications/craft-lifecycle.app'
   const executable = join(app, 'Contents', 'MacOS', 'craft-lifecycle')
+  // `installer` can report success and put the payload somewhere else entirely:
+  // a package built with bundle relocation enabled is redirected to wherever the
+  // system already has that bundle identifier registered. When that happened
+  // here the only symptom was `launch` throwing ENOENT, which says nothing about
+  // where the app went. The receipt does — `location:` is the path the payload
+  // actually landed at — so record it as its own step, into report.json and the
+  // uploaded evidence, every time.
+  const receipt = (label: string) => command(`receipt after ${label}`, ['pkgutil', '--pkg-info', 'dev.craft.lifecycle'])
+
   if (existsSync(app)) await command('remove pre-existing fixture', ['sudo', 'rm', '-rf', app])
   await command('install v1', ['sudo', 'installer', '-pkg', first, '-target', '/'])
+  await receipt('install v1')
   await command('launch v1', [executable], 'craft-lifecycle 1.0.0')
   await command('update to v2', ['sudo', 'installer', '-pkg', second, '-target', '/'])
+  await receipt('update to v2')
   await command('launch v2', [executable], 'craft-lifecycle 1.0.1')
   for (const step of macOSRollbackPlan(app, 'dev.craft.lifecycle', first))
     await command(step.name, step.argv)


### PR DESCRIPTION
Every `.pkg` craft has ever produced can install itself somewhere other than where it says, and report success.

`createPKG` let `pkgbuild` infer its component. `pkgbuild`'s default for a bundle is `BundleIsRelocatable = true`, so the package carries:

```xml
<relocate><bundle id="dev.example.app"/></relocate>
```

That directive tells `installer` the payload path is only a suggestion. It looks the bundle identifier up on the target volume and, if the system has a copy of that bundle registered anywhere, writes the payload over **that** copy instead — and exits 0. The user gets *"The install was successful"* and finds nothing at `/Applications`.

### I had this wrong, twice

I told you this was Intel-specific. It isn't — `darwin-arm64` failed with a byte-identical `ENOENT` in an adjacent run, on the same code and the same runner image.

And the relocation *directive* alone isn't the cause either — it's present in packages from green runs too. It's the enabler; the trigger is a registered copy of the same bundle id existing when the install happens. That's why it's intermittent, and what actually separates green from red is how long the job had already been running:

| lifecycle step began | outcome |
|---|---|
| ~22 minutes into the job | all 3 failing macOS legs |
| 20–124 seconds in | all 8 passing macOS legs |

Which is what a race against the system's bundle indexer looks like. The lifecycle script leaves two copies of the fixture bundle in its work directory — those are the relocation target.

### The fix

Write the component plist instead of inferring it, with `BundleIsRelocatable` off. Verified on a real fixture package, not just in the unit test:

```
relocate:          <relocate/>
install root mode: drwxr-xr-x  "."
payload exe count: 1
```

Empty `<relocate/>` — nothing for `installer` to redirect to — with the payload unchanged.

Note the `pkg-info` attribute `relocatable="false"` appears **either way** and does not govern this; only the `<relocate>` element does. I built both variants side by side to confirm that, because that attribute is exactly the thing that makes the current package look fine on inspection.

`BundleIsVersionChecked` is off too: with it on, installing an older version over a newer one is skipped — silently turning the rollback step, and a user's rollback, into a no-op.

### Two things found alongside

- **The package asked for `/` to be `0700`.** The staging dir came from `mkdtemp` (mode 0700), and `pkgbuild` records the `--root` directory's own mode as the mode of `.` — which under `--install-location /` is the target volume's root. Measured: `drwx------  "."`. Now staged in a `0755` child, measured `drwxr-xr-x`.
- **The failure left no evidence.** `installer` reporting success while writing elsewhere surfaced only as a bare `ENOENT` from the launch step, which cannot distinguish "nothing installed" from "installed elsewhere". The receipt is now recorded after each install, into `report.json` and the uploaded evidence — `location:` is where the payload actually landed. The workflow uploads the whole evidence directory too; the compiled fixtures sat outside the old upload path, which is why this needed a workflow dispatch to diagnose rather than an artifact download.

### Verification

- `bun test` — 471 pass, including 3 new ones; I confirmed they discriminate by flipping `BundleIsRelocatable` back to `true` and watching 18 pass / 1 fail
- `tsc --noEmit` clean, `pickier` clean
- real fixture package rebuilt and inspected with `pkgutil --expand` / `lsbom` / `pkgutil --payload-files`

**This is a user-facing bug, not a CI one.** The lifecycle workflow is just the thing that noticed.