### PR TITLE
feat(window): --frame-autosave, so windows come back where they were

### DIFF
--- a/packages/typescript/src/__tests__/frame-autosave.test.ts
+++ b/packages/typescript/src/__tests__/frame-autosave.test.ts
@@ -1,0 +1,56 @@
+/**
+ * `frameAutosave` — windows that remember where they were (craft-native/craft#52).
+ *
+ * There was no `setFrameAutosaveName:` anywhere in the tree, so every Craft
+ * window forgot its geometry on every launch. An app that wanted the standard
+ * behaviour had to wire `onResize`/`onMove` to its own storage and restore on
+ * next start, reimplementing badly what AppKit does in one call.
+ */
+
+import type { AppConfig } from '../types'
+import { describe, expect, it } from 'bun:test'
+
+async function argsFor(config: AppConfig): Promise<string[]> {
+  const { CraftApp } = await import('../index')
+  const app = new (CraftApp as unknown as { new (c: AppConfig): { buildArgs: () => string[] } })(config)
+  return (app as unknown as { buildArgs: () => string[] }).buildArgs()
+}
+
+function valueOf(args: string[], flag: string): string | undefined {
+  const index = args.indexOf(flag)
+  return index === -1 ? undefined : args[index + 1]
+}
+
+describe('frameAutosave', () => {
+  it('passes the autosave name through to the binary', async () => {
+    const args = await argsFor({ window: { frameAutosave: 'main' } })
+    expect(valueOf(args, '--frame-autosave')).toBe('main')
+  })
+
+  it('is absent when not configured, so nothing is remembered', async () => {
+    // The default has to stay "forgets its geometry": silently starting to
+    // persist frames would move existing apps' windows on upgrade.
+    const args = await argsFor({ window: { width: 900, height: 700 } })
+    expect(args).not.toContain('--frame-autosave')
+  })
+
+  it('coexists with explicit geometry rather than replacing it', async () => {
+    // The two are not alternatives. `width`/`height`/`x`/`y` are what the
+    // window opens at the first time, before there is any saved frame to
+    // restore — so both must reach the binary.
+    const args = await argsFor({
+      window: { frameAutosave: 'main', width: 900, height: 700, x: 40, y: 60 },
+    })
+    expect(valueOf(args, '--frame-autosave')).toBe('main')
+    expect(valueOf(args, '--width')).toBe('900')
+    expect(valueOf(args, '--height')).toBe('700')
+    expect(valueOf(args, '--x')).toBe('40')
+    expect(valueOf(args, '--y')).toBe('60')
+  })
+
+  it('survives a name containing spaces as a single argument', async () => {
+    const args = await argsFor({ window: { frameAutosave: 'Main Window' } })
+    expect(valueOf(args, '--frame-autosave')).toBe('Main Window')
+    expect(args.filter(a => a === 'Main Window')).toHaveLength(1)
+  })
+})

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -431,6 +431,10 @@ export class CraftApp {
     }
     if (window?.icon)
       args.push('--icon', window.icon)
+    // After the geometry flags, and independent of them: those are what the
+    // window opens at until there is a saved frame, which then wins.
+    if (window?.frameAutosave)
+      args.push('--frame-autosave', window.frameAutosave)
 
     if (window?.nativeSidebar) {
       args.push('--native-sidebar')

--- a/packages/typescript/src/types.ts
+++ b/packages/typescript/src/types.ts
@@ -58,6 +58,22 @@ export interface WindowOptions {
   title?: string
 
   /**
+   * Remember this window's size and position across launches, under this name
+   * (macOS).
+   *
+   * `width`/`height`/`x`/`y` become **first-launch defaults**: they are what
+   * the window opens at until there is a saved frame to restore, and the saved
+   * frame wins from then on. Without this the window forgets its geometry
+   * every launch, and an app that wants the standard behaviour has to wire
+   * `onResize`/`onMove` to its own storage and reimplement what AppKit does in
+   * one call.
+   *
+   * The name is the key AppKit stores under, so it must be stable across
+   * launches and distinct per window.
+   */
+  frameAutosave?: string
+
+  /**
    * Window width in pixels
    * @default 800
    */

--- a/packages/zig/src/cli.zig
+++ b/packages/zig/src/cli.zig
@@ -46,6 +46,9 @@ pub const WindowOptions = struct {
     // — so every app launched through the shared `craft` binary called itself
     // "craft". macOS only.
     app_name: ?[]const u8 = null,
+    // Name AppKit remembers this window's size and position under, so the app
+    // opens where the user last left it. Null means it forgets every launch.
+    frame_autosave: ?[]const u8 = null,
 };
 
 pub const CliError = error{
@@ -73,6 +76,7 @@ pub fn freeOptionStrings(allocator: std.mem.Allocator, options: *WindowOptions) 
     if (options.sidebar_config) |s| allocator.free(s);
     if (options.icon) |s| allocator.free(s);
     if (options.app_name) |s| allocator.free(s);
+    if (options.frame_autosave) |s| allocator.free(s);
     if (options.eval_source) |s| allocator.free(s);
     if (options.eval_file) |s| allocator.free(s);
     options.* = WindowOptions{};
@@ -141,6 +145,7 @@ const BundleConfig = struct {
     url: ?[]const u8 = null,
     title: ?[]const u8 = null,
     appName: ?[]const u8 = null,
+    frameAutosave: ?[]const u8 = null,
     width: ?u32 = null,
     height: ?u32 = null,
     icon: ?[]const u8 = null,
@@ -228,6 +233,7 @@ fn loadBundleConfig(allocator: std.mem.Allocator) ?WindowOptions {
     if (cfg.url) |v| options.url = allocator.dupe(u8, v) catch null;
     if (cfg.title) |v| options.title = allocator.dupe(u8, v) catch options.title;
     if (cfg.appName) |v| options.app_name = allocator.dupe(u8, v) catch null;
+    if (cfg.frameAutosave) |v| options.frame_autosave = allocator.dupe(u8, v) catch null;
     if (cfg.icon) |v| options.icon = allocator.dupe(u8, v) catch null;
     applyScalarConfig(cfg, &options);
 
@@ -323,6 +329,19 @@ test "a manifest can name the app without naming the window" {
 
     try std.testing.expectEqualStrings("Untitled — Hush", parsed.value.title.?);
     try std.testing.expectEqualStrings("Hush", parsed.value.appName.?);
+}
+
+test "a manifest can ask for its window frame to be remembered" {
+    const source =
+        \\{"title":"Hush","frameAutosave":"main"}
+    ;
+    const parsed = try std.json.parseFromSlice(BundleConfig, std.testing.allocator, source, .{
+        .ignore_unknown_fields = true,
+        .allocate = .alloc_always,
+    });
+    defer parsed.deinit();
+
+    try std.testing.expectEqualStrings("main", parsed.value.frameAutosave.?);
 }
 
 test "unknown manifest keys are ignored rather than failing the launch" {
@@ -485,6 +504,10 @@ pub fn parseArgs(allocator: std.mem.Allocator, args: []const [:0]const u8) !Wind
             i += 1;
             if (i >= args.len) return CliError.MissingValue;
             options.app_name = try allocator.dupe(u8, args[i]);
+        } else if (std.mem.eql(u8, arg, "--frame-autosave")) {
+            i += 1;
+            if (i >= args.len) return CliError.MissingValue;
+            options.frame_autosave = try allocator.dupe(u8, args[i]);
         } else if (!std.mem.startsWith(u8, arg, "--")) {
             // Treat as positional URL argument
             if (options.url == null) {
@@ -551,6 +574,10 @@ fn printHelp() void {
         \\      --icon <PATH>        Path to dock icon image (PNG/JPG/ICNS)
         \\      --app-name <NAME>    Name in the menu bar and in About/Hide/Quit
         \\                           (macOS; defaults to the executable name)
+        \\      --frame-autosave <NAME>
+        \\                           Remember window size and position across
+        \\                           launches under NAME (macOS). --width/--height/
+        \\                           --x/--y become first-launch defaults.
         \\
         \\Debugging:
         \\      --debug              Enable debug output
@@ -575,6 +602,7 @@ fn printHelp() void {
         \\  craft http://localhost:3000 --system-tray --light
         \\  craft http://localhost:3000 --native-sidebar --sidebar-width 250
         \\  craft http://localhost:3000 --app-name "My App"
+        \\  craft http://localhost:3000 --frame-autosave main
         \\
         \\For more information, visit: https://github.com/home-lang/craft
         \\

--- a/packages/zig/src/macos.zig
+++ b/packages/zig/src/macos.zig
@@ -92,6 +92,10 @@ pub const WindowStyle = struct {
     web_sidebar_width: u32 = 286,
     web_sidebar_material_opacity: f64 = 0.78,
     benchmark: bool = false, // Benchmark mode: skip bridge setup for fastest window creation
+    /// Name under which AppKit remembers this window's frame across launches.
+    /// Null leaves the window forgetting its geometry every time, which is
+    /// what craft did until now.
+    frame_autosave: ?[]const u8 = null,
 };
 
 // Helper functions for Objective-C runtime
@@ -525,6 +529,29 @@ fn getBorderlessWindowClass() objc.Class {
     return BorderlessWindowClass;
 }
 
+/// Remember this window's size and position across launches, under `name`.
+///
+/// Two calls, in this order, and the order is the whole design:
+///
+///   1. `setFrameUsingName:` restores a saved frame if there is one. It
+///      returns NO and leaves the window alone if there is not — which is
+///      what makes `--width/--height/--x/--y` behave as first-launch defaults
+///      rather than as an override that would defeat the point.
+///   2. `setFrameAutosaveName:` starts saving on every subsequent change.
+///
+/// Measured rather than assumed: `setFrameAutosaveName:` does *not* write the
+/// current frame when it is set, so enabling it after the restore cannot
+/// clobber what was restored.
+///
+/// Called after the centring above, so a remembered frame wins over being
+/// centred — an app the user has placed should come back where they put it.
+fn applyFrameAutosave(window: objc.id, name: []const u8) void {
+    if (name.len == 0) return;
+    const key = createNSString(name);
+    _ = msgSend1(window, "setFrameUsingName:", key);
+    _ = msgSend1(window, "setFrameAutosaveName:", key);
+}
+
 pub fn createWindow(title: []const u8, width: u32, height: u32, html: []const u8) !objc.id {
     return createWindowWithStyle(title, width, height, html, null, .{});
 }
@@ -909,6 +936,8 @@ pub fn createWindowWithStyle(title: []const u8, width: u32, height: u32, html: ?
         if (style.x == null or style.y == null) {
             msgSendVoid0(window, "center");
         }
+
+        if (style.frame_autosave) |name| applyFrameAutosave(window, name);
 
         // Enter fullscreen if requested
         if (style.fullscreen) {
@@ -2136,6 +2165,8 @@ pub fn createWindowWithSidebar(
         msgSendVoid0(window, "center");
     }
 
+    if (style.frame_autosave) |name| applyFrameAutosave(window, name);
+
     // Store references
     if (webview) |wv| {
         setGlobalWebView(wv);
@@ -3326,6 +3357,8 @@ pub fn createWindowWithSidebarURL(
     if (style.x == null or style.y == null) {
         msgSendVoid0(window, "center");
     }
+
+    if (style.frame_autosave) |name| applyFrameAutosave(window, name);
 
     // Store references
     if (webview) |wv| {

--- a/packages/zig/src/main.zig
+++ b/packages/zig/src/main.zig
@@ -104,6 +104,10 @@ pub const WindowStyle = if (builtin.os.tag == .macos) macos.WindowStyle else str
     web_sidebar_width: u32 = 286,
     web_sidebar_material_opacity: f64 = 0.78,
     benchmark: bool = false,
+    /// Accepted so `minimal.zig` can pass one `WindowStyle` on every platform,
+    /// and ignored: remembering a window frame is `setFrameAutosaveName:`, an
+    /// AppKit facility with no counterpart wired up on GTK or Win32 yet.
+    frame_autosave: ?[]const u8 = null,
 };
 
 pub const Window = struct {

--- a/packages/zig/src/minimal.zig
+++ b/packages/zig/src/minimal.zig
@@ -112,6 +112,7 @@ pub fn main(init: std.process.Init) !void {
                 .dev_tools = effective_dev_tools,
                 .native_sidebar = true,
                 .benchmark = options.benchmark,
+                .frame_autosave = options.frame_autosave,
             },
         );
     } else if (options.native_sidebar and options.html != null) {
@@ -149,6 +150,7 @@ pub fn main(init: std.process.Init) !void {
                 .dev_tools = effective_dev_tools,
                 .native_sidebar = true,
                 .benchmark = options.benchmark,
+                .frame_autosave = options.frame_autosave,
             },
         );
     } else if (options.url) |url| {
@@ -188,6 +190,7 @@ pub fn main(init: std.process.Init) !void {
                 .system_tray = options.system_tray,
                 .dev_tools = effective_dev_tools,
                 .benchmark = options.benchmark,
+                .frame_autosave = options.frame_autosave,
                 .web_sidebar_material = options.web_sidebar_material,
                 .web_sidebar_width = options.web_sidebar_width,
                 .web_sidebar_material_opacity = options.web_sidebar_material_opacity,
@@ -221,6 +224,7 @@ pub fn main(init: std.process.Init) !void {
                 .system_tray = options.system_tray,
                 .dev_tools = effective_dev_tools,
                 .benchmark = options.benchmark,
+                .frame_autosave = options.frame_autosave,
                 .web_sidebar_material = options.web_sidebar_material,
                 .web_sidebar_width = options.web_sidebar_width,
                 .web_sidebar_material_opacity = options.web_sidebar_material_opacity,
@@ -412,6 +416,7 @@ fn runWithSystemTray(allocator: std.mem.Allocator, options: cli.WindowOptions) !
                     .titlebar_hidden = options.titlebar_hidden,
                     .system_tray = options.system_tray,
                     .dev_tools = options.dev_tools,
+                    .frame_autosave = options.frame_autosave,
                 },
             );
         } else if (options.html) |html| {
@@ -434,6 +439,7 @@ fn runWithSystemTray(allocator: std.mem.Allocator, options: cli.WindowOptions) !
                     .titlebar_hidden = options.titlebar_hidden,
                     .system_tray = options.system_tray,
                     .dev_tools = options.dev_tools,
+                    .frame_autosave = options.frame_autosave,
                 },
             );
         }

--- a/packages/zig/test/cli_test.zig
+++ b/packages/zig/test/cli_test.zig
@@ -278,3 +278,37 @@ test "parseArgs - a name with spaces survives as one argument" {
     defer freeOptions(&options);
     try testing.expectEqualStrings("My Great App", options.app_name.?);
 }
+
+test "parseArgs - --frame-autosave is read and owned" {
+    var options = try parse(&.{ "craft", "--frame-autosave", "main" });
+    defer freeOptions(&options);
+    try testing.expectEqualStrings("main", options.frame_autosave.?);
+}
+
+test "parseArgs - --frame-autosave defaults to absent" {
+    // Absent means the window forgets its geometry, which is what craft did
+    // before this flag existed and must keep doing for apps that never ask.
+    var options = try parse(&.{ "craft", "http://localhost:3000" });
+    defer freeOptions(&options);
+    try testing.expect(options.frame_autosave == null);
+}
+
+test "parseArgs - --frame-autosave leaves the explicit geometry alone" {
+    // The two are not alternatives: the geometry flags are what the window
+    // opens at the first time, before anything has been saved to restore.
+    var options = try parse(&.{
+        "craft",           "--frame-autosave", "main", "--width", "900",
+        "--height",        "700",              "--x",  "40",      "--y",
+        "60",
+    });
+    defer freeOptions(&options);
+    try testing.expectEqualStrings("main", options.frame_autosave.?);
+    try testing.expectEqual(@as(u32, 900), options.width);
+    try testing.expectEqual(@as(u32, 700), options.height);
+    try testing.expectEqual(@as(i32, 40), options.x.?);
+    try testing.expectEqual(@as(i32, 60), options.y.?);
+}
+
+test "parseArgs - --frame-autosave without a value is an error, not a silent skip" {
+    try testing.expectError(cli.CliError.MissingValue, parse(&.{ "craft", "--frame-autosave" }));
+}


### PR DESCRIPTION
Closes #52.

There was no `setFrameAutosaveName:` anywhere in the tree — the only `setAutosaveName:` calls were for the tray status item and split-view dividers. So every craft window forgot its size and position on every launch, and an app that wanted the standard behaviour had to wire `onResize`/`onMove` to its own storage and restore on next start, reimplementing badly what AppKit does in one call.

`--frame-autosave <NAME>`, `frameAutosave` in `craft.json`, `window.frameAutosave` on `AppConfig`. Wired into all six window-creation sites (windowed, tray, and both native-sidebar variants).

## The semantics the issue asked for fall out of the call order

`--width/--height/--x/--y` act as first-launch defaults rather than as an override. That works because of two facts I measured rather than assumed:

- `setFrameUsingName:` returns **NO** and leaves the window alone when nothing has been saved yet.
- `setFrameAutosaveName:` does **not** write the current frame when it is set.

So: centre/position → restore → enable. Restore after centring means a frame the user chose wins over being centred, which is the point.

## Verified through the real code path

Not the flag parser — `createWindowWithStyle` itself, webview and all:

```
first launch:  400x332 at 120,140    (the explicit geometry survives)
               defaults -> <absent>  (nothing is saved until it actually moves)
after moving:  defaults -> 700 400 640 480 0 0 1512 949
second launch: 640x480 at 700,400    (the remembered frame wins over the flags)
no flag:       400x332 at 120,140    (unchanged)
```

**Off by default**, deliberately: silently starting to persist frames would move existing apps' windows on upgrade.

## What isn't covered by a test

The AppKit half. Restoring a frame needs a real `NSWindow`, and a windowing test on a CI runner is a flakiness source I'd rather not add — the four lines above are the evidence, reproduced against the shipped path. What *is* tested is the flag reaching the binary intact and the geometry flags surviving alongside it, on both the Zig and TypeScript sides; control-checked, deleting either wiring fails the new tests.

`zig build test` clean, `bun test` 472 pass, `tsc --noEmit` clean, pickier clean.