### PR TITLE
feat(packaging): register the URL schemes an app declares

### DIFF
--- a/packages/typescript/src/package.test.ts
+++ b/packages/typescript/src/package.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from 'bun:test'
 import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { candleArguments, codesignArguments, dmgCapacityMegabytes, dmgCreateArguments, formatPackagingCommandError, macOSInfoPlist, notarytoolArguments, packageApp, pkgbuildArguments, pkgbuildComponentPlist, productbuildArguments, renderWixSource, shouldRetryHdiutil, windowsArchitecture, windowsExecutableName } from './package.js'
+import { candleArguments, codesignArguments, dmgCapacityMegabytes, dmgCreateArguments, formatPackagingCommandError, macOSInfoPlist, notarytoolArguments, packageApp, pkgbuildArguments, pkgbuildComponentPlist, productbuildArguments, renderWixSource, shouldRetryHdiutil, urlTypesEntry, windowsArchitecture, windowsExecutableName } from './package.js'
 
 describe('Windows MSI packaging', () => {
   it('renders a deterministic major-upgrade installer without shell interpolation', () => {
@@ -179,6 +179,33 @@ describe('macOS app bundle assembly', () => {
     expect(readFileSync(join(app!.outputPath!, 'Contents', 'Info.plist'), 'utf8')).toContain('LSUIElement')
   })
 
+  it('writes the declared URL schemes into the bundle it produces', async () => {
+    // The unit tests below prove `macOSInfoPlist` can render the key. This
+    // proves `packageApp` actually asks it to: `urlSchemes` existed as a
+    // config field that nothing read, so an app could declare a scheme,
+    // typecheck, package, and never receive a link (#53).
+    const dir = workDir()
+    const binaryPath = join(dir, 'app-bin')
+    writeFileSync(binaryPath, '#!/bin/sh\n')
+    chmodSync(binaryPath, 0o755)
+
+    const results = await packageApp({
+      name: 'Harness',
+      version: '1.0.0',
+      binaryPath,
+      bundleId: 'org.stacksjs.harness',
+      outDir: join(dir, 'out'),
+      platforms: ['macos'],
+      macos: { dmg: false, urlSchemes: ['harness'] },
+    })
+
+    const app = results.find(result => result.format === 'app')
+    expect(app?.success).toBe(true)
+    const plist = readFileSync(join(app!.outputPath!, 'Contents', 'Info.plist'), 'utf8')
+    expect(plist).toContain('<key>CFBundleURLTypes</key>')
+    expect(plist).toContain('<string>harness</string>')
+  })
+
   it('fails clearly when a helper executable is missing', async () => {
     const dir = workDir()
     const binaryPath = join(dir, 'app-bin')
@@ -232,6 +259,69 @@ describe('macOS app bundle metadata', () => {
   it('escapes metadata rather than emitting malformed plist markup', () => {
     expect(macOSInfoPlist({ name: 'Stacks & Co', version: '1.0.0', bundleId: 'com.example.app' }))
       .toContain('<string>Stacks &amp; Co</string>')
+  })
+})
+
+describe('macOS URL schemes', () => {
+  // Craft's receive path was complete — a `kAEGetURL` AppleEvent handler, a
+  // buffer for a URL that arrives before the page loads — and nothing could
+  // ever cause macOS to send one, because no bundle craft produced declared a
+  // scheme. An app could set `urlSchemes`, typecheck, package, and never
+  // receive a link.
+  const base = { name: 'Harness', version: '1.0.0', bundleId: 'org.stacksjs.harness' }
+
+  it('declares the schemes an app handles', () => {
+    const plist = macOSInfoPlist({ ...base, urlSchemes: ['harness'] })
+    expect(plist).toContain('<key>CFBundleURLTypes</key>')
+    expect(plist).toContain('<string>harness</string>')
+    // The URL type has to be named, and the bundle id is the one identifier
+    // guaranteed unique to this app.
+    expect(plist).toContain('<key>CFBundleURLName</key>\n        <string>org.stacksjs.harness</string>')
+    expect(plist).toContain('<key>CFBundleTypeRole</key>\n        <string>Viewer</string>')
+  })
+
+  it('puts several schemes in one URL type', () => {
+    // They are alternative ways to reach the same app, not different kinds of
+    // document — splitting them across dicts would invent a distinction
+    // LaunchServices does not make.
+    const plist = macOSInfoPlist({ ...base, urlSchemes: ['harness', 'harness-dev'] })
+    expect(plist.match(/<key>CFBundleURLSchemes<\/key>/g)).toHaveLength(1)
+    expect(plist).toContain('<string>harness</string>')
+    expect(plist).toContain('<string>harness-dev</string>')
+  })
+
+  it('emits nothing at all when an app handles no schemes', () => {
+    // Every app packaged before this key existed must keep producing the same
+    // plist, and an empty array is a caller saying "none", not "broken".
+    expect(macOSInfoPlist(base)).not.toContain('CFBundleURLTypes')
+    expect(macOSInfoPlist({ ...base, urlSchemes: [] })).not.toContain('CFBundleURLTypes')
+  })
+
+  it('collapses schemes that differ only in case', () => {
+    // LaunchServices matches case-insensitively, so `Harness` and `harness`
+    // are one scheme declared twice.
+    const entry = urlTypesEntry(base.bundleId, ['harness', 'Harness'])!
+    expect(entry.match(/<string>[Hh]arness<\/string>/g)).toHaveLength(1)
+    expect(entry).toContain('<string>harness</string>')
+  })
+
+  it('refuses a scheme macOS would silently ignore', () => {
+    // The failure this prevents is invisible: LaunchServices drops a malformed
+    // scheme, the app installs and runs, and links simply never arrive.
+    expect(() => macOSInfoPlist({ ...base, urlSchemes: ['1harness'] })).toThrow(/Invalid URL scheme/)
+    expect(() => macOSInfoPlist({ ...base, urlSchemes: ['my app'] })).toThrow(/Invalid URL scheme/)
+    expect(() => macOSInfoPlist({ ...base, urlSchemes: ['harness://'] })).toThrow(/Invalid URL scheme/)
+    expect(() => macOSInfoPlist({ ...base, urlSchemes: [''] })).toThrow(/Invalid URL scheme/)
+    // RFC 3986 allows these three inside a scheme, and apps do use them.
+    expect(() => macOSInfoPlist({ ...base, urlSchemes: ['x-harness.dev+beta'] })).not.toThrow()
+  })
+
+  it('escapes a bundle id rather than emitting malformed markup', () => {
+    expect(urlTypesEntry('com.example.a&b', ['harness'])).toContain('<string>com.example.a&amp;b</string>')
+  })
+
+  it('returns null rather than an empty array for no schemes', () => {
+    expect(urlTypesEntry('com.example.app', [])).toBeNull()
   })
 })
 

--- a/packages/typescript/src/package.ts
+++ b/packages/typescript/src/package.ts
@@ -215,6 +215,21 @@ export interface PackageConfig {
      * the helper lands next to `process.execPath`.
      */
     additionalExecutables?: string[]
+
+    /**
+     * URL schemes the app registers as a handler for — `['myapp']` makes
+     * `myapp://…` open it.
+     *
+     * Emitted as `CFBundleURLTypes`. Without this key macOS never dispatches
+     * a URL to the app at all, so Craft's receive path (the `kAEGetURL`
+     * AppleEvent handler behind `craft.deepLink`) can be fully working and
+     * still never hear anything.
+     *
+     * Schemes are matched case-insensitively by LaunchServices and are
+     * global to the machine: pick something specific to the app, not `app`
+     * or `open`.
+     */
+    urlSchemes?: string[]
   }
 
   /** Windows-specific options */
@@ -341,6 +356,7 @@ async function packageMacOS(config: PackageConfig, outDir: string): Promise<Pack
     category: opts.category,
     minimumSystemVersion: opts.minimumSystemVersion,
     menuBarOnly: opts.menuBarOnly,
+    urlSchemes: opts.urlSchemes,
     binaryPath: config.binaryPath,
     iconPath: config.iconPath,
     provisioningProfile: opts.provisioningProfile,
@@ -594,6 +610,60 @@ export interface MacOSBundleMetadata {
   minimumSystemVersion?: string
   /** Sets `LSUIElement` — no Dock icon, no app switcher entry */
   menuBarOnly?: boolean
+  /** URL schemes the app handles, emitted as `CFBundleURLTypes` */
+  urlSchemes?: string[]
+}
+
+/**
+ * A URL scheme, as RFC 3986 defines one: a letter, then letters, digits, `+`,
+ * `-` and `.`.
+ *
+ * Worth rejecting at package time rather than passing through, because the
+ * failure is otherwise invisible: LaunchServices ignores a malformed scheme,
+ * the app installs and runs, and links simply never arrive — which is the
+ * exact shape of bug this key exists to fix.
+ */
+const URL_SCHEME = /^[a-z][a-z0-9+.-]*$/i
+
+/**
+ * `CFBundleURLTypes` for the schemes an app handles, or `null` if it handles
+ * none.
+ *
+ * All the schemes go in one URL type. They are alternatives for reaching the
+ * same app, not different kinds of document, so splitting them across several
+ * dicts would only invent distinctions LaunchServices does not care about.
+ */
+export function urlTypesEntry(bundleId: string, schemes: readonly string[]): string | null {
+  const seen = new Set<string>()
+  const unique: string[] = []
+
+  for (const scheme of schemes) {
+    if (!URL_SCHEME.test(scheme))
+      throw new Error(`Invalid URL scheme ${JSON.stringify(scheme)}: must start with a letter and contain only letters, digits, "+", "-" or "."`)
+    // LaunchServices matches case-insensitively, so `MyApp` and `myapp` are
+    // one scheme declared twice.
+    const key = scheme.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    unique.push(scheme)
+  }
+
+  if (unique.length === 0) return null
+
+  const list = unique.map(scheme => `          <string>${xml(scheme)}</string>`).join('\n')
+  return `    <key>CFBundleURLTypes</key>
+    <array>
+      <dict>
+        <key>CFBundleURLName</key>
+        <string>${xml(bundleId)}</string>
+        <key>CFBundleTypeRole</key>
+        <string>Viewer</string>
+        <key>CFBundleURLSchemes</key>
+        <array>
+${list}
+        </array>
+      </dict>
+    </array>`
 }
 
 /**
@@ -618,9 +688,15 @@ export function macOSInfoPlist(metadata: MacOSBundleMetadata): string {
   if (metadata.minimumSystemVersion) entries.push(['LSMinimumSystemVersion', metadata.minimumSystemVersion])
   if (metadata.menuBarOnly) entries.push(['LSUIElement', true])
 
-  const body = entries
+  const scalars = entries
     .map(([key, value]) => `    <key>${xml(key)}</key>\n${value === true ? '    <true/>' : `    <string>${xml(value)}</string>`}`)
     .join('\n')
+
+  // Appended after the scalars rather than mixed in: it is the one entry whose
+  // value is not a string or a boolean, and keeping the simple mapping above
+  // simple is worth the extra line here.
+  const urlTypes = urlTypesEntry(metadata.bundleId, metadata.urlSchemes || [])
+  const body = urlTypes ? `${scalars}\n${urlTypes}` : scalars
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/packages/zig/src/macos_deep_link.zig
+++ b/packages/zig/src/macos_deep_link.zig
@@ -19,11 +19,15 @@ const keyDirectObject: u32 = 0x2D2D2D2D; // '----'
 
 /// Register an AppleEvent handler for `kAEGetURL` so the OS routes
 /// `myapp://...` URLs into our process whenever the user opens such a
-/// link (including the very first launch). Apps still need to declare
-/// their URL scheme in the bundle's `Info.plist` under
-/// `CFBundleURLTypes` for macOS to dispatch URLs at all — Craft can't
-/// do that for them, but with the handler installed the rest is
-/// automatic.
+/// link (including the very first launch).
+///
+/// This is only half of it. macOS dispatches a URL to an app because the
+/// app's bundle claims the scheme under `CFBundleURLTypes`, and nothing
+/// craft produced used to write that key — so this handler was complete,
+/// correct, and could never fire. `packageApp` now emits it from the
+/// `urlSchemes` an app declares; a bare binary with no bundle still cannot
+/// be a URL handler, because there is nothing for LaunchServices to
+/// register.
 ///
 /// macOS-only. Idempotent.
 pub fn install() void {


### PR DESCRIPTION
Closes #53.

The receive path was genuinely finished — `kAEGetURL` AppleEvent handler, delivery through `__craftDeliverDeepLink`, a buffer for a URL that arrives before the page loads — and it could never fire, because macOS only dispatches a URL to an app whose bundle claims the scheme under `CFBundleURLTypes`, and `macOSInfoPlist` emitted no such key. `urlSchemes` was a config field nothing read: an app could declare `['myapp']`, typecheck, package, and never receive a link.

## Verified against LaunchServices, not against the plist text

Two bundles, identical but for the key, registered and then asked `-[NSWorkspace URLForApplicationToOpenURL:]` for `craftlsprobe://pair?code=123`:

```
baseline                        HANDLER: <none>
registered WITHOUT urlSchemes   HANDLER: <none>     ← today
registered WITH urlSchemes      HANDLER: .../with.app
```

Both test bundles were unregistered and deleted afterwards; `lsregister -dump | grep -c dev.craft.lsprobe` → `0`.

Getting that probe to mean anything took two corrections worth recording, because both are silent:

- A bundle under `/private/tmp` is flagged **`in-temp-dir`** and its URL claims are ignored outright.
- A bundle whose `CFBundleExecutable` is a shell script is flagged **`launch-disabled`**, same result.

Either one produces exactly the same `<none>` as a missing key, which is a good illustration of why "the plist contains the string" is not evidence for this particular fix.

## Decisions

**One URL type, all schemes.** They are alternative ways to reach the same app, not different kinds of document; splitting them across dicts would invent a distinction LaunchServices does not make. `CFBundleURLName` is the bundle id — the one identifier guaranteed unique to the app.

**A malformed scheme is now a package-time error.** RFC 3986 syntax, checked. That failure is otherwise invisible in precisely the way this whole issue is about: LaunchServices drops the claim, the app installs and runs fine, and links never arrive.

**Case-insensitive dedup**, since that is how LaunchServices matches — `['harness', 'Harness']` is one scheme declared twice, not two.

**Nothing is emitted when no schemes are declared**, so every app packaged before this key existed produces a byte-identical plist.

## What I did not do

The issue also asks to "fail loudly if `deepLink.onUrl` is reachable but the bundle declares no schemes". I don't think that one is deliverable as stated: `craft.deepLink.onUrl` is a pure-JS event subscription that never reaches native, so nothing at package time or at runtime can see it. Detecting it properly needs the page to be able to ask the native side what is actually wired — which is #49.

Related, and still true after this PR: `MacOSConfig.urlSchemes` (`types.ts:1723`) remains unconsumed, because `CraftAppConfig`/`MacOSConfig` as a whole are exported types with no runtime path into `packageApp`. The field that now works is `PackageConfig.macos.urlSchemes`, which is what `packageApp` actually reads. Worth its own issue rather than being smuggled in here.

The `macos_deep_link.zig` doc comment saying craft "can't do that for them" has been updated, since it is no longer true.

`bun test` 476 pass, `zig build` clean, `tsc --noEmit` clean, pickier clean. Control-checked: deleting the `urlSchemes: opts.urlSchemes` wiring fails the integration test, and deleting the plist rendering fails three unit tests.