### PR TITLE
feat(cli): --app-name, so an app can be itself without packaging

### DIFF
--- a/packages/typescript/src/__tests__/app-name.test.ts
+++ b/packages/typescript/src/__tests__/app-name.test.ts
@@ -1,0 +1,63 @@
+/**
+ * `appName` — the name macOS shows in the menu bar (craft-native/craft#50).
+ *
+ * The App menu title and the About/Hide/Quit items come from
+ * `NSProcessInfo.processName`, which for a bare binary is the executable — so
+ * every app launched through the shared `craft` binary called itself "craft".
+ * The workaround downstream was to symlink the binary under the app's name and
+ * spawn through the symlink.
+ */
+
+import type { AppConfig } from '../types'
+import { describe, expect, it } from 'bun:test'
+
+async function argsFor(config: AppConfig): Promise<string[]> {
+  const { CraftApp } = await import('../index')
+  const app = new (CraftApp as unknown as { new (c: AppConfig): { buildArgs: () => string[] } })(config)
+  return (app as unknown as { buildArgs: () => string[] }).buildArgs()
+}
+
+function valueOf(args: string[], flag: string): string | undefined {
+  const index = args.indexOf(flag)
+  return index === -1 ? undefined : args[index + 1]
+}
+
+describe('appName', () => {
+  it('passes the name through to the binary', async () => {
+    const args = await argsFor({ appName: 'Harness', html: '<h1>hi</h1>' })
+    expect(valueOf(args, '--app-name')).toBe('Harness')
+  })
+
+  it('is absent when not configured, so the binary keeps its own default', async () => {
+    const args = await argsFor({ html: '<h1>hi</h1>' })
+    expect(args).not.toContain('--app-name')
+  })
+
+  it('is independent of the window title', async () => {
+    // A note-taking app is "Notes" in the menu bar whatever the open document
+    // has put in the title bar. Conflating the two is the reason `--title`
+    // could not be used for this.
+    const args = await argsFor({
+      appName: 'Notes',
+      window: { title: 'Untitled — edited' },
+    })
+    expect(valueOf(args, '--app-name')).toBe('Notes')
+    expect(valueOf(args, '--title')).toBe('Untitled — edited')
+  })
+
+  it('survives a name containing spaces as a single argument', async () => {
+    // argv, not a shell string: the name must arrive whole rather than as
+    // three arguments the parser would read as a URL.
+    const args = await argsFor({ appName: 'My Great App' })
+    expect(valueOf(args, '--app-name')).toBe('My Great App')
+    expect(args.filter(a => a === 'My Great App')).toHaveLength(1)
+  })
+
+  it('is emitted even in menubar-only mode', async () => {
+    // A menubar app has no window at all, and the App menu is the only place
+    // its name is ever shown — so this is the mode that needs it most.
+    const args = await argsFor({ appName: 'Hush', window: { menubarOnly: true } })
+    expect(valueOf(args, '--app-name')).toBe('Hush')
+    expect(args).toContain('--menubar-only')
+  })
+})

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -366,7 +366,13 @@ export class CraftApp {
 
   private buildArgs(): string[] {
     const args: string[] = []
-    const { window, html, url } = this.config
+    const { window, html, url, appName } = this.config
+
+    // Before the window options: this names the *app*, not the window, and
+    // the two are independent — a note-taking app is "Notes" in the menu bar
+    // whatever the open document has put in the title bar.
+    if (appName)
+      args.push('--app-name', appName)
 
     // Menubar-only mode doesn't need content
     if (!window?.menubarOnly) {

--- a/packages/typescript/src/types.ts
+++ b/packages/typescript/src/types.ts
@@ -539,6 +539,20 @@ export interface AppConfig {
   window?: WindowOptions
 
   /**
+   * The name macOS shows for the app: the App menu title, and the
+   * "About X" / "Hide X" / "Quit X" items.
+   *
+   * Without it those read the executable's name, so every app launched
+   * through the shared `craft` binary calls itself "craft" in the menu bar.
+   * A packaged `.app` gets this from `CFBundleName` instead; this is what
+   * gives a dev-mode app its identity back without a packaging step.
+   *
+   * Not the name `ps` and Activity Monitor show — that comes from the
+   * executable and cannot be changed from inside the process.
+   */
+  appName?: string
+
+  /**
    * Path to Craft binary (auto-detected if not provided)
    */
   craftPath?: string

--- a/packages/zig/src/cli.zig
+++ b/packages/zig/src/cli.zig
@@ -40,6 +40,12 @@ pub const WindowOptions = struct {
     // process. NSImage decodes everything Cocoa can render, so any common
     // raster format works; .icns is preferred for crispness across sizes.
     icon: ?[]const u8 = null,
+    // The name AppKit shows for the app: the App menu title and the
+    // "About X" / "Hide X" / "Quit X" items. Without it those read
+    // `NSProcessInfo.processName`, which for a bare binary is the executable
+    // — so every app launched through the shared `craft` binary called itself
+    // "craft". macOS only.
+    app_name: ?[]const u8 = null,
 };
 
 pub const CliError = error{
@@ -66,6 +72,7 @@ pub fn freeOptionStrings(allocator: std.mem.Allocator, options: *WindowOptions) 
     if (!std.mem.eql(u8, options.title, "Craft App")) allocator.free(options.title);
     if (options.sidebar_config) |s| allocator.free(s);
     if (options.icon) |s| allocator.free(s);
+    if (options.app_name) |s| allocator.free(s);
     if (options.eval_source) |s| allocator.free(s);
     if (options.eval_file) |s| allocator.free(s);
     options.* = WindowOptions{};
@@ -133,6 +140,7 @@ const BundleConfig = struct {
     html: ?[]const u8 = null,
     url: ?[]const u8 = null,
     title: ?[]const u8 = null,
+    appName: ?[]const u8 = null,
     width: ?u32 = null,
     height: ?u32 = null,
     icon: ?[]const u8 = null,
@@ -219,6 +227,7 @@ fn loadBundleConfig(allocator: std.mem.Allocator) ?WindowOptions {
     }
     if (cfg.url) |v| options.url = allocator.dupe(u8, v) catch null;
     if (cfg.title) |v| options.title = allocator.dupe(u8, v) catch options.title;
+    if (cfg.appName) |v| options.app_name = allocator.dupe(u8, v) catch null;
     if (cfg.icon) |v| options.icon = allocator.dupe(u8, v) catch null;
     applyScalarConfig(cfg, &options);
 
@@ -297,6 +306,23 @@ test "a manifest parses into the fields it names and no others" {
     // Absent stays null so `parseArgs` keeps craft's default rather than a zero.
     try std.testing.expect(parsed.value.url == null);
     try std.testing.expect(parsed.value.devTools == null);
+}
+
+test "a manifest can name the app without naming the window" {
+    // Two different strings: `title` is the window's, `appName` is the one in
+    // the menu bar. A packaged app usually gets the latter from CFBundleName,
+    // but a manifest may override it.
+    const source =
+        \\{"title":"Untitled — Hush","appName":"Hush"}
+    ;
+    const parsed = try std.json.parseFromSlice(BundleConfig, std.testing.allocator, source, .{
+        .ignore_unknown_fields = true,
+        .allocate = .alloc_always,
+    });
+    defer parsed.deinit();
+
+    try std.testing.expectEqualStrings("Untitled — Hush", parsed.value.title.?);
+    try std.testing.expectEqualStrings("Hush", parsed.value.appName.?);
 }
 
 test "unknown manifest keys are ignored rather than failing the launch" {
@@ -455,6 +481,10 @@ pub fn parseArgs(allocator: std.mem.Allocator, args: []const [:0]const u8) !Wind
             i += 1;
             if (i >= args.len) return CliError.MissingValue;
             options.icon = try allocator.dupe(u8, args[i]);
+        } else if (std.mem.eql(u8, arg, "--app-name")) {
+            i += 1;
+            if (i >= args.len) return CliError.MissingValue;
+            options.app_name = try allocator.dupe(u8, args[i]);
         } else if (!std.mem.startsWith(u8, arg, "--")) {
             // Treat as positional URL argument
             if (options.url == null) {
@@ -519,6 +549,8 @@ fn printHelp() void {
         \\      --sidebar-config <J> Sidebar JSON configuration
         \\      --sidebar-width <W>  Sidebar width in pixels (default: 220)
         \\      --icon <PATH>        Path to dock icon image (PNG/JPG/ICNS)
+        \\      --app-name <NAME>    Name in the menu bar and in About/Hide/Quit
+        \\                           (macOS; defaults to the executable name)
         \\
         \\Debugging:
         \\      --debug              Enable debug output
@@ -542,6 +574,7 @@ fn printHelp() void {
         \\  craft http://localhost:3000 --dark --hot-reload
         \\  craft http://localhost:3000 --system-tray --light
         \\  craft http://localhost:3000 --native-sidebar --sidebar-width 250
+        \\  craft http://localhost:3000 --app-name "My App"
         \\
         \\For more information, visit: https://github.com/home-lang/craft
         \\

--- a/packages/zig/src/macos.zig
+++ b/packages/zig/src/macos.zig
@@ -6162,8 +6162,35 @@ const default_menus = [_]DefaultMenu{
     .{ .title = "Window", .items = &window_menu_items, .is_windows_menu = true },
 };
 
+/// Set the name AppKit shows for this app.
+///
+/// `-[NSProcessInfo processName]` is what the App menu title and the
+/// "About X" / "Hide X" / "Quit X" items are built from, and for a bare binary
+/// it is the executable's name — so every app launched through the shared
+/// `craft` binary called itself "craft" in the menu bar. Setting it is the
+/// whole of `--app-name`, and it is what makes a dev-mode app look like itself
+/// without a packaging step.
+///
+/// Not the *kernel's* idea of the process name: `ps` and Activity Monitor read
+/// that from the executable, and nothing running inside the process can change
+/// it. Renaming there needs either a real `.app` bundle or an exec under a
+/// different name.
+///
+/// Must run before `createApplicationMenu`, which reads the name once.
+pub fn setProcessName(name: []const u8) void {
+    // An empty name would leave the menu bar with a blank App menu and no way
+    // to tell it apart from a missing one.
+    if (name.len == 0) return;
+
+    const NSProcessInfo = getClass("NSProcessInfo");
+    const info = msgSend0(NSProcessInfo, "processInfo");
+    if (info == null) return;
+    msgSendVoid1(info, "setProcessName:", createNSString(name));
+}
+
 /// The app's display name: `-[NSProcessInfo processName]`, which is the
-/// executable name for a bare binary and CFBundleName inside a `.app`.
+/// executable name for a bare binary, CFBundleName inside a `.app`, and
+/// whatever `--app-name` said if it was given.
 ///
 /// Copied into `buf` because the titles built from it are formatted, and a
 /// name too long to fit is reported as absent rather than truncated — a cut

--- a/packages/zig/src/minimal.zig
+++ b/packages/zig/src/minimal.zig
@@ -42,6 +42,12 @@ pub fn main(init: std.process.Init) !void {
         cli.freeOptionStrings(allocator, &owned);
     }
 
+    // Before anything builds a menu bar: `createApplicationMenu` reads the
+    // process name once, and both branches below reach it.
+    if (comptime builtin.os.tag == .macos) {
+        if (options.app_name) |name| craft.macos.setProcessName(name);
+    }
+
     // In benchmark mode, disable dev_tools for lower overhead
     const effective_dev_tools = if (options.benchmark) false else options.dev_tools;
 

--- a/packages/zig/test/cli_test.zig
+++ b/packages/zig/test/cli_test.zig
@@ -230,3 +230,51 @@ test "WindowOptions - all boolean flags true" {
     try testing.expect(options.hot_reload);
     try testing.expect(options.system_tray);
 }
+
+// =============================================================================
+// parseArgs
+// =============================================================================
+//
+// These drive the real parser rather than constructing a `WindowOptions` by
+// hand, which is what the tests above do. A flag that is declared but never
+// wired into the argument loop passes every struct-shaped test in this file
+// and does nothing at all on the command line.
+
+fn parse(args: []const [:0]const u8) !cli.WindowOptions {
+    return cli.parseArgs(testing.allocator, args);
+}
+
+fn freeOptions(options: *cli.WindowOptions) void {
+    cli.freeOptionStrings(testing.allocator, options);
+}
+
+test "parseArgs - --app-name is read and owned" {
+    var options = try parse(&.{ "craft", "--app-name", "Harness" });
+    defer freeOptions(&options);
+    try testing.expectEqualStrings("Harness", options.app_name.?);
+    // The window title is a separate thing and must not be touched by it.
+    try testing.expectEqualStrings("Craft App", options.title);
+}
+
+test "parseArgs - --app-name and --title are independent" {
+    var options = try parse(&.{ "craft", "--app-name", "Hush", "--title", "Untitled" });
+    defer freeOptions(&options);
+    try testing.expectEqualStrings("Hush", options.app_name.?);
+    try testing.expectEqualStrings("Untitled", options.title);
+}
+
+test "parseArgs - --app-name defaults to absent" {
+    var options = try parse(&.{ "craft", "http://localhost:3000" });
+    defer freeOptions(&options);
+    try testing.expect(options.app_name == null);
+}
+
+test "parseArgs - --app-name without a value is an error, not a silent skip" {
+    try testing.expectError(cli.CliError.MissingValue, parse(&.{ "craft", "--app-name" }));
+}
+
+test "parseArgs - a name with spaces survives as one argument" {
+    var options = try parse(&.{ "craft", "--app-name", "My Great App" });
+    defer freeOptions(&options);
+    try testing.expectEqualStrings("My Great App", options.app_name.?);
+}


### PR DESCRIPTION
Closes #50.

The App menu title and the About/Hide/Quit items are built from `-[NSProcessInfo processName]`, which for a bare binary is the executable's name. Every app launched through the shared `craft` binary therefore called itself **craft** in the menu bar, and the only fix was to package a `.app` so `CFBundleName` answered instead.

`--app-name <NAME>` sets it directly. Also available as `appName` in `craft.json` and as `appName` on `AppConfig`.

## Verified against a real menu bar

Not just "the flag is parsed" — I built the default bar both ways and read the titles back out of AppKit:

```
default (no --app-name):
  menu[0] = tmp_menu_probe  [About tmp_menu_probe; Hide tmp_menu_probe; Hide Others; Show All; Quit tmp_menu_probe]
after --app-name Harness:
  menu[0] = Harness         [About Harness; Hide Harness; Hide Others; Show All; Quit Harness]
```

`setProcessName:` is set before `initPlatform()`, because `createApplicationMenu` reads the name once and both the windowed and the tray startup paths reach it.

## Two things worth flagging

**It does not touch `--title`.** The window's title and the app's name are different strings, and conflating them is exactly why `--title` could not already do this — a note-taking app is "Notes" in the menu bar whatever the open document has put in the title bar. There's a test pinning that they stay independent.

**It is the name AppKit shows, not the kernel's.** The issue mentions Activity Monitor; that one I can't deliver. `ps` and Activity Monitor read the process name from the executable, and nothing running inside the process can change it — renaming there still needs a real bundle or an exec under a different name (which is what the `namedAs()` symlink downstream was doing). The flag's own doc comment and the `AppConfig` JSDoc both say so rather than leaving it to be discovered.

## Tests

`test/cli_test.zig` gets its first tests that drive `parseArgs` rather than constructing a `WindowOptions` by hand. That distinction matters here: a flag declared in the struct but never wired into the argument loop passes every existing test in that file and does nothing at all on the command line. Control-checked — deleting the parse branch fails 4 of the 5 new tests, and deleting the `args.push` fails 4 of the 5 new TS ones.

`zig build test` clean, `bun test` 473 pass, `tsc --noEmit` clean, pickier clean.