### PR TITLE
fix(shortcuts): make global hotkeys actually fire

### DIFF
--- a/docs/BRIDGE_API.md
+++ b/docs/BRIDGE_API.md
@@ -8,6 +8,7 @@ The Craft JavaScript Bridge provides a seamless interface for your web applicati
 - [Getting Started](#getting-started)
 - [System Tray API](#system-tray-api)
 - [Application Menu (macOS)](#application-menu-macos)
+- [Global Shortcuts (macOS)](#global-shortcuts-macos)
 - [Window API](#window-api)
 - [App API](#app-api)
 - [TypeScript Support](#typescript-support)
@@ -286,6 +287,86 @@ a newer bridge surface therefore fails soft on an older binary.
 | `checkItem(itemId)` / `uncheckItem(itemId)` | checkmark |
 | `setItemLabel(itemId, label)` | rename in place |
 
+## Global Shortcuts (macOS)
+
+System-wide hotkeys: they fire whether or not your app is frontmost. macOS only
+— on Linux and Windows every registration is refused, because craft has no
+implementation there and a shortcut that can never fire is worse than one that
+was never accepted.
+
+Craft registers these through Carbon's `RegisterEventHotKey`, which needs no
+Accessibility or Input Monitoring permission and only ever calls back for the
+exact combinations you asked for. Your app never sees any other keystroke.
+
+### `window.craft.shortcuts.register(id, accelerator): Promise<void>`
+
+Reserve a combination. `id` is yours to choose and is what comes back when the
+key is pressed. Registering an id twice replaces the first binding.
+
+```javascript
+await window.craft.shortcuts.register('summon', 'Cmd+Shift+H');
+
+window.craft.shortcuts.on(({ id, accelerator }) => {
+  if (id === 'summon') window.craft.window.toggle();
+});
+```
+
+Accelerators are `+`-separated and case-insensitive. The last component is the
+key; everything before it is a modifier:
+
+| Modifier | Accepted as |
+|---|---|
+| Command | `Cmd`, `Command`, `Meta`, `Super`, `⌘` |
+| Control | `Ctrl`, `Control`, `⌃` |
+| Option | `Alt`, `Option`, `Opt`, `⌥` |
+| Shift | `Shift`, `⇧` |
+| Either | `CmdOrCtrl`, `CommandOrControl`, `Mod` — command on macOS, control elsewhere |
+
+Keys are named by position on the keyboard, not by the character they produce,
+so a shortcut survives the user switching layout. Letters, digits, punctuation,
+`Space`, `Tab`, `Return`, `Escape`, `Delete`, the arrows, `Home`/`End`/`PageUp`/
+`PageDown`, `F1`–`F20` and the keypad (`Keypad0`–`Keypad9`, `KeypadEnter`, …)
+are all bindable. Web and Electron spellings — `Backspace`, `Esc`, `Enter`,
+`ArrowLeft`, `Plus` — resolve to the same keys.
+
+**At least one of Command, Control or Option is required**, except on the
+function keys. A bare global hotkey on `H` would mean no application on the
+system — including yours — ever saw the user type an h again; failing the
+registration is recoverable, and that is not. Shift alone does not count, since
+Shift+H is how you type a capital H.
+
+### `window.craft.shortcuts.onError(handler): () => void`
+
+Where a failed call arrives: `{ id, code, message }`. Every verb here except
+`isRegistered` and `list` is fire-and-forget — the promise resolves as soon as
+the message is posted, not when the key is reserved — so this is how you learn
+that a combination belongs to another app or to the system, or that `enable()`
+could not take a released key back.
+
+```javascript
+window.craft.shortcuts.onError(({ id, message }) => {
+  showToast(`Could not bind ${id}: ${message}`);
+});
+```
+
+### `window.craft.shortcuts.on(handler): () => void`
+
+Fires on every press of a registered, enabled shortcut, with `{ id, accelerator }`.
+The accelerator is craft's canonical spelling — `Cmd+Delete`, whatever you
+originally wrote — so it round-trips back through `register()`. Returns an
+unsubscribe function.
+
+### The rest
+
+| Call | What it does |
+|---|---|
+| `unregister(id)` | give the key back to the system and forget the shortcut |
+| `unregisterAll()` | the same, for every shortcut this app holds |
+| `disable(id)` | stop firing **and release the key**, so other apps can use it again; the shortcut stays listed |
+| `enable(id)` | take it back — this can fail if something else claimed it in the meantime, and reports on `onError` |
+| `isRegistered(id): Promise<boolean>` | whether the id is known, enabled or not |
+| `list(): Promise<Shortcut[]>` | `{ id, accelerator, key, enabled }` for each |
+
 ## Window API
 
 Control the application window from JavaScript.
@@ -519,6 +600,7 @@ async function onComplete() {
 | Tray Menu | 🚧 | 🚧 | 🚧 |
 | Window Control | ✅ | ✅ | ✅ |
 | Hide Dock Icon | ✅ | ➖ | ➖ |
+| Global Shortcuts | ✅ | 🚧 | 🚧 |
 
 ✅ Implemented | 🚧 In Progress | ➖ Not Applicable
 

--- a/packages/typescript/src/types.ts
+++ b/packages/typescript/src/types.ts
@@ -1119,6 +1119,92 @@ export interface CraftBridgeAPI {
    * Screen-sharing and screen-recording detection (macOS)
    */
   screenSharing?: CraftScreenSharingAPI
+
+  /**
+   * System-wide hotkeys (macOS).
+   *
+   * Absent in effect on Linux and Windows: the calls exist, and every
+   * registration is refused, because Craft has no implementation there and a
+   * shortcut that can never fire is worse than one that was never accepted.
+   */
+  shortcuts?: CraftGlobalShortcutsAPI
+}
+
+/** A global hotkey, as `craft.shortcuts.list()` reports it. */
+export interface GlobalShortcut {
+  /** The id the app registered it under. */
+  id: string
+  /**
+   * Craft's canonical spelling of the combination — `Cmd+Delete`, whatever
+   * the app originally wrote — so it can be passed straight back to
+   * `register()`.
+   */
+  accelerator: string
+  /** The key alone, canonically named. */
+  key: string
+  /** False while `disable()` has the key released back to the system. */
+  enabled: boolean
+}
+
+/** Why a registration was refused. */
+export interface GlobalShortcutError {
+  /** The id from the payload that failed, or `''` if it had none. */
+  id: string
+  /** Craft's error code, e.g. `NATIVE_CALL_FAILED`, `INVALID_PARAMETER`. */
+  code: string
+  message: string
+}
+
+/**
+ * System-wide hotkeys: they fire whether or not the app is frontmost.
+ *
+ * Accelerators are `+`-separated and case-insensitive — `'Cmd+Shift+H'`. The
+ * last component is the key, everything before it a modifier (`Cmd`/`Command`/
+ * `Meta`, `Ctrl`/`Control`, `Alt`/`Option`, `Shift`, or `CmdOrCtrl` for the
+ * platform's own). Keys are named by position on the keyboard, not by the
+ * character they produce, so a binding survives a layout change.
+ *
+ * At least one of Command, Control or Option is required, except on the
+ * function keys: a bare global hotkey on `H` would mean no application on the
+ * system ever saw the user type an h again.
+ */
+export interface CraftGlobalShortcutsAPI {
+  /**
+   * Reserve a combination system-wide. Registering an `id` twice replaces the
+   * first binding.
+   *
+   * The promise resolves once the message is posted, **not** once the key is
+   * reserved — so a combination that belongs to another app or to the system
+   * resolves here and reports on {@link CraftGlobalShortcutsAPI.onError}.
+   */
+  register: (id: string, accelerator: string) => Promise<void>
+  /** Give the key back to the system and forget the shortcut. */
+  unregister: (id: string) => Promise<void>
+  /** The same, for every shortcut this app holds. */
+  unregisterAll: () => Promise<void>
+  /**
+   * Stop firing *and release the key*, so other apps can use it again. The
+   * shortcut stays listed. Holding a reservation while dropping the event
+   * would make the combination dead in every other app for as long as Craft
+   * ran.
+   */
+  disable: (id: string) => Promise<void>
+  /**
+   * Take the key back. Can fail if something else claimed it while it was
+   * released, which reports on {@link CraftGlobalShortcutsAPI.onError}.
+   */
+  enable: (id: string) => Promise<void>
+  /** Whether the id is known — enabled or not. */
+  isRegistered: (id: string) => Promise<boolean>
+  list: () => Promise<GlobalShortcut[]>
+  /** Every press of a registered, enabled shortcut. Returns an unsubscribe. */
+  on: (handler: (event: { id: string, accelerator: string }) => void) => () => void
+  /**
+   * Where every fire-and-forget call reports its failure — `register`,
+   * `enable`, `disable`, `unregister`. (`isRegistered` and `list` are
+   * requests and reject their own promise instead.) Returns an unsubscribe.
+   */
+  onError: (handler: (error: GlobalShortcutError) => void) => () => void
 }
 
 /**

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -165,10 +165,6 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/menubar.zig"),
     });
 
-    const bridge_menu_module = b.createModule(.{
-        .root_source_file = b.path("src/bridge_menu.zig"),
-    });
-
     const components_module = b.createModule(.{
         .root_source_file = b.path("src/components.zig"),
     });
@@ -561,6 +557,54 @@ pub fn build(b: *std.Build) void {
         }),
     });
 
+    // Accelerator strings ("Cmd+Shift+H") and the Carbon hotkey binding they
+    // are registered through. Both are pure enough to test without a window.
+    const accelerator_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/accelerator.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
+    const macos_hotkey_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/macos_hotkey.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    if (target_os == .macos) {
+        // These tests put a real `EventRef` through Carbon's own dispatcher —
+        // the only way to find out whether the handler signature and the
+        // `EventHotKeyID` layout are what Carbon expects, short of pressing
+        // the key on a Mac.
+        macos_hotkey_tests.root_module.linkFramework("Carbon", .{});
+        macos_hotkey_tests.root_module.link_libc = true;
+    }
+
+    // The global-shortcut registry: register / replace / disable / unregister,
+    // driven against a fake platform so the whole lifecycle is covered without
+    // an app, a window or a key press.
+    const shortcut_registry_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/shortcut_registry.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
+    // The name <-> macOS virtual key code table that global shortcuts are
+    // registered from. Pure data, so it is tested here rather than by pressing
+    // keys at a running app.
+    const key_codes_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/key_codes.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
     const config_tests = b.addTest(.{
         .root_module = b.createModule(.{
             .root_source_file = b.path("test/config_test.zig"),
@@ -897,6 +941,10 @@ pub fn build(b: *std.Build) void {
     const run_space_list_tests = b.addRunArtifact(space_list_tests);
     const run_local_tls_tests = b.addRunArtifact(local_tls_tests);
     const run_menu_roles_tests = b.addRunArtifact(menu_roles_tests);
+    const run_key_codes_tests = b.addRunArtifact(key_codes_tests);
+    const run_accelerator_tests = b.addRunArtifact(accelerator_tests);
+    const run_macos_hotkey_tests = b.addRunArtifact(macos_hotkey_tests);
+    const run_shortcut_registry_tests = b.addRunArtifact(shortcut_registry_tests);
     const run_config_tests = b.addRunArtifact(config_tests);
     const run_ipc_tests = b.addRunArtifact(ipc_tests);
     const run_performance_tests = b.addRunArtifact(performance_tests);
@@ -945,12 +993,17 @@ pub fn build(b: *std.Build) void {
                     .optimize = optimize,
                     .imports = &.{
                         .{ .name = "js", .module = js_dep.module("js") },
-                        // The native half of the menu contract. The test drives
-                        // the real craft-bridge.js and then decodes what it
-                        // posted with the very parser `setAppMenu` uses, so a
-                        // rename on either side fails the build rather than
-                        // silently producing a menu nobody can click (#27, #31).
-                        .{ .name = "../src/bridge_menu.zig", .module = bridge_menu_module },
+                        // The native halves of the contracts under test. The
+                        // test drives the real craft-bridge.js and then decodes
+                        // what it posted with the very code the bridge
+                        // dispatches to, so a rename on either side fails the
+                        // build rather than silently producing a menu nobody
+                        // can click (#27, #31) or a hotkey that never fires
+                        // (#47). One module, because both reach
+                        // `bridge_error.zig` — see the file's own comment.
+                        .{ .name = "bridge_contracts", .module = b.createModule(.{
+                            .root_source_file = b.path("src/bridge_contracts.zig"),
+                        }) },
                     },
                 }),
             });
@@ -998,6 +1051,10 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_space_list_tests.step);
     test_step.dependOn(&run_local_tls_tests.step);
     test_step.dependOn(&run_menu_roles_tests.step);
+    test_step.dependOn(&run_key_codes_tests.step);
+    test_step.dependOn(&run_accelerator_tests.step);
+    test_step.dependOn(&run_macos_hotkey_tests.step);
+    test_step.dependOn(&run_shortcut_registry_tests.step);
     test_step.dependOn(&run_config_tests.step);
     test_step.dependOn(&run_ipc_tests.step);
     test_step.dependOn(&run_performance_tests.step);
@@ -1096,6 +1153,16 @@ pub fn build(b: *std.Build) void {
 
     const test_menu_roles_step = b.step("test:menu-roles", "Run menu role table tests");
     test_menu_roles_step.dependOn(&run_menu_roles_tests.step);
+
+    const test_key_codes_step = b.step("test:key-codes", "Run key code table tests");
+    test_key_codes_step.dependOn(&run_key_codes_tests.step);
+
+    const test_accelerator_step = b.step("test:accelerator", "Run accelerator parsing tests");
+    test_accelerator_step.dependOn(&run_accelerator_tests.step);
+    test_accelerator_step.dependOn(&run_macos_hotkey_tests.step);
+
+    const test_shortcut_registry_step = b.step("test:shortcut-registry", "Run global shortcut registry tests");
+    test_shortcut_registry_step.dependOn(&run_shortcut_registry_tests.step);
 
     const test_config_step = b.step("test:config", "Run Config tests");
     test_config_step.dependOn(&run_config_tests.step);
@@ -1599,6 +1666,11 @@ fn linkPlatformLibraries(b: *std.Build, module: *std.Build.Module, target_os: st
             // when the app dynamically loads them.
             module.linkFramework("CoreMIDI", .{});
             module.linkFramework("CoreSpotlight", .{});
+            // Carbon for `macos_hotkey.zig`: `RegisterEventHotKey` is the only
+            // route to a global hotkey that neither needs an Objective-C block
+            // (which Zig cannot write) nor Accessibility permission (which a
+            // CGEventTap would).
+            module.linkFramework("Carbon", .{});
             applySdkPaths(b, module, sdk_path);
         },
         .linux => {

--- a/packages/zig/src/accelerator.zig
+++ b/packages/zig/src/accelerator.zig
@@ -1,0 +1,336 @@
+//! Accelerator strings — `"Cmd+Shift+H"` — parsed into a key and modifiers.
+//!
+//! This is the shape `window.craft.shortcuts.register(id, accelerator)` sends,
+//! and it is deliberately the same spelling Electron and the web use, so an
+//! accelerator copied out of existing app code means here what it meant there.
+//!
+//! Pure: no Objective-C, no Carbon, nothing platform-specific. That is what
+//! lets the whole of it be tested without a window, a key press or a running
+//! app — which matters, because the bug this file exists to fix
+//! (craft-native/craft#47) was precisely that nothing between the JS call and
+//! the keyboard was exercised by anything.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const key_codes = @import("key_codes.zig");
+
+pub const Modifiers = struct {
+    cmd: bool = false,
+    ctrl: bool = false,
+    alt: bool = false,
+    shift: bool = false,
+
+    /// `NSEventModifierFlag` bits, for matching against a Cocoa event.
+    pub fn toCocoaFlags(self: Modifiers) c_ulong {
+        var flags: c_ulong = 0;
+        if (self.shift) flags |= (1 << 17); // NSEventModifierFlagShift
+        if (self.ctrl) flags |= (1 << 18); // NSEventModifierFlagControl
+        if (self.alt) flags |= (1 << 19); // NSEventModifierFlagOption
+        if (self.cmd) flags |= (1 << 20); // NSEventModifierFlagCommand
+        return flags;
+    }
+
+    /// Carbon modifier bits, for `RegisterEventHotKey`. A different set of
+    /// values entirely from the Cocoa ones above: Cocoa's command bit is
+    /// 1<<20, Carbon's is 1<<8, and passing one where the other is expected
+    /// registers a hotkey nobody can press.
+    ///
+    /// From `<Carbon/HIToolbox/Events.h>`.
+    pub const carbon_command: u32 = 1 << 8;
+    pub const carbon_shift: u32 = 1 << 9;
+    pub const carbon_option: u32 = 1 << 11;
+    pub const carbon_control: u32 = 1 << 12;
+
+    pub fn toCarbonFlags(self: Modifiers) u32 {
+        var flags: u32 = 0;
+        if (self.cmd) flags |= carbon_command;
+        if (self.shift) flags |= carbon_shift;
+        if (self.alt) flags |= carbon_option;
+        if (self.ctrl) flags |= carbon_control;
+        return flags;
+    }
+
+    /// Whether any modifier that changes what a key *does*, rather than which
+    /// character it produces, is held. Shift is excluded on purpose: Shift+H
+    /// is just how you type H.
+    pub fn hasCommandingModifier(self: Modifiers) bool {
+        return self.cmd or self.ctrl or self.alt;
+    }
+
+    pub fn eql(self: Modifiers, other: Modifiers) bool {
+        return self.cmd == other.cmd and self.ctrl == other.ctrl and
+            self.alt == other.alt and self.shift == other.shift;
+    }
+};
+
+pub const Binding = struct {
+    /// Canonical name of the key, from `key_codes.zig` — so a shortcut
+    /// registered as `"Cmd+Backspace"` reports itself as `Cmd+Delete`.
+    key: []const u8,
+    /// macOS virtual key code.
+    keycode: u16,
+    modifiers: Modifiers,
+
+    pub fn eql(self: Binding, other: Binding) bool {
+        return self.keycode == other.keycode and self.modifiers.eql(other.modifiers);
+    }
+};
+
+pub const ParseError = error{
+    /// The accelerator was empty, or was nothing but modifiers.
+    MissingKey,
+    /// A component was empty — `"Cmd++"`, `"+H"`, `"Cmd+ +H"`.
+    EmptyComponent,
+    /// The final component names no key craft knows.
+    UnknownKey,
+    /// A component before the key is neither a modifier nor a key.
+    UnknownModifier,
+    /// The same modifier was named twice.
+    DuplicateModifier,
+    /// A global hotkey with no commanding modifier would make the key
+    /// untypeable in every app on the system.
+    ModifierRequired,
+};
+
+/// Function keys are the exception to `ModifierRequired`: they produce no
+/// text, so reserving F13 on its own costs the user nothing. Everything else
+/// bare — `"H"`, `"Space"`, `"Shift+H"` — would take a key away system-wide.
+fn isBareBindable(name: []const u8) bool {
+    if (name.len < 2 or (name[0] != 'F' and name[0] != 'f')) return false;
+    _ = std.fmt.parseInt(u8, name[1..], 10) catch return false;
+    return true;
+}
+
+fn applyModifier(name: []const u8, mods: *Modifiers) ParseError!void {
+    const Target = enum { cmd, ctrl, alt, shift };
+    const target: Target = blk: {
+        // `CmdOrCtrl` is the portable spelling: command where command is what
+        // apps use, control everywhere else. Resolved here rather than being
+        // carried through, so everything downstream sees a concrete modifier.
+        if (eq(name, "cmdorctrl") or eq(name, "commandorcontrol") or eq(name, "mod"))
+            break :blk if (builtin.os.tag == .macos) .cmd else .ctrl;
+        if (eq(name, "cmd") or eq(name, "command") or eq(name, "meta") or
+            eq(name, "super") or eq(name, "win") or eq(name, "\u{2318}")) break :blk .cmd;
+        if (eq(name, "ctrl") or eq(name, "control") or eq(name, "\u{2303}")) break :blk .ctrl;
+        if (eq(name, "alt") or eq(name, "option") or eq(name, "opt") or
+            eq(name, "\u{2325}")) break :blk .alt;
+        if (eq(name, "shift") or eq(name, "\u{21E7}")) break :blk .shift;
+        return ParseError.UnknownModifier;
+    };
+
+    const slot = switch (target) {
+        .cmd => &mods.cmd,
+        .ctrl => &mods.ctrl,
+        .alt => &mods.alt,
+        .shift => &mods.shift,
+    };
+    // Naming a modifier twice is a typo, and silently accepting it hides which
+    // half of `"Cmd+Cmd+Shift"` the author meant to write.
+    if (slot.*) return ParseError.DuplicateModifier;
+    slot.* = true;
+}
+
+fn eq(a: []const u8, comptime b: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(a, b);
+}
+
+/// Parse `"Cmd+Shift+H"` into the key and modifiers it names.
+///
+/// The last `+`-separated component is the key; everything before it is a
+/// modifier. Components are matched case-insensitively.
+pub fn parse(input: []const u8) ParseError!Binding {
+    const trimmed = std.mem.trim(u8, input, " \t");
+    if (trimmed.len == 0) return ParseError.MissingKey;
+
+    var mods = Modifiers{};
+    var key_part: ?[]const u8 = null;
+
+    var it = std.mem.splitScalar(u8, trimmed, '+');
+    while (it.next()) |raw| {
+        const part = std.mem.trim(u8, raw, " \t");
+        if (part.len == 0) return ParseError.EmptyComponent;
+
+        // The key is whatever is last, so a component only becomes a modifier
+        // once another component turns up behind it.
+        if (key_part) |previous| try applyModifier(previous, &mods);
+        key_part = part;
+    }
+
+    const key_name = key_part orelse return ParseError.MissingKey;
+    const keycode = key_codes.codeFor(key_name) orelse return ParseError.UnknownKey;
+    const canonical = key_codes.nameFor(keycode).?;
+
+    if (!mods.hasCommandingModifier() and !isBareBindable(canonical)) {
+        return ParseError.ModifierRequired;
+    }
+
+    return .{ .key = canonical, .keycode = keycode, .modifiers = mods };
+}
+
+/// Render a binding back into the canonical accelerator string, so what an
+/// app reads out of `craft.shortcuts.list()` is something it could pass
+/// straight back to `register()`.
+pub fn format(buf: []u8, binding: Binding) ![]const u8 {
+    var pos: usize = 0;
+    const parts = [_]struct { on: bool, name: []const u8 }{
+        .{ .on = binding.modifiers.cmd, .name = "Cmd" },
+        .{ .on = binding.modifiers.ctrl, .name = "Ctrl" },
+        .{ .on = binding.modifiers.alt, .name = "Alt" },
+        .{ .on = binding.modifiers.shift, .name = "Shift" },
+    };
+    for (parts) |part| {
+        if (!part.on) continue;
+        if (pos + part.name.len + 1 > buf.len) return error.NoSpaceLeft;
+        @memcpy(buf[pos..][0..part.name.len], part.name);
+        pos += part.name.len;
+        buf[pos] = '+';
+        pos += 1;
+    }
+    if (pos + binding.key.len > buf.len) return error.NoSpaceLeft;
+    @memcpy(buf[pos..][0..binding.key.len], binding.key);
+    return buf[0 .. pos + binding.key.len];
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+test "the accelerator the downstream bug report names parses" {
+    // stacksjs/harness registers exactly this and has never received a key.
+    const b = try parse("Cmd+Shift+H");
+    try std.testing.expectEqualStrings("H", b.key);
+    try std.testing.expectEqual(@as(u16, 0x04), b.keycode);
+    try std.testing.expect(b.modifiers.cmd);
+    try std.testing.expect(b.modifiers.shift);
+    try std.testing.expect(!b.modifiers.ctrl);
+    try std.testing.expect(!b.modifiers.alt);
+}
+
+test "modifier spellings are interchangeable" {
+    const expected = try parse("Cmd+Alt+K");
+    for ([_][]const u8{
+        "cmd+alt+k",
+        "Command+Option+K",
+        "COMMAND+OPT+K",
+        "Meta+Alt+K",
+        "Super+Option+K",
+        "\u{2318}+\u{2325}+K",
+    }) |spelling| {
+        const b = try parse(spelling);
+        try std.testing.expect(b.eql(expected));
+    }
+}
+
+test "CmdOrCtrl resolves to this platform's modifier" {
+    const b = try parse("CmdOrCtrl+S");
+    if (builtin.os.tag == .macos) {
+        try std.testing.expect(b.modifiers.cmd);
+        try std.testing.expect(!b.modifiers.ctrl);
+    } else {
+        try std.testing.expect(b.modifiers.ctrl);
+        try std.testing.expect(!b.modifiers.cmd);
+    }
+}
+
+test "the key reported back is canonical, not the spelling that arrived" {
+    const b = try parse("Cmd+Backspace");
+    try std.testing.expectEqualStrings("Delete", b.key);
+
+    var buf: [64]u8 = undefined;
+    try std.testing.expectEqualStrings("Cmd+Delete", try format(&buf, b));
+}
+
+test "format round-trips through parse" {
+    var buf: [64]u8 = undefined;
+    for ([_][]const u8{
+        "Cmd+Shift+H",
+        "Ctrl+Alt+Delete",
+        "Cmd+Ctrl+Alt+Shift+Space",
+        "Alt+Left",
+        "F13",
+    }) |source| {
+        const first = try parse(source);
+        const rendered = try format(&buf, first);
+        const again = try parse(rendered);
+        try std.testing.expect(first.eql(again));
+        try std.testing.expectEqualStrings(first.key, again.key);
+    }
+}
+
+test "a bare key is refused rather than made untypeable everywhere" {
+    // A global hotkey on `H` means no application on the system, craft's
+    // included, ever sees the user type an h again. Failing the registration
+    // is recoverable; that is not.
+    try std.testing.expectError(ParseError.ModifierRequired, parse("H"));
+    try std.testing.expectError(ParseError.ModifierRequired, parse("Space"));
+    // Shift does not count: Shift+H is how you type a capital H.
+    try std.testing.expectError(ParseError.ModifierRequired, parse("Shift+H"));
+}
+
+test "function keys may be bound bare" {
+    // They produce no text, so reserving one costs the user nothing.
+    const b = try parse("F13");
+    try std.testing.expectEqualStrings("F13", b.key);
+    try std.testing.expect(!b.modifiers.hasCommandingModifier());
+    _ = try parse("F5");
+    _ = try parse("Shift+F1");
+}
+
+test "malformed accelerators name what is wrong with them" {
+    try std.testing.expectError(ParseError.MissingKey, parse(""));
+    try std.testing.expectError(ParseError.MissingKey, parse("   "));
+    try std.testing.expectError(ParseError.EmptyComponent, parse("Cmd+"));
+    try std.testing.expectError(ParseError.EmptyComponent, parse("+H"));
+    try std.testing.expectError(ParseError.EmptyComponent, parse("Cmd++H"));
+    try std.testing.expectError(ParseError.UnknownKey, parse("Cmd+Nonsense"));
+    try std.testing.expectError(ParseError.UnknownModifier, parse("Hyper+Cmd+H"));
+    try std.testing.expectError(ParseError.DuplicateModifier, parse("Cmd+Cmd+H"));
+}
+
+test "surrounding whitespace is tolerated" {
+    const spaced = try parse("  Cmd + Shift + H  ");
+    const tight = try parse("Cmd+Shift+H");
+    try std.testing.expect(spaced.eql(tight));
+}
+
+test "a modifier name in the key position is the key, not a modifier" {
+    // `"Cmd+Shift"` names no key: Shift is the last component, so it is where
+    // the key should be, and it is not one.
+    try std.testing.expectError(ParseError.UnknownKey, parse("Cmd+Shift"));
+}
+
+test "Cocoa and Carbon flag sets do not agree, and both are right" {
+    const mods = Modifiers{ .cmd = true, .shift = true };
+    try std.testing.expectEqual(@as(c_ulong, (1 << 20) | (1 << 17)), mods.toCocoaFlags());
+    try std.testing.expectEqual(@as(u32, 0x0100 | 0x0200), mods.toCarbonFlags());
+
+    // Pin the Carbon values against the header. The two sets overlap in
+    // meaning and in nothing else, and a hotkey registered with Cocoa's 1<<20
+    // for command asks for a combination involving no modifier the user can
+    // press.
+    try std.testing.expectEqual(@as(u32, 0x0100), Modifiers.carbon_command);
+    try std.testing.expectEqual(@as(u32, 0x0200), Modifiers.carbon_shift);
+    try std.testing.expectEqual(@as(u32, 0x0800), Modifiers.carbon_option);
+    try std.testing.expectEqual(@as(u32, 0x1000), Modifiers.carbon_control);
+    try std.testing.expect(Modifiers.carbon_command != (1 << 20));
+}
+
+test "every modifier maps to a distinct bit in both sets" {
+    const each = [_]Modifiers{
+        .{ .cmd = true }, .{ .ctrl = true }, .{ .alt = true }, .{ .shift = true },
+    };
+    for (each, 0..) |a, i| {
+        try std.testing.expect(a.toCocoaFlags() != 0);
+        try std.testing.expect(a.toCarbonFlags() != 0);
+        for (each[i + 1 ..]) |b| {
+            try std.testing.expect(a.toCocoaFlags() != b.toCocoaFlags());
+            try std.testing.expect(a.toCarbonFlags() != b.toCarbonFlags());
+        }
+    }
+}
+
+test "keypad keys are bindable and distinct from the number row" {
+    const pad = try parse("Cmd+Keypad5");
+    const row = try parse("Cmd+5");
+    try std.testing.expect(!pad.eql(row));
+}

--- a/packages/zig/src/bridge_contracts.zig
+++ b/packages/zig/src/bridge_contracts.zig
@@ -1,0 +1,16 @@
+//! The native halves of the JS bridge contracts, in one place.
+//!
+//! `test/injected_js_test.zig` drives the real injected JavaScript and then
+//! decodes what it posted with the very code the bridge dispatches to — which
+//! is the only kind of test that can catch a JS side and a native side that
+//! are each individually correct and disagree with each other. Both #27 (menu
+//! action names) and #47 (shortcut payload shape) were exactly that.
+//!
+//! They arrive through one aggregate rather than as two named modules because
+//! both reach `bridge_error.zig`, and a file may belong to only one module per
+//! compilation. A test module also cannot `@import` outside its own directory,
+//! so this has to live here beside the code it re-exports rather than in
+//! `test/`.
+
+pub const menu = @import("bridge_menu.zig");
+pub const shortcuts = @import("shortcut_registry.zig");

--- a/packages/zig/src/bridge_shortcuts.zig
+++ b/packages/zig/src/bridge_shortcuts.zig
@@ -1,454 +1,212 @@
+//! `window.craft.shortcuts` — global hotkeys.
+//!
+//! A thin adapter: it decodes the action, hands the payload to
+//! `shortcut_registry.zig`, and turns the answer back into JavaScript. The
+//! decisions live in the registry, where they are testable; the key is
+//! actually reserved by `macos_hotkey.zig`.
+//!
+//! What used to be here, and what craft-native/craft#47 was about: an app
+//! could register a hotkey, be told it worked, and never receive a keystroke.
+//! `setupGlobalMonitor` computed an event mask, discarded it, installed
+//! nothing, and logged "Global monitor setup (polling mode)" — there was no
+//! polling either. The matcher it was supposed to feed was reachable only from
+//! a function with no callers anywhere in the tree. Three further mismatches
+//! sat on top of it, each individually fatal:
+//!
+//!   * the JS bridge sends `{id, accelerator}`; this file read `key` and
+//!     `modifiers`, so every registration failed its own validation before it
+//!     got anywhere near the missing monitor;
+//!   * `isRegistered` and `list` answered by calling `__craftShortcutList` and
+//!     friends, which nothing defines — so those promises hung for the full
+//!     30-second request timeout and then rejected;
+//!   * a triggered shortcut called `__craftShortcutCallback`, which nothing
+//!     defines either, while the JS side was listening for a `craft:shortcut`
+//!     event that was never dispatched.
+
 const std = @import("std");
 const builtin = @import("builtin");
 const bridge_error = @import("bridge_error.zig");
 const logging = @import("logging.zig");
+const registry_mod = @import("shortcut_registry.zig");
+const accel = @import("accelerator.zig");
 
 const log = logging.shortcuts;
 
 const BridgeError = bridge_error.BridgeError;
 
-/// Modifier flags for keyboard shortcuts
-pub const Modifiers = struct {
-    cmd: bool = false,
-    ctrl: bool = false,
-    alt: bool = false,
-    shift: bool = false,
+/// Re-exported so callers that named these through this module keep working.
+pub const Modifiers = accel.Modifiers;
+pub const Shortcut = registry_mod.Registration;
 
-    pub fn toCocoaFlags(self: Modifiers) c_ulong {
-        var flags: c_ulong = 0;
-        if (self.cmd) flags |= (1 << 20); // NSEventModifierFlagCommand
-        if (self.ctrl) flags |= (1 << 18); // NSEventModifierFlagControl
-        if (self.alt) flags |= (1 << 19); // NSEventModifierFlagOption
-        if (self.shift) flags |= (1 << 17); // NSEventModifierFlagShift
-        return flags;
+pub const action_register = registry_mod.action_register;
+pub const action_unregister = registry_mod.action_unregister;
+pub const action_unregister_all = registry_mod.action_unregister_all;
+pub const action_enable = registry_mod.action_enable;
+pub const action_disable = registry_mod.action_disable;
+pub const action_is_registered = registry_mod.action_is_registered;
+pub const action_list = registry_mod.action_list;
+
+/// The event a triggered shortcut arrives on, matching `_evt('craft:shortcut')`
+/// in `craft-bridge.js`.
+pub const event_triggered = "craft:shortcut";
+
+/// Where a registration that could not be granted is reported.
+///
+/// `register` is fire-and-forget on the JS side — its action name collides
+/// with other bridges' in the request queue, so it cannot be a request without
+/// mixing replies — which leaves an app no way to hear that the key it asked
+/// for belongs to someone else. This event is that way.
+pub const event_error = "craft:shortcut:error";
+
+fn platform() registry_mod.Platform {
+    if (comptime builtin.os.tag == .macos) {
+        return .{
+            .register = struct {
+                fn f(keycode: u16, modifiers: u32, hotkey_id: u32) registry_mod.Ref {
+                    return @import("macos_hotkey.zig").register(keycode, modifiers, hotkey_id);
+                }
+            }.f,
+            .unregister = struct {
+                fn f(ref: registry_mod.Ref) void {
+                    @import("macos_hotkey.zig").unregister(ref);
+                }
+            }.f,
+        };
     }
-};
+    // Linux and Windows have no global-hotkey implementation in craft yet.
+    // Refusing every registration is the honest answer: the alternative —
+    // accepting them — is the bug this file was rewritten to fix.
+    return registry_mod.unsupported_platform;
+}
 
-/// Registered shortcut
-pub const Shortcut = struct {
-    id: []const u8,
-    key: []const u8,
-    modifiers: Modifiers,
-    callback_id: []const u8,
-    enabled: bool = true,
-};
-
-/// Bridge handler for global keyboard shortcuts
 pub const ShortcutsBridge = struct {
     allocator: std.mem.Allocator,
-    shortcuts: std.StringHashMap(Shortcut),
-    global_monitor: ?*anyopaque = null,
-    local_monitor: ?*anyopaque = null,
+    registry: registry_mod.Registry,
 
     const Self = @This();
 
     pub fn init(allocator: std.mem.Allocator) Self {
         return .{
             .allocator = allocator,
-            .shortcuts = std.StringHashMap(Shortcut).init(allocator),
+            .registry = registry_mod.Registry.init(allocator, platform()),
         };
     }
 
-    /// Handle shortcut-related messages from JavaScript
+    pub fn deinit(self: *Self) void {
+        self.registry.deinit();
+        if (comptime builtin.os.tag == .macos) {
+            @import("macos_hotkey.zig").on_pressed = null;
+        }
+        const global_state = @import("global_state.zig");
+        global_state.instance.setShortcutsBridge(null);
+    }
+
     pub fn handleMessage(self: *Self, action: []const u8, data: []const u8) !void {
         self.handleMessageInternal(action, data) catch |err| {
-            self.reportError(action, err);
+            const bridge_err: BridgeError = err;
+            // The action name travels with the error so `__craftBridgeError`
+            // rejects only that action's callers.
+            bridge_error.sendErrorToJS(self.allocator, action, bridge_err);
+
+            // `isRegistered` and `list` are requests: the line above rejects
+            // the promise their caller is holding, and that is the whole
+            // report. Every other verb is fire-and-forget, so its caller has
+            // already moved on and there is nothing to reject — the error
+            // event is the only way it hears anything at all.
+            const is_request = std.mem.eql(u8, action, action_is_registered) or
+                std.mem.eql(u8, action, action_list);
+            if (!is_request) self.reportFailure(data, bridge_err);
         };
     }
 
     fn handleMessageInternal(self: *Self, action: []const u8, data: []const u8) !void {
-        if (std.mem.eql(u8, action, "register")) {
-            try self.registerShortcut(data);
-        } else if (std.mem.eql(u8, action, "unregister")) {
-            try self.unregisterShortcut(data);
-        } else if (std.mem.eql(u8, action, "unregisterAll")) {
-            try self.unregisterAllShortcuts();
-        } else if (std.mem.eql(u8, action, "enable")) {
-            try self.enableShortcut(data);
-        } else if (std.mem.eql(u8, action, "disable")) {
-            try self.disableShortcut(data);
-        } else if (std.mem.eql(u8, action, "isRegistered")) {
-            try self.isRegistered(data);
-        } else if (std.mem.eql(u8, action, "list")) {
-            try self.listShortcuts();
+        if (std.mem.eql(u8, action, action_register)) {
+            self.ensureDelivery();
+            const entry = try self.registry.register(data);
+            log.debug("registered {s} as {s}", .{ entry.id, entry.accelerator });
+        } else if (std.mem.eql(u8, action, action_unregister)) {
+            try self.registry.unregister(data);
+        } else if (std.mem.eql(u8, action, action_unregister_all)) {
+            self.registry.unregisterAll();
+        } else if (std.mem.eql(u8, action, action_enable)) {
+            try self.registry.setEnabled(data, true);
+        } else if (std.mem.eql(u8, action, action_disable)) {
+            try self.registry.setEnabled(data, false);
+        } else if (std.mem.eql(u8, action, action_is_registered)) {
+            const json = try self.registry.isRegisteredJson(data);
+            defer self.allocator.free(json);
+            bridge_error.sendResultToJS(self.allocator, action, json);
+        } else if (std.mem.eql(u8, action, action_list)) {
+            const json = try self.registry.listJson();
+            defer self.allocator.free(json);
+            bridge_error.sendResultToJS(self.allocator, action, json);
         } else {
             return BridgeError.UnknownAction;
         }
     }
 
-    fn reportError(self: *Self, action: []const u8, err: anyerror) void {
-        const bridge_err: BridgeError = switch (err) {
-            BridgeError.MissingData => BridgeError.MissingData,
-            BridgeError.InvalidJSON => BridgeError.InvalidJSON,
-            else => BridgeError.NativeCallFailed,
-        };
-        bridge_error.sendErrorToJS(self.allocator, action, bridge_err);
-    }
-
-    /// Register a global shortcut
-    /// JSON: {"id": "toggle", "key": "Space", "modifiers": {"cmd": true, "shift": true}, "callback": "onToggle"}
-    fn registerShortcut(self: *Self, data: []const u8) !void {
-        // Parse shortcut data
-        var id: []const u8 = "";
-        var key: []const u8 = "";
-        var callback_id: []const u8 = "";
-        var modifiers = Modifiers{};
-
-        // Parse id
-        if (std.mem.indexOf(u8, data, "\"id\":\"")) |idx| {
-            const start = idx + 6;
-            if (std.mem.indexOfPos(u8, data, start, "\"")) |end| {
-                id = data[start..end];
-            }
-        }
-
-        // Parse key
-        if (std.mem.indexOf(u8, data, "\"key\":\"")) |idx| {
-            const start = idx + 7;
-            if (std.mem.indexOfPos(u8, data, start, "\"")) |end| {
-                key = data[start..end];
-            }
-        }
-
-        // Parse callback
-        if (std.mem.indexOf(u8, data, "\"callback\":\"")) |idx| {
-            const start = idx + 12;
-            if (std.mem.indexOfPos(u8, data, start, "\"")) |end| {
-                callback_id = data[start..end];
-            }
-        }
-
-        // Parse modifiers
-        if (std.mem.indexOf(u8, data, "\"cmd\":true")) |_| modifiers.cmd = true;
-        if (std.mem.indexOf(u8, data, "\"ctrl\":true")) |_| modifiers.ctrl = true;
-        if (std.mem.indexOf(u8, data, "\"alt\":true")) |_| modifiers.alt = true;
-        if (std.mem.indexOf(u8, data, "\"shift\":true")) |_| modifiers.shift = true;
-
-        if (id.len == 0 or key.len == 0) {
-            return BridgeError.MissingData;
-        }
-
-        log.debug("register: id={s}, key={s}, cmd={}, ctrl={}, alt={}, shift={}", .{ id, key, modifiers.cmd, modifiers.ctrl, modifiers.alt, modifiers.shift });
-
-        // Store shortcut
-        const id_owned = try self.allocator.dupe(u8, id);
-        const key_owned = try self.allocator.dupe(u8, key);
-        const callback_owned = try self.allocator.dupe(u8, callback_id);
-
-        try self.shortcuts.put(id_owned, Shortcut{
-            .id = id_owned,
-            .key = key_owned,
-            .modifiers = modifiers,
-            .callback_id = callback_owned,
-            .enabled = true,
-        });
-
-        // Setup global monitor if not already done
-        if (self.global_monitor == null) {
-            try self.setupGlobalMonitor();
-        }
-    }
-
-    /// Setup global event monitor
-    fn setupGlobalMonitor(self: *Self) !void {
-        if (comptime builtin.os.tag != .macos) return;
-
-        const macos = @import("macos.zig");
-
-        // Create a global monitor for key down events
-        // NSEventMaskKeyDown = 1 << 10 = 1024
-        const event_mask: c_ulonglong = 1 << 10;
-
-        // We need to use addGlobalMonitorForEventsMatchingMask:handler:
-        // This requires creating an Objective-C block, which is complex in Zig
-        // For now, we'll use a polling approach via the run loop
-
-        // Alternative: Use local monitor for when app is active
-        const NSEvent = macos.getClass("NSEvent");
-        _ = NSEvent;
-        _ = event_mask;
-
-        // Store reference to self for callback
+    /// Point the platform's hotkey callback at this bridge. Cheap and
+    /// idempotent, so it runs before every registration rather than depending
+    /// on an initialisation order.
+    fn ensureDelivery(self: *Self) void {
         const global_state = @import("global_state.zig");
         global_state.instance.setShortcutsBridge(self);
-
-        log.debug("Global monitor setup (polling mode)", .{});
-    }
-
-    /// Check if a key event matches any registered shortcut
-    pub fn checkKeyEvent(self: *Self, keycode: u16, flags: c_ulong) void {
-        const key_name = keycodeToName(keycode);
-
-        var it = self.shortcuts.iterator();
-        while (it.next()) |entry| {
-            const shortcut = entry.value_ptr.*;
-            if (!shortcut.enabled) continue;
-
-            // Check if key matches
-            if (!std.mem.eql(u8, shortcut.key, key_name)) continue;
-
-            // Check modifiers
-            const required_flags = shortcut.modifiers.toCocoaFlags();
-            const masked_flags = flags & ((1 << 17) | (1 << 18) | (1 << 19) | (1 << 20));
-
-            if (masked_flags == required_flags) {
-                log.debug("Shortcut triggered: {s}", .{shortcut.id});
-                self.triggerCallback(shortcut.id, shortcut.callback_id);
-            }
+        if (comptime builtin.os.tag == .macos) {
+            @import("macos_hotkey.zig").on_pressed = onHotKeyPressed;
         }
     }
 
-    /// Trigger JavaScript callback for shortcut.
-    /// Escapes both IDs before embedding them in the JS literal so a value
-    /// containing `'` / `\` / newline cannot break out and inject code.
-    fn triggerCallback(self: *Self, shortcut_id: []const u8, callback_id: []const u8) void {
-        _ = self;
+    /// Called on the main thread when a registered combination is pressed
+    /// anywhere in the system.
+    pub fn deliver(self: *Self, hotkey_id: u32) void {
+        const entry = self.registry.findByHotkeyId(hotkey_id) orelse return;
+        // A hotkey disabled between the press and its delivery must not fire.
+        if (!entry.enabled) return;
 
+        log.debug("triggered {s} ({s})", .{ entry.id, entry.accelerator });
+        const detail = registry_mod.triggeredDetail(self.allocator, entry.id, entry.accelerator) catch return;
+        defer self.allocator.free(detail);
+        self.dispatch(event_triggered, detail);
+    }
+
+    fn reportFailure(self: *Self, data: []const u8, err: BridgeError) void {
+        // Best effort: the id is read back out of the payload so the app can
+        // tell which of its registrations failed. A payload too malformed to
+        // yield an id still gets the error, just without one.
+        const IdOnly = struct { id: []const u8 = "" };
+        var id: []const u8 = "";
+        const parsed = std.json.parseFromSlice(IdOnly, self.allocator, data, .{
+            .ignore_unknown_fields = true,
+            .allocate = .alloc_always,
+        }) catch null;
+        defer if (parsed) |p| p.deinit();
+        if (parsed) |p| id = p.value.id;
+
+        const detail = registry_mod.errorDetail(
+            self.allocator,
+            id,
+            bridge_error.errorCodeString(err),
+            bridge_error.errorMessage(err),
+        ) catch return;
+        defer self.allocator.free(detail);
+        self.dispatch(event_error, detail);
+    }
+
+    /// Emit `new CustomEvent(name, { detail })` into the page.
+    fn dispatch(self: *Self, name: []const u8, detail: []const u8) void {
         const bridge = @import("bridge.zig");
 
-        var sid_buf: [128]u8 = undefined;
-        var cb_buf: [128]u8 = undefined;
-        const sid_esc = bridge_error.escapeJsSingleQuoted(&sid_buf, shortcut_id) catch return;
-        const cb_esc = bridge_error.escapeJsSingleQuoted(&cb_buf, callback_id) catch return;
+        const js = registry_mod.eventScript(self.allocator, name, detail) catch return;
+        defer self.allocator.free(js);
 
-        var buf: [512]u8 = undefined;
-        const js = std.fmt.bufPrint(&buf,
-            \\if(window.__craftShortcutCallback)window.__craftShortcutCallback('{s}','{s}');
-        , .{ sid_esc, cb_esc }) catch return;
-
-        bridge.evalJS(js) catch |err| {
-            log.debug("Failed to trigger callback: {}", .{err});
+        bridge.evalJS(js) catch |eval_err| {
+            log.debug("could not deliver {s}: {}", .{ name, eval_err });
         };
-    }
-
-    /// Unregister a shortcut
-    /// JSON: {"id": "toggle"}
-    fn unregisterShortcut(self: *Self, data: []const u8) !void {
-        var id: []const u8 = "";
-        if (std.mem.indexOf(u8, data, "\"id\":\"")) |idx| {
-            const start = idx + 6;
-            if (std.mem.indexOfPos(u8, data, start, "\"")) |end| {
-                id = data[start..end];
-            }
-        }
-
-        if (id.len == 0) return BridgeError.MissingData;
-
-        log.debug("unregister: {s}", .{id});
-
-        if (self.shortcuts.fetchRemove(id)) |kv| {
-            self.allocator.free(kv.value.id);
-            self.allocator.free(kv.value.key);
-            self.allocator.free(kv.value.callback_id);
-        }
-    }
-
-    /// Unregister all shortcuts
-    fn unregisterAllShortcuts(self: *Self) !void {
-        log.debug("unregisterAll", .{});
-
-        var it = self.shortcuts.iterator();
-        while (it.next()) |entry| {
-            self.allocator.free(entry.value_ptr.id);
-            self.allocator.free(entry.value_ptr.key);
-            self.allocator.free(entry.value_ptr.callback_id);
-        }
-        self.shortcuts.clearAndFree();
-    }
-
-    /// Enable a shortcut
-    /// JSON: {"id": "toggle"}
-    fn enableShortcut(self: *Self, data: []const u8) !void {
-        var id: []const u8 = "";
-        if (std.mem.indexOf(u8, data, "\"id\":\"")) |idx| {
-            const start = idx + 6;
-            if (std.mem.indexOfPos(u8, data, start, "\"")) |end| {
-                id = data[start..end];
-            }
-        }
-
-        if (self.shortcuts.getPtr(id)) |shortcut| {
-            shortcut.enabled = true;
-            log.debug("enabled: {s}", .{id});
-        }
-    }
-
-    /// Disable a shortcut
-    /// JSON: {"id": "toggle"}
-    fn disableShortcut(self: *Self, data: []const u8) !void {
-        var id: []const u8 = "";
-        if (std.mem.indexOf(u8, data, "\"id\":\"")) |idx| {
-            const start = idx + 6;
-            if (std.mem.indexOfPos(u8, data, start, "\"")) |end| {
-                id = data[start..end];
-            }
-        }
-
-        if (self.shortcuts.getPtr(id)) |shortcut| {
-            shortcut.enabled = false;
-            log.debug("disabled: {s}", .{id});
-        }
-    }
-
-    /// Check if shortcut is registered
-    /// JSON: {"id": "toggle"}
-    fn isRegistered(self: *Self, data: []const u8) !void {
-        var id: []const u8 = "";
-        if (std.mem.indexOf(u8, data, "\"id\":\"")) |idx| {
-            const start = idx + 6;
-            if (std.mem.indexOfPos(u8, data, start, "\"")) |end| {
-                id = data[start..end];
-            }
-        }
-
-        const registered = self.shortcuts.contains(id);
-
-        const bridge = @import("bridge.zig");
-        var id_buf: [128]u8 = undefined;
-        const id_esc = bridge_error.escapeJsSingleQuoted(&id_buf, id) catch return;
-
-        var buf: [256]u8 = undefined;
-        const js = std.fmt.bufPrint(&buf,
-            \\if(window.__craftShortcutRegistered)window.__craftShortcutRegistered('{s}',{});
-        , .{ id_esc, registered }) catch return;
-
-        bridge.evalJS(js) catch |err| {
-            std.log.debug("JS eval failed for shortcut registered callback: {}", .{err});
-        };
-    }
-
-    /// List all registered shortcuts
-    fn listShortcuts(self: *Self) !void {
-        const bridge = @import("bridge.zig");
-
-        var buf: [2048]u8 = undefined;
-        var pos: usize = 0;
-
-        // Start JSON array
-        buf[pos] = '[';
-        pos += 1;
-
-        var first = true;
-        var it = self.shortcuts.iterator();
-        while (it.next()) |entry| {
-            const s = entry.value_ptr.*;
-            if (!first) {
-                buf[pos] = ',';
-                pos += 1;
-            }
-            first = false;
-
-            const item = std.fmt.bufPrint(buf[pos..],
-                \\{{"id":"{s}","key":"{s}","enabled":{}}}
-            , .{ s.id, s.key, s.enabled }) catch break;
-            pos += item.len;
-        }
-
-        buf[pos] = ']';
-        pos += 1;
-
-        var js_buf: [2200]u8 = undefined;
-        const js = std.fmt.bufPrint(&js_buf,
-            \\if(window.__craftShortcutList)window.__craftShortcutList({s});
-        , .{buf[0..pos]}) catch return;
-
-        bridge.evalJS(js) catch |err| {
-            std.log.debug("JS eval failed for shortcut list callback: {}", .{err});
-        };
-    }
-
-    pub fn deinit(self: *Self) void {
-        var it = self.shortcuts.iterator();
-        while (it.next()) |entry| {
-            self.allocator.free(entry.value_ptr.id);
-            self.allocator.free(entry.value_ptr.key);
-            self.allocator.free(entry.value_ptr.callback_id);
-        }
-        self.shortcuts.deinit();
-        const global_state = @import("global_state.zig");
-        global_state.instance.setShortcutsBridge(null);
     }
 };
 
-/// Convert keycode to key name
-fn keycodeToName(keycode: u16) []const u8 {
-    return switch (keycode) {
-        0 => "A",
-        1 => "S",
-        2 => "D",
-        3 => "F",
-        4 => "H",
-        5 => "G",
-        6 => "Z",
-        7 => "X",
-        8 => "C",
-        9 => "V",
-        11 => "B",
-        12 => "Q",
-        13 => "W",
-        14 => "E",
-        15 => "R",
-        16 => "Y",
-        17 => "T",
-        18 => "1",
-        19 => "2",
-        20 => "3",
-        21 => "4",
-        22 => "6",
-        23 => "5",
-        24 => "=",
-        25 => "9",
-        26 => "7",
-        27 => "-",
-        28 => "8",
-        29 => "0",
-        30 => "]",
-        31 => "O",
-        32 => "U",
-        33 => "[",
-        34 => "I",
-        35 => "P",
-        36 => "Return",
-        37 => "L",
-        38 => "J",
-        39 => "'",
-        40 => "K",
-        41 => ";",
-        42 => "\\",
-        43 => ",",
-        44 => "/",
-        45 => "N",
-        46 => "M",
-        47 => ".",
-        48 => "Tab",
-        49 => "Space",
-        50 => "`",
-        51 => "Delete",
-        53 => "Escape",
-        96 => "F5",
-        97 => "F6",
-        98 => "F7",
-        99 => "F3",
-        100 => "F8",
-        101 => "F9",
-        103 => "F11",
-        109 => "F10",
-        111 => "F12",
-        118 => "F4",
-        120 => "F2",
-        122 => "F1",
-        123 => "Left",
-        124 => "Right",
-        125 => "Down",
-        126 => "Up",
-        else => "Unknown",
-    };
-}
-
-/// Public function for external event handling
-pub fn handleGlobalKeyEvent(keycode: u16, flags: c_ulong) void {
+/// Bridge between the platform's C callback and the live bridge instance.
+fn onHotKeyPressed(hotkey_id: u32) void {
     const global_state = @import("global_state.zig");
-    if (global_state.instance.getShortcutsBridge()) |bridge| {
-        bridge.checkKeyEvent(keycode, flags);
-    }
+    if (global_state.instance.getShortcutsBridge()) |bridge| bridge.deliver(hotkey_id);
 }

--- a/packages/zig/src/js/craft-bridge.js
+++ b/packages/zig/src/js/craft-bridge.js
@@ -539,6 +539,13 @@
   // -------------------------------------------------------------------------
   // shortcuts — global hotkeys
   // -------------------------------------------------------------------------
+  // `register` is fire-and-forget by necessity, not by choice: `_req` keys its
+  // pending queue by action name alone, and `register`/`enable`/`disable` are
+  // action names other bridges use too, so making these requests would mix
+  // replies between namespaces. `onError` is how a refused registration —
+  // the key already belongs to another app, or to the system — still reaches
+  // the caller. Registering a hotkey and never hearing that you did not get it
+  // is the bug this whole namespace was rewritten to fix (#47).
   window.craft.shortcuts = {
     register:       function (id, accelerator, opts) {
       return _send('shortcuts', 'register', _stringify(Object.assign({
@@ -552,6 +559,7 @@
     isRegistered:   function (id) { return _req('shortcuts', 'isRegistered', _stringify({ id: String(id) })).then(function (r) { return !!(r && r.value) }) },
     list:           function ()   { return _req('shortcuts', 'list').then(function (r) { return (r && r.shortcuts) || [] }) },
     on:             _evt('craft:shortcut'),
+    onError:        _evt('craft:shortcut:error'),
   }
 
   // -------------------------------------------------------------------------

--- a/packages/zig/src/key_codes.zig
+++ b/packages/zig/src/key_codes.zig
@@ -1,0 +1,269 @@
+//! macOS virtual key codes, and the accelerator strings that name them.
+//!
+//! One table, read in both directions. `bridge_shortcuts.zig` needs the
+//! name→code direction to hand a key to `RegisterEventHotKey`, and the
+//! code→name direction to describe a shortcut back to JavaScript. Those used
+//! to be two independent switch statements, one of which did not exist — so
+//! there was nothing to keep them agreeing.
+//!
+//! The codes are the `kVK_*` constants from `<Carbon/HIToolbox/Events.h>`.
+//! They are positions on the keyboard, not characters: `kVK_ANSI_A` is 0
+//! whatever the active layout prints there. That is exactly what a global
+//! hotkey wants — the user who set Cmd+Shift+H keeps it after switching to
+//! Dvorak, because the physical key is what was registered.
+
+const std = @import("std");
+
+pub const Entry = struct {
+    /// The name craft uses in accelerators and reports back to JS.
+    name: []const u8,
+    code: u16,
+};
+
+/// The canonical name for each key: the one `nameFor` returns.
+///
+/// Order matters only in that the first entry for a code wins in `nameFor`;
+/// aliases live in `aliases` below so they can never shadow a canonical name.
+pub const table = [_]Entry{
+    // Letters, in keyboard order rather than alphabetical — this is the
+    // order Events.h lists them in, and matching it makes the constants
+    // checkable against the header by eye.
+    .{ .name = "A", .code = 0x00 },
+    .{ .name = "S", .code = 0x01 },
+    .{ .name = "D", .code = 0x02 },
+    .{ .name = "F", .code = 0x03 },
+    .{ .name = "H", .code = 0x04 },
+    .{ .name = "G", .code = 0x05 },
+    .{ .name = "Z", .code = 0x06 },
+    .{ .name = "X", .code = 0x07 },
+    .{ .name = "C", .code = 0x08 },
+    .{ .name = "V", .code = 0x09 },
+    .{ .name = "B", .code = 0x0B },
+    .{ .name = "Q", .code = 0x0C },
+    .{ .name = "W", .code = 0x0D },
+    .{ .name = "E", .code = 0x0E },
+    .{ .name = "R", .code = 0x0F },
+    .{ .name = "Y", .code = 0x10 },
+    .{ .name = "T", .code = 0x11 },
+    .{ .name = "1", .code = 0x12 },
+    .{ .name = "2", .code = 0x13 },
+    .{ .name = "3", .code = 0x14 },
+    .{ .name = "4", .code = 0x15 },
+    .{ .name = "6", .code = 0x16 },
+    .{ .name = "5", .code = 0x17 },
+    .{ .name = "=", .code = 0x18 },
+    .{ .name = "9", .code = 0x19 },
+    .{ .name = "7", .code = 0x1A },
+    .{ .name = "-", .code = 0x1B },
+    .{ .name = "8", .code = 0x1C },
+    .{ .name = "0", .code = 0x1D },
+    .{ .name = "]", .code = 0x1E },
+    .{ .name = "O", .code = 0x1F },
+    .{ .name = "U", .code = 0x20 },
+    .{ .name = "[", .code = 0x21 },
+    .{ .name = "I", .code = 0x22 },
+    .{ .name = "P", .code = 0x23 },
+    .{ .name = "Return", .code = 0x24 },
+    .{ .name = "L", .code = 0x25 },
+    .{ .name = "J", .code = 0x26 },
+    .{ .name = "'", .code = 0x27 },
+    .{ .name = "K", .code = 0x28 },
+    .{ .name = ";", .code = 0x29 },
+    .{ .name = "\\", .code = 0x2A },
+    .{ .name = ",", .code = 0x2B },
+    .{ .name = "/", .code = 0x2C },
+    .{ .name = "N", .code = 0x2D },
+    .{ .name = "M", .code = 0x2E },
+    .{ .name = ".", .code = 0x2F },
+    .{ .name = "Tab", .code = 0x30 },
+    .{ .name = "Space", .code = 0x31 },
+    .{ .name = "`", .code = 0x32 },
+    // `kVK_Delete` is the key labelled Delete on a Mac keyboard, which sends
+    // backspace. The one labelled Delete on a PC keyboard is
+    // `kVK_ForwardDelete` below. Both spellings are accepted; see `aliases`.
+    .{ .name = "Delete", .code = 0x33 },
+    .{ .name = "Escape", .code = 0x35 },
+
+    // Keypad. Distinct codes from the number row, so a shortcut bound to
+    // keypad 5 does not fire on the 5 above the T.
+    .{ .name = "KeypadDecimal", .code = 0x41 },
+    .{ .name = "KeypadMultiply", .code = 0x43 },
+    .{ .name = "KeypadPlus", .code = 0x45 },
+    .{ .name = "KeypadClear", .code = 0x47 },
+    .{ .name = "KeypadDivide", .code = 0x4B },
+    .{ .name = "KeypadEnter", .code = 0x4C },
+    .{ .name = "KeypadMinus", .code = 0x4E },
+    .{ .name = "KeypadEquals", .code = 0x51 },
+    .{ .name = "Keypad0", .code = 0x52 },
+    .{ .name = "Keypad1", .code = 0x53 },
+    .{ .name = "Keypad2", .code = 0x54 },
+    .{ .name = "Keypad3", .code = 0x55 },
+    .{ .name = "Keypad4", .code = 0x56 },
+    .{ .name = "Keypad5", .code = 0x57 },
+    .{ .name = "Keypad6", .code = 0x58 },
+    .{ .name = "Keypad7", .code = 0x59 },
+    .{ .name = "Keypad8", .code = 0x5B },
+    .{ .name = "Keypad9", .code = 0x5C },
+
+    // Function keys. Note that the codes are not in numeric order — F5 comes
+    // before F3 — which is why writing them out beats computing them.
+    .{ .name = "F1", .code = 0x7A },
+    .{ .name = "F2", .code = 0x78 },
+    .{ .name = "F3", .code = 0x63 },
+    .{ .name = "F4", .code = 0x76 },
+    .{ .name = "F5", .code = 0x60 },
+    .{ .name = "F6", .code = 0x61 },
+    .{ .name = "F7", .code = 0x62 },
+    .{ .name = "F8", .code = 0x64 },
+    .{ .name = "F9", .code = 0x65 },
+    .{ .name = "F10", .code = 0x6D },
+    .{ .name = "F11", .code = 0x67 },
+    .{ .name = "F12", .code = 0x6F },
+    .{ .name = "F13", .code = 0x69 },
+    .{ .name = "F14", .code = 0x6B },
+    .{ .name = "F15", .code = 0x71 },
+    .{ .name = "F16", .code = 0x6A },
+    .{ .name = "F17", .code = 0x40 },
+    .{ .name = "F18", .code = 0x4F },
+    .{ .name = "F19", .code = 0x50 },
+    .{ .name = "F20", .code = 0x5A },
+
+    // Navigation and editing.
+    .{ .name = "Help", .code = 0x72 },
+    .{ .name = "Home", .code = 0x73 },
+    .{ .name = "PageUp", .code = 0x74 },
+    .{ .name = "ForwardDelete", .code = 0x75 },
+    .{ .name = "End", .code = 0x77 },
+    .{ .name = "PageDown", .code = 0x79 },
+    .{ .name = "Left", .code = 0x7B },
+    .{ .name = "Right", .code = 0x7C },
+    .{ .name = "Down", .code = 0x7D },
+    .{ .name = "Up", .code = 0x7E },
+};
+
+/// Extra spellings accepted by `codeFor`, never returned by `nameFor`.
+///
+/// The point is that an accelerator copied out of an Electron app, a web
+/// `KeyboardEvent.key`, or a Mac keyboard's own labelling all resolve to the
+/// same key rather than failing registration.
+const aliases = [_]Entry{
+    .{ .name = "Backspace", .code = 0x33 },
+    .{ .name = "Esc", .code = 0x35 },
+    .{ .name = "Enter", .code = 0x24 },
+    .{ .name = "Plus", .code = 0x18 },
+    .{ .name = "Equal", .code = 0x18 },
+    .{ .name = "Minus", .code = 0x1B },
+    .{ .name = "Comma", .code = 0x2B },
+    .{ .name = "Period", .code = 0x2F },
+    .{ .name = "Slash", .code = 0x2C },
+    .{ .name = "Backslash", .code = 0x2A },
+    .{ .name = "Semicolon", .code = 0x29 },
+    .{ .name = "Quote", .code = 0x27 },
+    .{ .name = "Backquote", .code = 0x32 },
+    .{ .name = "Grave", .code = 0x32 },
+    .{ .name = "BracketLeft", .code = 0x21 },
+    .{ .name = "BracketRight", .code = 0x1E },
+    .{ .name = "Del", .code = 0x75 },
+    .{ .name = "ArrowLeft", .code = 0x7B },
+    .{ .name = "ArrowRight", .code = 0x7C },
+    .{ .name = "ArrowDown", .code = 0x7D },
+    .{ .name = "ArrowUp", .code = 0x7E },
+    .{ .name = "PgUp", .code = 0x74 },
+    .{ .name = "PgDn", .code = 0x79 },
+};
+
+/// The virtual key code named by `name`, or null if nothing is.
+///
+/// Case-insensitive: an app writing `cmd+shift+h` means the same key as one
+/// writing `Cmd+Shift+H`, and neither should have to know which craft
+/// prefers.
+pub fn codeFor(name: []const u8) ?u16 {
+    for (table) |entry| {
+        if (std.ascii.eqlIgnoreCase(name, entry.name)) return entry.code;
+    }
+    for (aliases) |entry| {
+        if (std.ascii.eqlIgnoreCase(name, entry.name)) return entry.code;
+    }
+    return null;
+}
+
+/// The canonical name for `code`, or null if it is not a key craft names.
+pub fn nameFor(code: u16) ?[]const u8 {
+    for (table) |entry| {
+        if (entry.code == code) return entry.name;
+    }
+    return null;
+}
+
+test "every canonical name resolves back to its own code" {
+    for (table) |entry| {
+        try std.testing.expectEqual(entry.code, codeFor(entry.name).?);
+        try std.testing.expectEqualStrings(entry.name, nameFor(entry.code).?);
+    }
+}
+
+test "lookup is case-insensitive" {
+    try std.testing.expectEqual(@as(u16, 0x04), codeFor("h").?);
+    try std.testing.expectEqual(@as(u16, 0x04), codeFor("H").?);
+    try std.testing.expectEqual(@as(u16, 0x31), codeFor("space").?);
+    try std.testing.expectEqual(@as(u16, 0x31), codeFor("SPACE").?);
+}
+
+test "aliases resolve, and every one of them names a real key" {
+    for (aliases) |alias| {
+        try std.testing.expectEqual(alias.code, codeFor(alias.name).?);
+        // An alias pointing at a code no canonical entry claims would resolve
+        // fine and then list itself as "Unknown".
+        try std.testing.expect(nameFor(alias.code) != null);
+    }
+    // `nameFor` answers with the canonical spelling, so a shortcut registered
+    // as "Backspace" lists itself as "Delete" rather than echoing whichever
+    // spelling happened to arrive.
+    try std.testing.expectEqualStrings("Delete", nameFor(codeFor("Backspace").?).?);
+    try std.testing.expectEqualStrings("Escape", nameFor(codeFor("Esc").?).?);
+}
+
+test "no two canonical entries share a name or a code" {
+    for (table, 0..) |a, i| {
+        for (table[i + 1 ..]) |b| {
+            try std.testing.expect(!std.ascii.eqlIgnoreCase(a.name, b.name));
+            try std.testing.expect(a.code != b.code);
+        }
+    }
+}
+
+test "an alias never collides with a canonical name" {
+    // A duplicate here would be silently unreachable: `codeFor` checks the
+    // canonical table first, so an alias shadowing one could disagree with it
+    // forever without anything noticing.
+    for (aliases) |alias| {
+        for (table) |entry| {
+            try std.testing.expect(!std.ascii.eqlIgnoreCase(alias.name, entry.name));
+        }
+    }
+}
+
+test "unknown keys are absent rather than guessed" {
+    try std.testing.expect(codeFor("") == null);
+    try std.testing.expect(codeFor("Meta") == null);
+    try std.testing.expect(codeFor("F21") == null);
+    // 0x34 is unassigned between Escape and kVK_Delete.
+    try std.testing.expect(nameFor(0x34) == null);
+    try std.testing.expect(nameFor(0xFFFF) == null);
+}
+
+test "the number row and the keypad are different keys" {
+    // Bound to Keypad5, a shortcut must not fire on the 5 above the T — they
+    // are distinct physical keys and macOS gives them distinct codes.
+    try std.testing.expect(codeFor("5").? != codeFor("Keypad5").?);
+    try std.testing.expect(codeFor("Return").? != codeFor("KeypadEnter").?);
+}
+
+test "Delete is backspace and ForwardDelete is not" {
+    // The Mac key labelled Delete sends backspace; the PC key labelled Delete
+    // is a different code. Getting these the wrong way round silently binds
+    // the wrong key, so pin both.
+    try std.testing.expectEqual(@as(u16, 0x33), codeFor("Delete").?);
+    try std.testing.expectEqual(@as(u16, 0x75), codeFor("ForwardDelete").?);
+    try std.testing.expectEqual(@as(u16, 0x33), codeFor("Backspace").?);
+}

--- a/packages/zig/src/macos_hotkey.zig
+++ b/packages/zig/src/macos_hotkey.zig
@@ -1,0 +1,263 @@
+//! Global hotkeys on macOS, via Carbon's `RegisterEventHotKey`.
+//!
+//! This is the mechanism macOS provides for "fire even when my app is not
+//! frontmost", and the reason craft uses it over the two obvious alternatives:
+//!
+//!   * `+[NSEvent addGlobalMonitorForEventsMatchingMask:handler:]` takes an
+//!     Objective-C block. Zig cannot write one, which is where the previous
+//!     attempt stopped — the mask was computed and then discarded, and no
+//!     monitor was ever installed. See `bridge_shortcuts.zig`.
+//!   * `CGEventTapCreate` takes a plain C callback and would work, but it is a
+//!     keylogging-grade primitive: it demands Accessibility or Input
+//!     Monitoring permission and sees every keystroke the user types. Asking
+//!     for that to deliver one hotkey is a bad trade for craft's users.
+//!
+//! Carbon hotkeys take a plain C callback, require no permission prompt at
+//! all, and the system only calls us for the exact combinations we asked for.
+//! The API is old but is neither deprecated nor unavailable: it is what the
+//! system's own hotkey UI is built on, and it is present on arm64.
+//!
+//! Registration is by *physical key*, not character. Cmd+Shift+H stays on the
+//! same key after the user switches to Dvorak — see `key_codes.zig`.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+const is_macos = builtin.os.tag == .macos;
+
+/// Opaque `EventHotKeyRef`. Held so the registration can be undone.
+pub const Ref = ?*anyopaque;
+
+/// Build a four-character code the way Carbon's headers do, so the constants
+/// below read as the strings they are rather than as hex nobody can check.
+fn fourCC(comptime s: *const [4:0]u8) u32 {
+    return (@as(u32, s[0]) << 24) | (@as(u32, s[1]) << 16) | (@as(u32, s[2]) << 8) | @as(u32, s[3]);
+}
+
+const k_event_class_keyboard = fourCC("keyb");
+const k_event_hotkey_pressed: u32 = 5;
+const k_event_param_direct_object = fourCC("----");
+const type_event_hotkey_id = fourCC("hkid");
+
+/// Signature for every hotkey craft registers, so ours are distinguishable
+/// from another framework's inside the same process.
+const craft_signature = fourCC("craf");
+
+const noErr: i32 = 0;
+
+const EventHotKeyID = extern struct {
+    signature: u32,
+    id: u32,
+};
+
+const EventTypeSpec = extern struct {
+    eventClass: u32,
+    eventKind: u32,
+};
+
+// `ItemCount`/`ByteCount` are `unsigned long` in MacTypes.h — 64-bit on every
+// target craft builds for — and `OSStatus` is `SInt32`.
+extern "c" fn GetApplicationEventTarget() ?*anyopaque;
+extern "c" fn RegisterEventHotKey(
+    inHotKeyCode: u32,
+    inHotKeyModifiers: u32,
+    inHotKeyID: EventHotKeyID,
+    inTarget: ?*anyopaque,
+    inOptions: u32,
+    outRef: *Ref,
+) i32;
+extern "c" fn UnregisterEventHotKey(inHotKey: ?*anyopaque) i32;
+extern "c" fn InstallEventHandler(
+    inTarget: ?*anyopaque,
+    inHandler: ?*const anyopaque,
+    inNumTypes: usize,
+    inList: [*]const EventTypeSpec,
+    inUserData: ?*anyopaque,
+    outRef: ?*?*anyopaque,
+) i32;
+extern "c" fn GetEventParameter(
+    inEvent: ?*anyopaque,
+    inName: u32,
+    inDesiredType: u32,
+    outActualType: ?*u32,
+    inBufferSize: usize,
+    outActualSize: ?*usize,
+    outData: ?*anyopaque,
+) i32;
+
+/// Called on the main thread with the `id` a hotkey was registered under,
+/// every time that combination is pressed anywhere in the system.
+pub var on_pressed: ?*const fn (id: u32) void = null;
+
+var handler_installed = false;
+
+fn hotKeyHandler(_: ?*anyopaque, event: ?*anyopaque, _: ?*anyopaque) callconv(.c) i32 {
+    var hotkey_id: EventHotKeyID = undefined;
+    const status = GetEventParameter(
+        event,
+        k_event_param_direct_object,
+        type_event_hotkey_id,
+        null,
+        @sizeOf(EventHotKeyID),
+        null,
+        &hotkey_id,
+    );
+    // Returning noErr regardless: the event was ours to handle either way, and
+    // reporting failure here asks Carbon to keep looking for another handler
+    // for a hotkey only craft registered.
+    if (status != noErr) return noErr;
+    if (hotkey_id.signature != craft_signature) return noErr;
+    if (on_pressed) |cb| cb(hotkey_id.id);
+    return noErr;
+}
+
+/// Install the one application-wide handler that every craft hotkey is
+/// delivered through. Idempotent; safe to call before each registration.
+///
+/// Returns false if Carbon refused, in which case registering hotkeys is
+/// pointless — they would be reserved system-wide and never delivered.
+pub fn ensureHandler() bool {
+    if (comptime !is_macos) return false;
+
+    if (handler_installed) return true;
+
+    const spec = [_]EventTypeSpec{.{
+        .eventClass = k_event_class_keyboard,
+        .eventKind = k_event_hotkey_pressed,
+    }};
+    const status = InstallEventHandler(
+        GetApplicationEventTarget(),
+        @ptrCast(&hotKeyHandler),
+        spec.len,
+        &spec,
+        null,
+        null,
+    );
+    if (status != noErr) return false;
+
+    handler_installed = true;
+    return true;
+}
+
+/// Reserve `keycode` + `modifiers` system-wide, delivered as `id`.
+///
+/// `modifiers` is a Carbon modifier mask — `accelerator.Modifiers.toCarbonFlags`
+/// produces one — not the Cocoa `NSEventModifierFlag` set.
+///
+/// Returns null when the combination is already taken — by another app, or by
+/// the system itself, which owns things like Cmd+Space. That is a normal
+/// outcome and the caller should report it to the app rather than treat it as
+/// a crash: the user has to pick a different key.
+pub fn register(keycode: u16, modifiers: u32, id: u32) Ref {
+    if (comptime !is_macos) return null;
+
+    if (!ensureHandler()) return null;
+
+    var ref: Ref = null;
+    const status = RegisterEventHotKey(
+        @intCast(keycode),
+        modifiers,
+        .{ .signature = craft_signature, .id = id },
+        GetApplicationEventTarget(),
+        0,
+        &ref,
+    );
+    if (status != noErr or ref == null) return null;
+    return ref;
+}
+
+/// Release a reservation so the combination reaches whoever wants it next.
+pub fn unregister(ref: Ref) void {
+    if (comptime !is_macos) return;
+
+    if (ref) |r| _ = UnregisterEventHotKey(r);
+}
+
+// Carbon's event *construction* API, used only by the test below. Declared
+// here rather than in the file's main body because craft never builds an event
+// itself at runtime — it only ever receives them.
+extern "c" fn CreateEvent(inAllocator: ?*anyopaque, inClassID: u32, inKind: u32, inWhen: f64, inAttributes: u32, outEvent: *?*anyopaque) i32;
+extern "c" fn SetEventParameter(inEvent: ?*anyopaque, inName: u32, inType: u32, inSize: usize, inDataPtr: *const anyopaque) i32;
+extern "c" fn SendEventToEventTarget(inEvent: ?*anyopaque, inTarget: ?*anyopaque) i32;
+extern "c" fn ReleaseEvent(inEvent: ?*anyopaque) void;
+
+var test_last_id: ?u32 = null;
+
+fn recordPressed(id: u32) void {
+    test_last_id = id;
+}
+
+/// Build the event Carbon sends on a hotkey press and put it through the real
+/// dispatcher, so the handler runs exactly as it does for a real keystroke.
+fn sendSyntheticHotKey(signature: u32, id: u32) !void {
+    var event: ?*anyopaque = null;
+    if (CreateEvent(null, k_event_class_keyboard, k_event_hotkey_pressed, 0, 0, &event) != noErr)
+        return error.CreateEventFailed;
+    defer ReleaseEvent(event);
+
+    const payload = EventHotKeyID{ .signature = signature, .id = id };
+    if (SetEventParameter(event, k_event_param_direct_object, type_event_hotkey_id, @sizeOf(EventHotKeyID), &payload) != noErr)
+        return error.SetParameterFailed;
+    if (SendEventToEventTarget(event, GetApplicationEventTarget()) != noErr)
+        return error.SendFailed;
+}
+
+test "a hotkey event dispatched by Carbon reaches the callback" {
+    // The one part of this file that cannot be reasoned about from the source:
+    // whether the handler signature, the `EventHotKeyID` layout and the
+    // `GetEventParameter` call are what Carbon actually expects. Getting any
+    // of them wrong compiles, links, registers — and then silently never
+    // delivers, which is the exact shape of the bug this file exists to fix.
+    //
+    // Everything here is real except the keystroke: a genuine `EventRef`, put
+    // through Carbon's own dispatcher, decoded by the handler craft installs.
+    if (comptime !is_macos) return error.SkipZigTest;
+
+    // A build host with no Carbon event target — some headless CI images —
+    // cannot install the handler, and there is nothing left to assert.
+    if (!ensureHandler()) return error.SkipZigTest;
+
+    const previous = on_pressed;
+    defer on_pressed = previous;
+    on_pressed = recordPressed;
+
+    test_last_id = null;
+    try sendSyntheticHotKey(craft_signature, 4242);
+    try std.testing.expectEqual(@as(?u32, 4242), test_last_id);
+}
+
+test "a hotkey belonging to someone else is left alone" {
+    // Another framework in the same process can register its own hotkeys, and
+    // its events arrive at every handler installed on the application target.
+    // Acting on one would fire an unrelated app's shortcut as if it were ours.
+    if (comptime !is_macos) return error.SkipZigTest;
+    if (!ensureHandler()) return error.SkipZigTest;
+
+    const previous = on_pressed;
+    defer on_pressed = previous;
+    on_pressed = recordPressed;
+
+    test_last_id = null;
+    try sendSyntheticHotKey(fourCC("othr"), 4242);
+    try std.testing.expectEqual(@as(?u32, null), test_last_id);
+}
+
+test "the four-character codes match the constants Carbon documents" {
+    // These are the values every Carbon hotkey example hard-codes as hex.
+    // Deriving them from the strings is what makes them readable; pinning the
+    // hex is what makes the derivation checkable.
+    try std.testing.expectEqual(@as(u32, 0x6B657962), fourCC("keyb"));
+    try std.testing.expectEqual(@as(u32, 0x2D2D2D2D), fourCC("----"));
+    try std.testing.expectEqual(@as(u32, 0x686B6964), fourCC("hkid"));
+    try std.testing.expectEqual(@as(u32, 0x63726166), fourCC("craf"));
+}
+
+test "EventHotKeyID is laid out the way Carbon reads it" {
+    // `GetEventParameter` writes straight into this struct, so a wrong size or
+    // a reordered field is a silent memory-corruption bug rather than a
+    // compile error.
+    try std.testing.expectEqual(@as(usize, 8), @sizeOf(EventHotKeyID));
+    try std.testing.expectEqual(@as(usize, 0), @offsetOf(EventHotKeyID, "signature"));
+    try std.testing.expectEqual(@as(usize, 4), @offsetOf(EventHotKeyID, "id"));
+    try std.testing.expectEqual(@as(usize, 8), @sizeOf(EventTypeSpec));
+}

--- a/packages/zig/src/shortcut_registry.zig
+++ b/packages/zig/src/shortcut_registry.zig
@@ -1,0 +1,878 @@
+//! The set of global shortcuts an app has asked for, and what craft did about
+//! each one.
+//!
+//! Separated from `bridge_shortcuts.zig` so that the whole lifecycle —
+//! register, replace, disable, re-enable, unregister — can be tested against a
+//! fake platform, without an app, a window or a key press. The bug this exists
+//! to close (craft-native/craft#47) survived because the only thing that could
+//! have caught it was pressing the key on a real Mac.
+//!
+//! The registry owns the bookkeeping and the JSON on both sides of it. Actually
+//! reserving a key with the system is the one thing it delegates, through
+//! `Platform`.
+
+const std = @import("std");
+const accel = @import("accelerator.zig");
+const key_codes = @import("key_codes.zig");
+const bridge_error = @import("bridge_error.zig");
+
+const BridgeError = bridge_error.BridgeError;
+
+/// The `a` field of a `shortcuts` bridge message. Shared constants rather than
+/// literals on each side: a wrong action name is not an error on the native
+/// side, only a log line, so a rename would otherwise silently stop a whole
+/// verb working.
+pub const action_register = "register";
+pub const action_unregister = "unregister";
+pub const action_unregister_all = "unregisterAll";
+pub const action_enable = "enable";
+pub const action_disable = "disable";
+pub const action_is_registered = "isRegistered";
+pub const action_list = "list";
+
+/// An opaque handle from the platform, held so a reservation can be released.
+pub const Ref = ?*anyopaque;
+
+/// How the registry reserves a key with the operating system.
+///
+/// `register` returns null when the combination is unavailable — already taken
+/// by another app, or by the system. That is an ordinary outcome, not a
+/// failure of craft's, and it has to reach the app: the user must pick a
+/// different key.
+pub const Platform = struct {
+    register: *const fn (keycode: u16, carbon_modifiers: u32, hotkey_id: u32) Ref,
+    unregister: *const fn (ref: Ref) void,
+};
+
+/// A platform that reserves nothing. Used where global hotkeys have no
+/// implementation, so `register` reports honestly instead of accepting a
+/// shortcut that could never fire.
+pub const unsupported_platform = Platform{
+    .register = struct {
+        fn f(_: u16, _: u32, _: u32) Ref {
+            return null;
+        }
+    }.f,
+    .unregister = struct {
+        fn f(_: Ref) void {}
+    }.f,
+};
+
+pub const Registration = struct {
+    /// App-chosen identifier. Owned.
+    id: []const u8,
+    /// Canonical accelerator — what `format` renders, not necessarily the
+    /// spelling that arrived. Owned.
+    accelerator: []const u8,
+    binding: accel.Binding,
+    /// Identifier handed to the platform, and the only thing that comes back
+    /// when the key is pressed.
+    hotkey_id: u32,
+    /// Null exactly when the key is not currently reserved — i.e. when the
+    /// shortcut is disabled.
+    ref: Ref = null,
+    enabled: bool = true,
+};
+
+/// The payload `shortcuts.register` accepts.
+///
+/// `accelerator` is what the JS bridge sends. `key` + `modifiers` is the older
+/// shape the SDK's message tests document; both are accepted so neither
+/// caller has to change to get a shortcut that works.
+const RegisterPayload = struct {
+    id: []const u8 = "",
+    accelerator: ?[]const u8 = null,
+    key: ?[]const u8 = null,
+    modifiers: ?PayloadModifiers = null,
+
+    const PayloadModifiers = struct {
+        cmd: bool = false,
+        ctrl: bool = false,
+        alt: bool = false,
+        shift: bool = false,
+        /// Web keyboard events spell command `metaKey`.
+        meta: bool = false,
+    };
+};
+
+/// A payload naming only an id: unregister, enable, disable, isRegistered.
+const IdPayload = struct {
+    id: []const u8 = "",
+};
+
+pub const Registry = struct {
+    allocator: std.mem.Allocator,
+    entries: std.ArrayListUnmanaged(Registration) = .empty,
+    platform: Platform,
+    next_hotkey_id: u32 = 1,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator, platform: Platform) Self {
+        return .{ .allocator = allocator, .platform = platform };
+    }
+
+    pub fn deinit(self: *Self) void {
+        for (self.entries.items) |*entry| {
+            self.platform.unregister(entry.ref);
+            self.allocator.free(entry.id);
+            self.allocator.free(entry.accelerator);
+        }
+        self.entries.deinit(self.allocator);
+    }
+
+    pub fn count(self: *const Self) usize {
+        return self.entries.items.len;
+    }
+
+    /// The entry for `id`, or null.
+    ///
+    /// The pointer is into the backing array and is invalidated by any
+    /// subsequent `register`, so callers must finish with it before the next
+    /// one.
+    pub fn find(self: *Self, id: []const u8) ?*Registration {
+        const index = self.findIndex(id) orelse return null;
+        return &self.entries.items[index];
+    }
+
+    fn findIndex(self: *const Self, id: []const u8) ?usize {
+        for (self.entries.items, 0..) |entry, index| {
+            if (std.mem.eql(u8, entry.id, id)) return index;
+        }
+        return null;
+    }
+
+    /// The shortcut a pressed hotkey belongs to, or null if the id is stale —
+    /// which can happen for a key released between the press and its delivery.
+    pub fn findByHotkeyId(self: *Self, hotkey_id: u32) ?*Registration {
+        for (self.entries.items) |*entry| {
+            if (entry.hotkey_id == hotkey_id) return entry;
+        }
+        return null;
+    }
+
+    /// Register the shortcut described by `data`, replacing any shortcut
+    /// already using the same id.
+    ///
+    /// Returns the registration on success. The errors are all things the app
+    /// needs to hear about, and every one of them used to be a silent success.
+    pub fn register(self: *Self, data: []const u8) BridgeError!*Registration {
+        const parsed = std.json.parseFromSlice(RegisterPayload, self.allocator, data, .{
+            .ignore_unknown_fields = true,
+            .allocate = .alloc_always,
+        }) catch return BridgeError.InvalidJSON;
+        defer parsed.deinit();
+
+        const payload = parsed.value;
+        if (payload.id.len == 0) return BridgeError.MissingData;
+
+        const binding = try bindingFor(payload);
+
+        var rendered: [96]u8 = undefined;
+        const canonical = accel.format(&rendered, binding) catch return BridgeError.InvalidParameter;
+
+        // Registering over an existing id replaces it, and the old entry goes
+        // first — reservation included. Two reasons, both load-bearing:
+        // re-registering the *same* accelerator would otherwise fail against
+        // craft's own outstanding reservation, and a reservation dropped on
+        // the floor keeps that key dead system-wide for the life of the
+        // process with nothing left pointing at it to release it.
+        if (self.findIndex(payload.id)) |index| self.forget(index);
+
+        const id_owned = self.allocator.dupe(u8, payload.id) catch return BridgeError.AllocationFailed;
+        errdefer self.allocator.free(id_owned);
+        const accel_owned = self.allocator.dupe(u8, canonical) catch return BridgeError.AllocationFailed;
+        errdefer self.allocator.free(accel_owned);
+
+        const hotkey_id = self.next_hotkey_id;
+        const ref = self.platform.register(binding.keycode, binding.modifiers.toCarbonFlags(), hotkey_id);
+        // A shortcut nobody can trigger is worse than a failed registration:
+        // the app believes it has a hotkey and waits forever.
+        if (ref == null) return BridgeError.NativeCallFailed;
+        self.next_hotkey_id += 1;
+        errdefer self.platform.unregister(ref);
+
+        self.entries.append(self.allocator, .{
+            .id = id_owned,
+            .accelerator = accel_owned,
+            .binding = binding,
+            .hotkey_id = hotkey_id,
+            .ref = ref,
+        }) catch return BridgeError.AllocationFailed;
+        return &self.entries.items[self.entries.items.len - 1];
+    }
+
+    /// Release the entry's reservation and drop it from the registry.
+    fn forget(self: *Self, index: usize) void {
+        const entry = &self.entries.items[index];
+        self.release(entry);
+        self.allocator.free(entry.id);
+        self.allocator.free(entry.accelerator);
+        _ = self.entries.orderedRemove(index);
+    }
+
+    /// Release the system reservation, leaving the entry in place. Idempotent.
+    fn release(self: *Self, entry: *Registration) void {
+        if (entry.ref == null) return;
+        self.platform.unregister(entry.ref);
+        entry.ref = null;
+    }
+
+    pub fn unregister(self: *Self, data: []const u8) BridgeError!void {
+        const id = try self.idFrom(data);
+        defer self.allocator.free(id);
+
+        const index = self.findIndex(id) orelse return BridgeError.NotFound;
+        self.forget(index);
+    }
+
+    pub fn unregisterAll(self: *Self) void {
+        for (self.entries.items) |*entry| {
+            self.release(entry);
+            self.allocator.free(entry.id);
+            self.allocator.free(entry.accelerator);
+        }
+        self.entries.clearRetainingCapacity();
+    }
+
+    /// Enable or disable a shortcut.
+    ///
+    /// Disabling gives the key back to the rest of the system rather than
+    /// holding the reservation and dropping the event: a disabled shortcut
+    /// that still swallowed its key would make that combination dead in every
+    /// other app for as long as craft ran.
+    pub fn setEnabled(self: *Self, data: []const u8, enabled: bool) BridgeError!void {
+        const id = try self.idFrom(data);
+        defer self.allocator.free(id);
+
+        const entry = self.find(id) orelse return BridgeError.NotFound;
+        if (entry.enabled == enabled) return;
+        entry.enabled = enabled;
+
+        if (!enabled) {
+            self.release(entry);
+            return;
+        }
+
+        const ref = self.platform.register(
+            entry.binding.keycode,
+            entry.binding.modifiers.toCarbonFlags(),
+            entry.hotkey_id,
+        );
+        if (ref == null) {
+            // Someone else claimed the key while it was released. The app
+            // asked for it back and cannot have it.
+            entry.enabled = false;
+            return BridgeError.NativeCallFailed;
+        }
+        entry.ref = ref;
+    }
+
+    pub fn isRegistered(self: *Self, data: []const u8) BridgeError!bool {
+        const id = try self.idFrom(data);
+        defer self.allocator.free(id);
+        return self.find(id) != null;
+    }
+
+    /// `{"value":true}` — the shape `_req('shortcuts','isRegistered')` reads.
+    pub fn isRegisteredJson(self: *Self, data: []const u8) BridgeError![]u8 {
+        const registered = try self.isRegistered(data);
+        return std.fmt.allocPrint(self.allocator, "{{\"value\":{}}}", .{registered}) catch
+            BridgeError.AllocationFailed;
+    }
+
+    /// `{"shortcuts":[…]}` — the shape `_req('shortcuts','list')` reads.
+    ///
+    /// Caller frees.
+    pub fn listJson(self: *Self) BridgeError![]u8 {
+        var out: std.ArrayListUnmanaged(u8) = .empty;
+        errdefer out.deinit(self.allocator);
+
+        out.appendSlice(self.allocator, "{\"shortcuts\":[") catch return BridgeError.AllocationFailed;
+        for (self.entries.items, 0..) |entry, index| {
+            if (index > 0) out.append(self.allocator, ',') catch return BridgeError.AllocationFailed;
+
+            // Ids come from app code and can contain anything. Interpolating
+            // one unescaped produces either broken JSON or an injection.
+            const id_escaped = try escapeId(self.allocator, entry.id);
+            defer self.allocator.free(id_escaped);
+
+            // `accelerator` and `key` need no escaping: both are craft's own
+            // canonical spellings, out of a fixed table, never app input.
+            const item = std.fmt.allocPrint(
+                self.allocator,
+                "{{\"id\":\"{s}\",\"accelerator\":\"{s}\",\"key\":\"{s}\",\"enabled\":{}}}",
+                .{ id_escaped, entry.accelerator, entry.binding.key, entry.enabled },
+            ) catch return BridgeError.AllocationFailed;
+            defer self.allocator.free(item);
+            out.appendSlice(self.allocator, item) catch return BridgeError.AllocationFailed;
+        }
+        out.appendSlice(self.allocator, "]}") catch return BridgeError.AllocationFailed;
+
+        return out.toOwnedSlice(self.allocator) catch BridgeError.AllocationFailed;
+    }
+
+    /// Copy the `id` out of a `{"id":"…"}` payload. Copied because the JSON
+    /// arena it was parsed into does not outlive the call.
+    fn idFrom(self: *Self, data: []const u8) BridgeError![]u8 {
+        const parsed = std.json.parseFromSlice(IdPayload, self.allocator, data, .{
+            .ignore_unknown_fields = true,
+            .allocate = .alloc_always,
+        }) catch return BridgeError.InvalidJSON;
+        defer parsed.deinit();
+
+        if (parsed.value.id.len == 0) return BridgeError.MissingData;
+        return self.allocator.dupe(u8, parsed.value.id) catch BridgeError.AllocationFailed;
+    }
+};
+
+/// The `detail` of the event a triggered shortcut is delivered as.
+///
+/// Built as JSON and embedded straight into the script: JSON object syntax is
+/// a subset of JavaScript's, so escaping once as JSON escapes it for the
+/// script too. That matters because shortcut ids come from app code, and an
+/// unescaped quote in one is an injection into every craft window.
+pub fn triggeredDetail(allocator: std.mem.Allocator, id: []const u8, accelerator: []const u8) BridgeError![]u8 {
+    const escaped = try escapeId(allocator, id);
+    defer allocator.free(escaped);
+    // `accelerator` is craft's own canonical spelling, out of a fixed table,
+    // and never app input.
+    return std.fmt.allocPrint(allocator, "{{\"id\":\"{s}\",\"accelerator\":\"{s}\"}}", .{ escaped, accelerator }) catch
+        BridgeError.AllocationFailed;
+}
+
+/// The `detail` of the event a refused registration is reported as.
+pub fn errorDetail(allocator: std.mem.Allocator, id: []const u8, code: []const u8, message: []const u8) BridgeError![]u8 {
+    const escaped = try escapeId(allocator, id);
+    defer allocator.free(escaped);
+    // `code` and `message` are compile-time constants from `bridge_error`.
+    return std.fmt.allocPrint(allocator, "{{\"id\":\"{s}\",\"code\":\"{s}\",\"message\":\"{s}\"}}", .{ escaped, code, message }) catch
+        BridgeError.AllocationFailed;
+}
+
+/// Wrap a detail object in the `dispatchEvent` call that delivers it.
+pub fn eventScript(allocator: std.mem.Allocator, name: []const u8, detail_json: []const u8) BridgeError![]u8 {
+    return std.fmt.allocPrint(
+        allocator,
+        "if(window.dispatchEvent)window.dispatchEvent(new CustomEvent('{s}',{{detail:{s}}}));",
+        .{ name, detail_json },
+    ) catch BridgeError.AllocationFailed;
+}
+
+/// Six bytes is the worst case per input byte (`\u001f`), plus a terminator.
+fn escapeId(allocator: std.mem.Allocator, id: []const u8) BridgeError![]u8 {
+    const buf = allocator.alloc(u8, id.len * 6 + 1) catch return BridgeError.AllocationFailed;
+    errdefer allocator.free(buf);
+    const escaped = bridge_error.escapeJsonString(buf, id) catch return BridgeError.InvalidParameter;
+    return allocator.realloc(buf, escaped.len) catch buf[0..escaped.len];
+}
+
+/// Resolve whichever of the two accepted payload shapes arrived into a binding.
+fn bindingFor(payload: RegisterPayload) BridgeError!accel.Binding {
+    if (payload.accelerator) |text| {
+        return accel.parse(text) catch |err| return translate(err);
+    }
+
+    const key = payload.key orelse return BridgeError.MissingData;
+    const mods = payload.modifiers orelse RegisterPayload.PayloadModifiers{};
+    const resolved = accel.Modifiers{
+        .cmd = mods.cmd or mods.meta,
+        .ctrl = mods.ctrl,
+        .alt = mods.alt,
+        .shift = mods.shift,
+    };
+    const keycode = key_codes.codeFor(key) orelse return BridgeError.InvalidParameter;
+    const canonical = key_codes.nameFor(keycode).?;
+
+    // The same guard `accel.parse` applies, for the same reason: a global
+    // hotkey with no commanding modifier takes the key away system-wide.
+    var probe: [96]u8 = undefined;
+    const rendered = accel.format(&probe, .{
+        .key = canonical,
+        .keycode = keycode,
+        .modifiers = resolved,
+    }) catch return BridgeError.InvalidParameter;
+    return accel.parse(rendered) catch |err| return translate(err);
+}
+
+fn translate(err: accel.ParseError) BridgeError {
+    return switch (err) {
+        error.MissingKey, error.EmptyComponent => BridgeError.MissingData,
+        error.UnknownKey, error.UnknownModifier, error.DuplicateModifier => BridgeError.InvalidParameter,
+        error.ModifierRequired => BridgeError.InvalidParameter,
+    };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+/// A platform that hands out increasing fake refs and records every call, so
+/// tests can assert on what the system was actually asked to reserve.
+const FakePlatform = struct {
+    var registrations: usize = 0;
+    var releases: usize = 0;
+    var last_keycode: u16 = 0;
+    var last_modifiers: u32 = 0;
+    var next_ref: usize = 0;
+    /// When set, `register` refuses — standing in for a key another app owns.
+    var refuse: bool = false;
+
+    fn reset() void {
+        registrations = 0;
+        releases = 0;
+        last_keycode = 0;
+        last_modifiers = 0;
+        next_ref = 0;
+        refuse = false;
+    }
+
+    fn register(keycode: u16, modifiers: u32, _: u32) Ref {
+        if (refuse) return null;
+        registrations += 1;
+        last_keycode = keycode;
+        last_modifiers = modifiers;
+        next_ref += 1;
+        return @ptrFromInt(next_ref);
+    }
+
+    fn unregister(ref: Ref) void {
+        if (ref != null) releases += 1;
+    }
+
+    fn platform() Platform {
+        return .{ .register = register, .unregister = unregister };
+    }
+};
+
+fn testRegistry() Registry {
+    FakePlatform.reset();
+    return Registry.init(std.testing.allocator, FakePlatform.platform());
+}
+
+test "registering reserves the key the accelerator names" {
+    var registry = testRegistry();
+    defer registry.deinit();
+
+    const entry = try registry.register(
+        \\{"id":"harness.summon","accelerator":"Cmd+Shift+H"}
+    );
+    try std.testing.expectEqualStrings("harness.summon", entry.id);
+    try std.testing.expectEqualStrings("Cmd+Shift+H", entry.accelerator);
+    try std.testing.expectEqual(@as(usize, 1), FakePlatform.registrations);
+    try std.testing.expectEqual(@as(u16, 0x04), FakePlatform.last_keycode);
+    try std.testing.expectEqual(@as(u32, 0x0100 | 0x0200), FakePlatform.last_modifiers);
+    try std.testing.expect(entry.ref != null);
+}
+
+test "a key the system will not give up is reported, not accepted" {
+    var registry = testRegistry();
+    defer registry.deinit();
+
+    FakePlatform.refuse = true;
+    try std.testing.expectError(
+        BridgeError.NativeCallFailed,
+        registry.register(
+            \\{"id":"spotlight","accelerator":"Cmd+Space"}
+        ),
+    );
+    // Nothing is left behind claiming to be registered.
+    try std.testing.expectEqual(@as(usize, 0), registry.count());
+    try std.testing.expect(!try registry.isRegistered(
+        \\{"id":"spotlight"}
+    ));
+}
+
+test "re-registering an id releases the key it used to hold" {
+    var registry = testRegistry();
+    defer registry.deinit();
+
+    _ = try registry.register(
+        \\{"id":"toggle","accelerator":"Cmd+Shift+H"}
+    );
+    _ = try registry.register(
+        \\{"id":"toggle","accelerator":"Cmd+Shift+J"}
+    );
+
+    try std.testing.expectEqual(@as(usize, 1), registry.count());
+    try std.testing.expectEqual(@as(usize, 2), FakePlatform.registrations);
+    // The old reservation must be handed back. Leaking it would keep
+    // Cmd+Shift+H dead system-wide with nothing left to release it.
+    try std.testing.expectEqual(@as(usize, 1), FakePlatform.releases);
+    try std.testing.expectEqualStrings("Cmd+Shift+J", registry.find("toggle").?.accelerator);
+}
+
+test "disabling gives the key back to the rest of the system" {
+    var registry = testRegistry();
+    defer registry.deinit();
+
+    _ = try registry.register(
+        \\{"id":"toggle","accelerator":"Cmd+Shift+H"}
+    );
+    try registry.setEnabled(
+        \\{"id":"toggle"}
+    , false);
+
+    try std.testing.expectEqual(@as(usize, 1), FakePlatform.releases);
+    try std.testing.expect(registry.find("toggle").?.ref == null);
+    try std.testing.expect(!registry.find("toggle").?.enabled);
+    // Still listed: disabled is not unregistered.
+    try std.testing.expect(try registry.isRegistered(
+        \\{"id":"toggle"}
+    ));
+}
+
+test "re-enabling takes the key back" {
+    var registry = testRegistry();
+    defer registry.deinit();
+
+    _ = try registry.register(
+        \\{"id":"toggle","accelerator":"Cmd+Shift+H"}
+    );
+    try registry.setEnabled(
+        \\{"id":"toggle"}
+    , false);
+    try registry.setEnabled(
+        \\{"id":"toggle"}
+    , true);
+
+    try std.testing.expectEqual(@as(usize, 2), FakePlatform.registrations);
+    try std.testing.expect(registry.find("toggle").?.ref != null);
+    try std.testing.expect(registry.find("toggle").?.enabled);
+}
+
+test "re-enabling a key someone else took in the meantime fails loudly" {
+    var registry = testRegistry();
+    defer registry.deinit();
+
+    _ = try registry.register(
+        \\{"id":"toggle","accelerator":"Cmd+Shift+H"}
+    );
+    try registry.setEnabled(
+        \\{"id":"toggle"}
+    , false);
+
+    FakePlatform.refuse = true;
+    try std.testing.expectError(BridgeError.NativeCallFailed, registry.setEnabled(
+        \\{"id":"toggle"}
+    , true));
+    // And it stays disabled rather than claiming to be on with no reservation.
+    try std.testing.expect(!registry.find("toggle").?.enabled);
+    try std.testing.expect(registry.find("toggle").?.ref == null);
+}
+
+test "enabling something already enabled does not double-reserve" {
+    var registry = testRegistry();
+    defer registry.deinit();
+
+    _ = try registry.register(
+        \\{"id":"toggle","accelerator":"Cmd+Shift+H"}
+    );
+    try registry.setEnabled(
+        \\{"id":"toggle"}
+    , true);
+    try std.testing.expectEqual(@as(usize, 1), FakePlatform.registrations);
+}
+
+test "unregistering releases the key and forgets the shortcut" {
+    var registry = testRegistry();
+    defer registry.deinit();
+
+    _ = try registry.register(
+        \\{"id":"toggle","accelerator":"Cmd+Shift+H"}
+    );
+    try registry.unregister(
+        \\{"id":"toggle"}
+    );
+    try std.testing.expectEqual(@as(usize, 0), registry.count());
+    try std.testing.expectEqual(@as(usize, 1), FakePlatform.releases);
+    try std.testing.expectError(BridgeError.NotFound, registry.unregister(
+        \\{"id":"toggle"}
+    ));
+}
+
+test "unregisterAll releases every reservation" {
+    var registry = testRegistry();
+    defer registry.deinit();
+
+    _ = try registry.register(
+        \\{"id":"a","accelerator":"Cmd+Shift+A"}
+    );
+    _ = try registry.register(
+        \\{"id":"b","accelerator":"Cmd+Shift+B"}
+    );
+    _ = try registry.register(
+        \\{"id":"c","accelerator":"Cmd+Shift+C"}
+    );
+    registry.unregisterAll();
+
+    try std.testing.expectEqual(@as(usize, 0), registry.count());
+    try std.testing.expectEqual(@as(usize, 3), FakePlatform.releases);
+}
+
+test "a disabled shortcut is released once, not twice" {
+    // Double-releasing an already-freed EventHotKeyRef is a use-after-free
+    // against Carbon's own table.
+    var registry = testRegistry();
+    defer registry.deinit();
+
+    _ = try registry.register(
+        \\{"id":"toggle","accelerator":"Cmd+Shift+H"}
+    );
+    try registry.setEnabled(
+        \\{"id":"toggle"}
+    , false);
+    registry.unregisterAll();
+    try std.testing.expectEqual(@as(usize, 1), FakePlatform.releases);
+}
+
+test "each shortcut gets its own hotkey id" {
+    var registry = testRegistry();
+    defer registry.deinit();
+
+    const a = try registry.register(
+        \\{"id":"a","accelerator":"Cmd+Shift+A"}
+    );
+    const first_id = a.hotkey_id;
+    const b = try registry.register(
+        \\{"id":"b","accelerator":"Cmd+Shift+B"}
+    );
+    try std.testing.expect(first_id != b.hotkey_id);
+    try std.testing.expectEqualStrings("b", registry.findByHotkeyId(b.hotkey_id).?.id);
+    try std.testing.expect(registry.findByHotkeyId(9999) == null);
+}
+
+test "a pressed hotkey still resolves after other shortcuts are removed" {
+    // `findByHotkeyId` used to be an index into a list; removing an earlier
+    // entry would then deliver the wrong shortcut's callback.
+    var registry = testRegistry();
+    defer registry.deinit();
+
+    _ = try registry.register(
+        \\{"id":"first","accelerator":"Cmd+Shift+A"}
+    );
+    const second = try registry.register(
+        \\{"id":"second","accelerator":"Cmd+Shift+B"}
+    );
+    const second_hotkey = second.hotkey_id;
+
+    try registry.unregister(
+        \\{"id":"first"}
+    );
+    try std.testing.expectEqualStrings("second", registry.findByHotkeyId(second_hotkey).?.id);
+}
+
+test "the legacy key + modifiers payload still registers" {
+    var registry = testRegistry();
+    defer registry.deinit();
+
+    const entry = try registry.register(
+        \\{"id":"toggle","key":"Space","modifiers":{"cmd":true,"shift":true},"callback":"onToggle"}
+    );
+    try std.testing.expectEqualStrings("Cmd+Shift+Space", entry.accelerator);
+    try std.testing.expectEqual(key_codes.codeFor("Space").?, FakePlatform.last_keycode);
+}
+
+test "metaKey is command" {
+    var registry = testRegistry();
+    defer registry.deinit();
+
+    const entry = try registry.register(
+        \\{"id":"toggle","key":"K","modifiers":{"meta":true}}
+    );
+    try std.testing.expectEqualStrings("Cmd+K", entry.accelerator);
+}
+
+test "the legacy shape gets the same bare-key guard" {
+    var registry = testRegistry();
+    defer registry.deinit();
+
+    try std.testing.expectError(BridgeError.InvalidParameter, registry.register(
+        \\{"id":"toggle","key":"H"}
+    ));
+    try std.testing.expectEqual(@as(usize, 0), FakePlatform.registrations);
+}
+
+test "bad payloads are refused without reserving anything" {
+    var registry = testRegistry();
+    defer registry.deinit();
+
+    try std.testing.expectError(BridgeError.InvalidJSON, registry.register("not json"));
+    try std.testing.expectError(BridgeError.MissingData, registry.register(
+        \\{"accelerator":"Cmd+Shift+H"}
+    ));
+    try std.testing.expectError(BridgeError.MissingData, registry.register(
+        \\{"id":"x"}
+    ));
+    try std.testing.expectError(BridgeError.InvalidParameter, registry.register(
+        \\{"id":"x","accelerator":"Cmd+Nonsense"}
+    ));
+    try std.testing.expectError(BridgeError.InvalidParameter, registry.register(
+        \\{"id":"x","accelerator":"H"}
+    ));
+    try std.testing.expectEqual(@as(usize, 0), FakePlatform.registrations);
+    try std.testing.expectEqual(@as(usize, 0), registry.count());
+}
+
+test "actions naming an unknown id say so" {
+    var registry = testRegistry();
+    defer registry.deinit();
+
+    try std.testing.expectError(BridgeError.NotFound, registry.unregister(
+        \\{"id":"nope"}
+    ));
+    try std.testing.expectError(BridgeError.NotFound, registry.setEnabled(
+        \\{"id":"nope"}
+    , false));
+    try std.testing.expectError(BridgeError.MissingData, registry.unregister(
+        \\{}
+    ));
+}
+
+test "isRegistered answers in the shape the JS bridge reads" {
+    var registry = testRegistry();
+    defer registry.deinit();
+
+    _ = try registry.register(
+        \\{"id":"toggle","accelerator":"Cmd+Shift+H"}
+    );
+
+    const yes = try registry.isRegisteredJson(
+        \\{"id":"toggle"}
+    );
+    defer std.testing.allocator.free(yes);
+    try std.testing.expectEqualStrings("{\"value\":true}", yes);
+
+    const no = try registry.isRegisteredJson(
+        \\{"id":"other"}
+    );
+    defer std.testing.allocator.free(no);
+    try std.testing.expectEqualStrings("{\"value\":false}", no);
+}
+
+test "list answers in the shape the JS bridge reads" {
+    var registry = testRegistry();
+    defer registry.deinit();
+
+    const empty = try registry.listJson();
+    defer std.testing.allocator.free(empty);
+    try std.testing.expectEqualStrings("{\"shortcuts\":[]}", empty);
+
+    _ = try registry.register(
+        \\{"id":"toggle","accelerator":"cmd+shift+h"}
+    );
+    _ = try registry.register(
+        \\{"id":"quit","accelerator":"Ctrl+Alt+Backspace"}
+    );
+
+    const json = try registry.listJson();
+    defer std.testing.allocator.free(json);
+    try std.testing.expectEqualStrings(
+        "{\"shortcuts\":[" ++
+            "{\"id\":\"toggle\",\"accelerator\":\"Cmd+Shift+H\",\"key\":\"H\",\"enabled\":true}," ++
+            "{\"id\":\"quit\",\"accelerator\":\"Ctrl+Alt+Delete\",\"key\":\"Delete\",\"enabled\":true}" ++
+            "]}",
+        json,
+    );
+}
+
+test "an id full of quotes cannot break the reply out of its JSON" {
+    var registry = testRegistry();
+    defer registry.deinit();
+
+    _ = try registry.register(
+        \\{"id":"ev\"il\\","accelerator":"Cmd+Shift+H"}
+    );
+
+    const json = try registry.listJson();
+    defer std.testing.allocator.free(json);
+    // Re-parsing is the assertion: if the escaping were wrong this would fail
+    // or would silently yield a different id.
+    const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, json, .{});
+    defer parsed.deinit();
+    const list = parsed.value.object.get("shortcuts").?.array;
+    try std.testing.expectEqual(@as(usize, 1), list.items.len);
+    try std.testing.expectEqualStrings("ev\"il\\", list.items[0].object.get("id").?.string);
+}
+
+test "a disabled shortcut says so in the listing" {
+    var registry = testRegistry();
+    defer registry.deinit();
+
+    _ = try registry.register(
+        \\{"id":"toggle","accelerator":"Cmd+Shift+H"}
+    );
+    try registry.setEnabled(
+        \\{"id":"toggle"}
+    , false);
+
+    const json = try registry.listJson();
+    defer std.testing.allocator.free(json);
+    try std.testing.expect(std.mem.indexOf(u8, json, "\"enabled\":false") != null);
+}
+
+test "the triggered event carries the id and the canonical accelerator" {
+    const detail = try triggeredDetail(std.testing.allocator, "harness.summon", "Cmd+Shift+H");
+    defer std.testing.allocator.free(detail);
+    try std.testing.expectEqualStrings(
+        "{\"id\":\"harness.summon\",\"accelerator\":\"Cmd+Shift+H\"}",
+        detail,
+    );
+
+    const script = try eventScript(std.testing.allocator, "craft:shortcut", detail);
+    defer std.testing.allocator.free(script);
+    try std.testing.expectEqualStrings(
+        "if(window.dispatchEvent)window.dispatchEvent(new CustomEvent('craft:shortcut',{detail:{\"id\":\"harness.summon\",\"accelerator\":\"Cmd+Shift+H\"}}));",
+        script,
+    );
+}
+
+test "an id cannot break out of the event it is delivered in" {
+    // `'); doSomething(); //` in an id would otherwise run in every window.
+    const detail = try triggeredDetail(std.testing.allocator, "a'); alert(1); //", "Cmd+Shift+H");
+    defer std.testing.allocator.free(detail);
+    try std.testing.expect(std.mem.indexOf(u8, detail, "alert(1)") != null);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, detail, .{});
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings("a'); alert(1); //", parsed.value.object.get("id").?.string);
+
+    const script = try eventScript(std.testing.allocator, "craft:shortcut", detail);
+    defer std.testing.allocator.free(script);
+    // The single quotes that would have closed the event-name literal are
+    // still literal quotes inside a JSON string, not syntax.
+    try std.testing.expectEqualStrings(
+        "if(window.dispatchEvent)window.dispatchEvent(new CustomEvent('craft:shortcut',{detail:" ++
+            "{\"id\":\"a'); alert(1); //\",\"accelerator\":\"Cmd+Shift+H\"}}));",
+        script,
+    );
+}
+
+test "a quote in an id is escaped for the event, not just for the listing" {
+    const detail = try triggeredDetail(std.testing.allocator, "ev\"il", "Cmd+K");
+    defer std.testing.allocator.free(detail);
+    const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, detail, .{});
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings("ev\"il", parsed.value.object.get("id").?.string);
+}
+
+test "a refused registration names the shortcut it refused" {
+    const detail = try errorDetail(std.testing.allocator, "toggle", "NATIVE_CALL_FAILED", "Native API call failed");
+    defer std.testing.allocator.free(detail);
+    const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, detail, .{});
+    defer parsed.deinit();
+    try std.testing.expectEqualStrings("toggle", parsed.value.object.get("id").?.string);
+    try std.testing.expectEqualStrings("NATIVE_CALL_FAILED", parsed.value.object.get("code").?.string);
+}
+
+test "the unsupported platform refuses every registration" {
+    // What a build with no global-hotkey implementation gets: an honest error
+    // per call, rather than a shortcut that registers and never fires.
+    var registry = Registry.init(std.testing.allocator, unsupported_platform);
+    defer registry.deinit();
+
+    try std.testing.expectError(BridgeError.NativeCallFailed, registry.register(
+        \\{"id":"toggle","accelerator":"Cmd+Shift+H"}
+    ));
+    try std.testing.expectEqual(@as(usize, 0), registry.count());
+}

--- a/packages/zig/test/injected_js_test.zig
+++ b/packages/zig/test/injected_js_test.zig
@@ -16,7 +16,9 @@
 const std = @import("std");
 const js = @import("js");
 const testing = std.testing;
-const bridge_menu = @import("../src/bridge_menu.zig");
+const contracts = @import("bridge_contracts");
+const bridge_menu = contracts.menu;
+const shortcut_registry = contracts.shortcuts;
 
 // Supplied by build.zig as named imports — a test module cannot embed
 // files outside its own package path.
@@ -190,15 +192,36 @@ test "the bridge script parses" {
 ///
 /// Everything native would do with a posted message begins with these bytes,
 /// so capturing them is capturing the whole JS half of the contract.
+/// `addEventListener` and `dispatchEvent` are real rather than stubs, because
+/// half of what native sends the page arrives as an event — and a listener
+/// registered for a name nothing dispatches is exactly the failure being
+/// tested for.
 const WEBVIEW_HOST =
     \\var posted = [];
     \\window.webkit = { messageHandlers: { craft: { postMessage: function (m) { posted.push(m) } } } };
-    \\window.addEventListener = function () {};
-    \\window.removeEventListener = function () {};
-    \\window.dispatchEvent = function () { return true };
+    \\var listeners = {};
+    \\window.addEventListener = function (name, fn) { (listeners[name] = listeners[name] || []).push(fn) };
+    \\window.removeEventListener = function (name, fn) {
+    \\  var q = listeners[name] || [];
+    \\  var i = q.indexOf(fn);
+    \\  if (i >= 0) q.splice(i, 1);
+    \\};
+    \\window.dispatchEvent = function (e) {
+    \\  (listeners[e.type] || []).slice().forEach(function (fn) { fn(e) });
+    \\  return true;
+    \\};
     \\function CustomEvent(type, init) { this.type = type; this.detail = init && init.detail }
     \\var document = { readyState: 'complete', addEventListener: function () {} };
+    \\globalThis.setTimeout = function () { return 0 };
+    \\globalThis.clearTimeout = function () {};
 ;
+// The timer stubs are load-bearing rather than cosmetic. `_req` arms a
+// 30-second reaping timeout inside its Promise executor, so without a
+// `setTimeout` the executor throws a ReferenceError and every request-shaped
+// call rejects before it has posted anything — which is not a failure mode
+// worth reproducing in a test, and is invisible if you only ever exercise the
+// fire-and-forget half of the bridge. Stubs that never fire keep it
+// deterministic: these tests resolve their own calls explicitly.
 
 test "craft.menu.set posts what bridge_menu.zig's parser reads" {
     // The one path that matters, end to end and without a window: the real
@@ -276,4 +299,231 @@ test "an empty menu bar is a parse, not a failure" {
     defer parsed.deinit();
 
     try testing.expect(parsed.value.menus == null);
+}
+
+// =============================================================================
+// Global shortcuts (#47)
+// =============================================================================
+
+/// A registry over a platform that grants every key, so these tests are about
+/// the payload contract rather than about what the machine will hand over.
+const GrantingPlatform = struct {
+    var granted: usize = 0;
+
+    fn register(_: u16, _: u32, _: u32) shortcut_registry.Ref {
+        granted += 1;
+        return @ptrFromInt(granted);
+    }
+    fn unregister(_: shortcut_registry.Ref) void {}
+};
+
+fn grantingRegistry() shortcut_registry.Registry {
+    GrantingPlatform.granted = 0;
+    return shortcut_registry.Registry.init(testing.allocator, .{
+        .register = GrantingPlatform.register,
+        .unregister = GrantingPlatform.unregister,
+    });
+}
+
+test "craft.shortcuts.register posts what the native registry reads" {
+    // The mismatch that made #47 unfixable-looking: the JS side has always
+    // posted `{id, accelerator}` and the native side has always read `key` and
+    // `modifiers`, so every registration failed its own validation long before
+    // reaching the event monitor that was also never installed. Neither half
+    // was wrong on its own terms, and neither half's tests could see it.
+    var fx = try Fixture.init();
+    defer fx.deinit();
+    const ctx = fx.ctx;
+
+    _ = try ctx.evaluate(WEBVIEW_HOST);
+    _ = try ctx.evaluate(BRIDGE);
+    _ = try ctx.evaluate("window.craft.shortcuts.register('harness.summon', 'Cmd+Shift+H');");
+
+    try testing.expectEqualStrings("1", try fx.text("String(posted.length)"));
+    try testing.expectEqualStrings("shortcuts", try fx.text("posted[0].t"));
+    try testing.expectEqualStrings(shortcut_registry.action_register, try fx.text("posted[0].a"));
+
+    var registry = grantingRegistry();
+    defer registry.deinit();
+
+    const entry = try registry.register(try fx.text("posted[0].d"));
+    try testing.expectEqualStrings("harness.summon", entry.id);
+    try testing.expectEqualStrings("Cmd+Shift+H", entry.accelerator);
+    try testing.expectEqual(@as(u16, 0x04), entry.binding.keycode); // kVK_ANSI_H
+    try testing.expect(entry.binding.modifiers.cmd);
+    try testing.expect(entry.binding.modifiers.shift);
+}
+
+test "unregister, enable and disable post the id the registry looks up" {
+    var fx = try Fixture.init();
+    defer fx.deinit();
+    const ctx = fx.ctx;
+
+    _ = try ctx.evaluate(WEBVIEW_HOST);
+    _ = try ctx.evaluate(BRIDGE);
+    _ = try ctx.evaluate(
+        \\window.craft.shortcuts.register('toggle', 'Cmd+Shift+H');
+        \\window.craft.shortcuts.disable('toggle');
+        \\window.craft.shortcuts.enable('toggle');
+        \\window.craft.shortcuts.unregister('toggle');
+    );
+
+    var registry = grantingRegistry();
+    defer registry.deinit();
+
+    _ = try registry.register(try fx.text("posted[0].d"));
+    try testing.expectEqualStrings(shortcut_registry.action_disable, try fx.text("posted[1].a"));
+    try registry.setEnabled(try fx.text("posted[1].d"), false);
+    try testing.expectEqualStrings(shortcut_registry.action_enable, try fx.text("posted[2].a"));
+    try registry.setEnabled(try fx.text("posted[2].d"), true);
+    try testing.expectEqualStrings(shortcut_registry.action_unregister, try fx.text("posted[3].a"));
+    try registry.unregister(try fx.text("posted[3].d"));
+
+    try testing.expectEqual(@as(usize, 0), registry.count());
+}
+
+test "the reply to list is the shape the JS facade unwraps" {
+    // `list()` resolves through `__craftBridgeResult`, and native used to
+    // answer by calling `window.__craftShortcutList` — which nothing defines.
+    // The promise hung for the full 30-second request timeout and rejected.
+    var fx = try Fixture.init();
+    defer fx.deinit();
+    const ctx = fx.ctx;
+
+    _ = try ctx.evaluate(WEBVIEW_HOST);
+    _ = try ctx.evaluate(BRIDGE);
+    _ = try ctx.evaluate(
+        \\var listed = null;
+        \\window.craft.shortcuts.list().then(function (s) { listed = s });
+    );
+
+    var registry = grantingRegistry();
+    defer registry.deinit();
+    _ = try registry.register(
+        \\{"id":"toggle","accelerator":"Cmd+Shift+H"}
+    );
+
+    const reply = try registry.listJson();
+    defer testing.allocator.free(reply);
+
+    // Exactly what `sendResultToJS` evaluates in the page.
+    const script = try std.fmt.allocPrint(
+        testing.allocator,
+        "window.__craftBridgeResult('{s}',{s});",
+        .{ shortcut_registry.action_list, reply },
+    );
+    defer testing.allocator.free(script);
+    _ = try ctx.evaluate(script);
+
+    try testing.expectEqualStrings("1", try fx.text("String(listed.length)"));
+    try testing.expectEqualStrings("toggle", try fx.text("listed[0].id"));
+    try testing.expectEqualStrings("Cmd+Shift+H", try fx.text("listed[0].accelerator"));
+    try testing.expectEqualStrings("true", try fx.text("String(listed[0].enabled)"));
+}
+
+test "the reply to isRegistered is the shape the JS facade unwraps" {
+    var fx = try Fixture.init();
+    defer fx.deinit();
+    const ctx = fx.ctx;
+
+    _ = try ctx.evaluate(WEBVIEW_HOST);
+    _ = try ctx.evaluate(BRIDGE);
+    _ = try ctx.evaluate(
+        \\var answer = null;
+        \\window.craft.shortcuts.isRegistered('toggle').then(function (v) { answer = v });
+    );
+
+    var registry = grantingRegistry();
+    defer registry.deinit();
+    _ = try registry.register(
+        \\{"id":"toggle","accelerator":"Cmd+Shift+H"}
+    );
+
+    const reply = try registry.isRegisteredJson(
+        \\{"id":"toggle"}
+    );
+    defer testing.allocator.free(reply);
+
+    const script = try std.fmt.allocPrint(
+        testing.allocator,
+        "window.__craftBridgeResult('{s}',{s});",
+        .{ shortcut_registry.action_is_registered, reply },
+    );
+    defer testing.allocator.free(script);
+    _ = try ctx.evaluate(script);
+
+    try testing.expectEqualStrings("true", try fx.text("String(answer)"));
+}
+
+test "a triggered shortcut reaches the listener craft.shortcuts.on installs" {
+    // The third mismatch: native called `window.__craftShortcutCallback`,
+    // which nothing defines, while the JS side listened for `craft:shortcut`,
+    // which nothing dispatched. Both sides looked implemented.
+    var fx = try Fixture.init();
+    defer fx.deinit();
+    const ctx = fx.ctx;
+
+    _ = try ctx.evaluate(WEBVIEW_HOST);
+    _ = try ctx.evaluate(BRIDGE);
+    _ = try ctx.evaluate(
+        \\var fired = [];
+        \\window.craft.shortcuts.on(function (d) { fired.push(d.id + '@' + d.accelerator) });
+    );
+
+    // The exact bytes `deliver` evaluates in the page.
+    const detail = try shortcut_registry.triggeredDetail(testing.allocator, "harness.summon", "Cmd+Shift+H");
+    defer testing.allocator.free(detail);
+    const script = try shortcut_registry.eventScript(testing.allocator, "craft:shortcut", detail);
+    defer testing.allocator.free(script);
+    _ = try ctx.evaluate(script);
+
+    try testing.expectEqualStrings("harness.summon@Cmd+Shift+H", try fx.text("fired.join('|')"));
+}
+
+test "a refused registration reaches craft.shortcuts.onError" {
+    // `register` cannot be a request — its action name collides with other
+    // bridges' in the pending queue — so this event is the only way an app
+    // hears that the key it asked for belongs to someone else.
+    var fx = try Fixture.init();
+    defer fx.deinit();
+    const ctx = fx.ctx;
+
+    _ = try ctx.evaluate(WEBVIEW_HOST);
+    _ = try ctx.evaluate(BRIDGE);
+    _ = try ctx.evaluate(
+        \\var failures = [];
+        \\window.craft.shortcuts.onError(function (d) { failures.push(d.id + ':' + d.code) });
+    );
+
+    const detail = try shortcut_registry.errorDetail(
+        testing.allocator,
+        "harness.summon",
+        "NATIVE_CALL_FAILED",
+        "Native API call failed",
+    );
+    defer testing.allocator.free(detail);
+    const script = try shortcut_registry.eventScript(testing.allocator, "craft:shortcut:error", detail);
+    defer testing.allocator.free(script);
+    _ = try ctx.evaluate(script);
+
+    try testing.expectEqualStrings("harness.summon:NATIVE_CALL_FAILED", try fx.text("failures.join('|')"));
+}
+
+test "an accelerator the native side cannot bind is refused, not accepted" {
+    // A registration that can never fire is the worst of the three outcomes:
+    // the app waits forever for a key that was never reserved.
+    var fx = try Fixture.init();
+    defer fx.deinit();
+    const ctx = fx.ctx;
+
+    _ = try ctx.evaluate(WEBVIEW_HOST);
+    _ = try ctx.evaluate(BRIDGE);
+    _ = try ctx.evaluate("window.craft.shortcuts.register('oops', 'Cmd+Nonsense');");
+
+    var registry = grantingRegistry();
+    defer registry.deinit();
+    try testing.expectError(
+        error.InvalidParameter,
+        registry.register(try fx.text("posted[0].d")),
+    );
 }


### PR DESCRIPTION
Closes #47.

`window.craft.shortcuts.register()` reported success and then nothing ever happened. The issue names one cause; there turned out to be four, stacked in the same namespace, each individually fatal:

1. **No monitor was ever installed.** `setupGlobalMonitor` computed an `NSEventMask`, discarded it, logged `"Global monitor setup (polling mode)"` — there was no polling either — and returned. The matcher it was meant to feed was reachable only from `handleGlobalKeyEvent`, which had no callers anywhere in the tree.
2. **The payload shapes disagreed.** The JS bridge has always posted `{id, accelerator}`; the native side read `key` and `modifiers`. Every registration failed its own validation long before it reached the monitor that wasn't there.
3. **`isRegistered` and `list` answered into the void.** They called `__craftShortcutList` / `__craftShortcutRegistered`, which nothing defines, while the JS facade waited on `__craftBridgeResult`. Both promises hung for the full 30-second request timeout and then rejected.
4. **Triggering called an undefined global too.** `__craftShortcutCallback`, while the JS side listened for a `craft:shortcut` event nothing dispatched.

Breaks 2–4 are the same shape as #27/#29: two halves each correct on their own terms, disagreeing with each other, with tests on both sides that could not see it.

## The mechanism

Carbon's `RegisterEventHotKey`, as the issue suggests. It takes a plain C callback — no Objective-C block, which is where the previous attempt stopped — and unlike a `CGEventTap` it needs no Accessibility or Input Monitoring permission and only ever calls back for the exact combinations the app asked for. craft never sees any other keystroke.

Registration is by *physical key*, so a binding survives the user switching to Dvorak.

## Two behaviour decisions worth flagging

**A bare key is now refused** (`ModifierRequired`), function keys excepted. A global hotkey on `H` means no application on the system — craft's own windows included — ever sees the user type an h again. A failed registration is recoverable; that is not. Shift alone doesn't count, since Shift+H is how you type a capital H.

**`disable()` releases the key** rather than holding the reservation and dropping the event. The alternative would leave that combination dead in every other app for as long as craft ran.

## Verification

Beyond unit tests, I checked the Carbon binding against the live API, which turned out to matter:

```
handler installed: true
register -> anyopaque@100d1b430
duplicate register -> null           # a combination the process already holds is refused
after release, register -> non-null
```

That third line is why re-registering an id **must** release first — otherwise `register('toggle', 'Cmd+Shift+H')` twice (a page reload) silently fails the second time. The tests now pin it.

Delivery is covered by putting a real `EventRef` through Carbon's own dispatcher, which is the only way to find out whether the handler signature and the `EventHotKeyID` layout are what Carbon actually expects, short of pressing the key on a Mac:

```
fired = 42 (expect 42)
after foreign signature, fired = 0 (expect 0)
```

Control-checked: flipping the parameter type to a bogus FourCC fails that test rather than silently skipping. The one link I could not automate here is the OS's own key→hotkey matching — synthesizing the keystroke needs Accessibility permission this terminal doesn't have.

The JS↔native contract is now carried across the boundary in both directions in `injected_js_test.zig`, the way it already was for menus. Control check: reverting the JS half fails 5 of them.

While adding those I found `_req` throws a `ReferenceError` inside its Promise executor without a `setTimeout` — so the entire request-shaped half of the bridge had never been exercised headlessly. Stubbed and commented.

## Shape

Split so the parts are testable without an app, a window or a key press:

| file | what |
|---|---|
| `key_codes.zig` | name ↔ virtual keycode, one table read both ways |
| `accelerator.zig` | `"Cmd+Shift+H"` |
| `shortcut_registry.zig` | the lifecycle, against a fake platform |
| `macos_hotkey.zig` | Carbon |
| `bridge_shortcuts.zig` | now a thin adapter (556 lines → ~200) |

Linux and Windows refuse registration outright instead of accepting one that can never fire, and `craft.shortcuts.onError` carries a refusal back to the page. `register` cannot be a request — its action name collides with `serviceMenu`'s in the pending queue, and `enable`/`disable` with `autoLaunch`'s — so an event is the honest surface.

`bun test` 468 pass, `zig build test` clean, `tsc --noEmit` clean, pickier clean.