### PR TITLE
ci(lifecycle): run the packaging test as a path, not as a filter

### DIFF
--- a/.github/workflows/native-lifecycle.yml
+++ b/.github/workflows/native-lifecycle.yml
@@ -86,7 +86,19 @@ jobs:
           $bin.FullName | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Test packaging API
-        run: bun test packages/typescript/src/package.test.ts
+        # The leading `./` is load-bearing. Without it bun reads the argument as
+        # a *filter* and walks the repository looking for test files that match,
+        # and on a hoisted node_modules that walk runs out of file descriptors
+        # before it finds anything:
+        #
+        #   error: Cannot read file ".../packages/typescript/tsconfig.json": EMFILE
+        #
+        # which surfaces as a missing tsconfig rather than as a limit, and whose
+        # only job-level symptom is the artifact upload two steps later
+        # reporting "No files were found". With `./` bun opens the one file it
+        # was given: measured, the filter form needs >512 descriptors and the
+        # path form runs the same 19 tests in 64.
+        run: bun test ./packages/typescript/src/package.test.ts
 
       - name: Exercise native lifecycle
         run: bun scripts/native-lifecycle.ts --install


### PR DESCRIPTION
`Native Package Lifecycle` has been failing on PRs that touch packaging. This is the cause. It is not the fault of any of those PRs.

## What actually happens

```yaml
run: bun test packages/typescript/src/package.test.ts
```

bun reads that argument as a **filter**, not a path, and walks the repository looking for test files that match. On a hoisted `node_modules` the walk runs out of file descriptors before it finds anything:

```
error: Cannot read file "/Users/runner/work/craft/craft/packages/typescript": EMFILE
error: Cannot read file "/Users/runner/work/craft/craft/packages/typescript/tsconfig.json": EMFILE
##[error]Process completed with exit code 1
```

The fix is `./`:

```yaml
run: bun test ./packages/typescript/src/package.test.ts
```

Measured at a range of limits — the filter form needs **more than 512** descriptors, the path form runs the same 19 tests in **64**:

| `ulimit -n` | `bun test packages/…` | `bun test ./packages/…` |
|---|---|---|
| 64 | fail | **pass** |
| 128 | fail | **pass** |
| 256 | fail | **pass** |
| 512 | pass | pass |

## Why it took two attempts

My first fix was `ulimit -n 4096`, on the theory that the runner starts a step at 256 and the test genuinely needs ~500. That was wrong, and CI said so: the step ran with 4096 and failed anyway. Raising the soft limit does not stop the repository walk from exceeding what the process can actually have. Ruling it out is what led to the filter-vs-path difference.

## Why it was hard to read

Two signals, both pointing away:

- `Cannot read file … tsconfig.json` reads as a missing file, not a resource limit.
- The only job-level symptom is two steps later — `No files were found with the provided path: artifacts/native-lifecycle/…` — which points squarely at the artifact path, i.e. the most recently changed thing in that workflow, and entirely innocent.

It also failed intermittently rather than always, which cost a wasted rerun before I stopped calling it flaky: whether the walk trips depends on how much of `node_modules` is already open, so a cache-hit `bun install` (`Checked 397 installs … (no changes)`) survives where a fresh install of 351 packages does not.

`bun test --coverage` in `ci.yml` takes no filter argument and is unaffected; it is the only other `bun test` in the workflows.