### PR TITLE
feat(cli): --headless, and make DevTools reachable at all

### DIFF
--- a/docs/BRIDGE_API.md
+++ b/docs/BRIDGE_API.md
@@ -10,6 +10,7 @@ The Craft JavaScript Bridge provides a seamless interface for your web applicati
 - [Application Menu (macOS)](#application-menu-macos)
 - [Global Shortcuts (macOS)](#global-shortcuts-macos)
 - [Settings and Preferences (macOS)](#settings-and-preferences-macos)
+- [Headless mode](#headless-mode)
 - [Window API](#window-api)
 - [App API](#app-api)
 - [TypeScript Support](#typescript-support)
@@ -464,6 +465,61 @@ const { domain, readCommand } = await craft.prefs.info()
 craft namespaces its keys, so `clear()` and `keys()` cannot disturb the window
 positions and inspector state AppKit and WebKit keep in the same domain.
 
+## Headless mode
+
+`craft --headless` builds the window and never puts it on screen. The page
+loads, JavaScript runs, and the webview stays capturable — a snapshot taken
+after script has mutated the DOM reflects the mutation.
+
+```bash
+craft http://localhost:3000 --headless --timing
+```
+
+Also `headless: true` in `craft.json`, and `window.headless` on `AppConfig`.
+
+The motivating case is measurement: a perf loop that launches craft repeatedly
+no longer flashes a window at the operator each time, which is worth doing on
+its own terms.
+
+### What it cannot do
+
+**It does not animate.** An unshown window does not drive the compositor, so
+`requestAnimationFrame` stops after the first frame and page timers fall to
+roughly 1Hz. That means, silently:
+
+- CSS and JavaScript animations stay on frame one
+- canvas and WebGL render loops never advance
+- charting libraries that redraw on rAF show their initial state
+- "wait until the spinner stops" — implemented with `setInterval` — crawls
+
+Drive the page with explicit calls, and take readiness from load completion
+rather than from a polling loop inside the page. No invisible window
+configuration avoids this: what drives the compositor is the window being
+*unoccluded*, which needs activation, which means stealing focus and showing a
+Dock icon — a worse trade for the operator this mode exists to help.
+
+`--headless` and `--menubar-only` are contradictory (a menubar app has no
+window to hide) and passing both is an error rather than a silent no-op.
+
+### Inspecting a running window
+
+`craft --dev-tools` enables the Web Inspector and makes the webview appear in
+Safari's **Develop** menu.
+
+This flag is new because there was previously no way to turn DevTools *on*:
+the setting defaulted to off and the only flag, `--no-devtools`, set it off
+again. And even when it was enabled through `craft.json`, the inspector did not
+work on macOS 13.3 or later, which introduced `isInspectable` defaulting to
+`NO` — craft set only the older `developerExtrasEnabled`, which stopped being
+sufficient.
+
+It is a **debugging affordance, not automation**. It opens no port and prints
+no endpoint, because there is nothing to print: WebKit on macOS has no
+socket-based inspector server — an inspectable `WKWebView` holds no internet
+sockets at all — and `safaridriver` refuses to attach to anything that is not
+Safari. Driving a craft page from another process needs a control channel craft
+owns, which does not exist yet.
+
 ## Window API
 
 Control the application window from JavaScript.
@@ -697,6 +753,7 @@ async function onComplete() {
 | Tray Menu | 🚧 | 🚧 | 🚧 |
 | Window Control | ✅ | ✅ | ✅ |
 | Hide Dock Icon | ✅ | ➖ | ➖ |
+| Headless | ✅ | 🚧 | 🚧 |
 | Global Shortcuts | ✅ | 🚧 | 🚧 |
 | Settings… item | ✅ | 🚧 | 🚧 |
 | Preferences | ✅ | 🚧 | 🚧 |

--- a/packages/typescript/src/__tests__/headless.test.ts
+++ b/packages/typescript/src/__tests__/headless.test.ts
@@ -1,0 +1,56 @@
+/**
+ * `headless` and the DevTools flag (craft-native/craft#48).
+ *
+ * The issue is that there is no way to drive a craft window from outside the
+ * process, and that measurement loops had to spawn *visible* windows over and
+ * over — which the issue rightly calls hostile to photosensitive users.
+ */
+
+import type { AppConfig } from '../types'
+import { describe, expect, it } from 'bun:test'
+
+async function argsFor(config: AppConfig): Promise<string[]> {
+  const { CraftApp } = await import('../index')
+  const app = new (CraftApp as unknown as { new (c: AppConfig): { buildArgs: () => string[] } })(config)
+  return (app as unknown as { buildArgs: () => string[] }).buildArgs()
+}
+
+describe('headless', () => {
+  it('passes the flag through', async () => {
+    expect(await argsFor({ window: { headless: true } })).toContain('--headless')
+  })
+
+  it('is absent unless asked for', async () => {
+    expect(await argsFor({ window: { width: 900 } })).not.toContain('--headless')
+  })
+
+  it('does not change what the window is, only whether it is shown', async () => {
+    // A headless run has to build the same window a visible one would, or a
+    // measurement taken from it says nothing about the visible case.
+    const args = await argsFor({ window: { headless: true, width: 900, height: 700, title: 'T' } })
+    expect(args).toContain('--headless')
+    expect(args[args.indexOf('--width') + 1]).toBe('900')
+    expect(args[args.indexOf('--height') + 1]).toBe('700')
+    expect(args[args.indexOf('--title') + 1]).toBe('T')
+  })
+})
+
+describe('devTools', () => {
+  it('is pushed in both directions', async () => {
+    // The regression: the binary defaults DevTools off and had no flag that
+    // turned them on, so the SDK pushing only the negative meant `devTools:
+    // true` — what dev mode sets — silently did nothing.
+    expect(await argsFor({ window: { devTools: true } })).toContain('--dev-tools')
+    expect(await argsFor({ window: { devTools: false } })).toContain('--no-devtools')
+  })
+
+  it('always has an opinion, because the SDK fills one in', async () => {
+    // `window: {}` does not mean "unset": the SDK defaults `devTools` to
+    // `detectDevMode()`, so exactly one of the two flags is always sent. That
+    // is what makes the positive flag necessary — without it, dev mode asked
+    // for DevTools and got silence.
+    const args = await argsFor({ window: {} })
+    const sent = args.filter(a => a === '--dev-tools' || a === '--no-devtools')
+    expect(sent).toHaveLength(1)
+  })
+})

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -412,8 +412,13 @@ export class CraftApp {
       args.push('--dark')
     if (window?.hotReload)
       args.push('--hot-reload')
+    // Both directions. The binary defaults DevTools *off* and used to have no
+    // flag that turned them on, so pushing only the negative meant the SDK's
+    // `devTools: true` — which is what dev mode sets — silently did nothing.
     if (window?.devTools === false)
       args.push('--no-devtools')
+    else if (window?.devTools === true)
+      args.push('--dev-tools')
     if (window?.systemTray)
       args.push('--system-tray')
     if (window?.hideDockIcon)
@@ -422,6 +427,8 @@ export class CraftApp {
       args.push('--menubar-only')
     if (window?.titlebarHidden)
       args.push('--titlebar-hidden')
+    if (window?.headless)
+      args.push('--headless')
     if (window?.webSidebarMaterial) {
       args.push('--web-sidebar-material')
       if (window?.webSidebarWidth)

--- a/packages/typescript/src/types.ts
+++ b/packages/typescript/src/types.ts
@@ -58,6 +58,25 @@ export interface WindowOptions {
   title?: string
 
   /**
+   * Build the window without ever putting it on screen (macOS).
+   *
+   * The page loads and runs JavaScript exactly as it would visibly, and it
+   * remains capturable — a snapshot taken after script has mutated the DOM
+   * reflects the mutation.
+   *
+   * **It does not animate.** An unshown window does not drive the compositor,
+   * so `requestAnimationFrame` stops after one frame and page timers fall to
+   * roughly 1Hz. Anything that advances itself — CSS or canvas animation, a
+   * charting library redrawing on rAF, "wait until the spinner stops" — sees
+   * the first frame forever. Drive the page with explicit calls and take
+   * readiness from load completion, not from a polling loop inside the page.
+   *
+   * Contradicts `menubarOnly`, which has no window to hide; passing both is an
+   * error rather than a silent no-op.
+   */
+  headless?: boolean
+
+  /**
    * Remember this window's size and position across launches, under this name
    * (macOS).
    *

--- a/packages/zig/src/cli.zig
+++ b/packages/zig/src/cli.zig
@@ -40,6 +40,10 @@ pub const WindowOptions = struct {
     // process. NSImage decodes everything Cocoa can render, so any common
     // raster format works; .icns is preferred for crispness across sizes.
     icon: ?[]const u8 = null,
+    // Build the window and never put it on screen. The page still loads, still
+    // runs JavaScript, and can still be captured — what it loses is anything
+    // that advances itself; see `--help`.
+    headless: bool = false,
     // The name AppKit shows for the app: the App menu title and the
     // "About X" / "Hide X" / "Quit X" items. Without it those read
     // `NSProcessInfo.processName`, which for a bare binary is the executable
@@ -160,6 +164,7 @@ const BundleConfig = struct {
     hideDockIcon: ?bool = null,
     menubarOnly: ?bool = null,
     titlebarHidden: ?bool = null,
+    headless: ?bool = null,
 };
 
 /// Absolute path of the running executable's directory.
@@ -258,6 +263,7 @@ fn applyScalarConfig(cfg: BundleConfig, options: *WindowOptions) void {
     if (cfg.systemTray) |v| options.system_tray = v;
     if (cfg.hideDockIcon) |v| options.hide_dock_icon = v;
     if (cfg.titlebarHidden) |v| options.titlebar_hidden = v;
+    if (cfg.headless) |v| options.headless = v;
     // A menubar app with a dock icon and no tray is not a menubar app, so the
     // one flag sets all three rather than making every manifest repeat them.
     if (cfg.menubarOnly) |v| {
@@ -342,6 +348,22 @@ test "a manifest can ask for its window frame to be remembered" {
     defer parsed.deinit();
 
     try std.testing.expectEqualStrings("main", parsed.value.frameAutosave.?);
+}
+
+test "a manifest can ask to run headless" {
+    const source =
+        \\{"title":"Probe","headless":true}
+    ;
+    const parsed = try std.json.parseFromSlice(BundleConfig, std.testing.allocator, source, .{
+        .ignore_unknown_fields = true,
+        .allocate = .alloc_always,
+    });
+    defer parsed.deinit();
+    try std.testing.expect(parsed.value.headless.?);
+
+    var options = WindowOptions{};
+    applyScalarConfig(parsed.value, &options);
+    try std.testing.expect(options.headless);
 }
 
 test "unknown manifest keys are ignored rather than failing the launch" {
@@ -446,6 +468,14 @@ pub fn parseArgs(allocator: std.mem.Allocator, args: []const [:0]const u8) !Wind
             options.titlebar_hidden = true;
         } else if (std.mem.eql(u8, arg, "--debug")) {
             // Already handled in first pass
+        } else if (std.mem.eql(u8, arg, "--dev-tools") or std.mem.eql(u8, arg, "--devtools")) {
+            // Until this existed there was no way to turn DevTools *on*: the
+            // field defaults to false here, `--no-devtools` only sets it false
+            // again, and the only other writer was the bundle manifest. So the
+            // inspector was unreachable from the command line and from the SDK,
+            // which pushes `--no-devtools` when it wants them off and nothing
+            // when it wants them on.
+            options.dev_tools = true;
         } else if (std.mem.eql(u8, arg, "--no-devtools")) {
             options.dev_tools = false;
         } else if (std.mem.eql(u8, arg, "--dark")) {
@@ -458,6 +488,8 @@ pub fn parseArgs(allocator: std.mem.Allocator, args: []const [:0]const u8) !Wind
             options.system_tray = true;
         } else if (std.mem.eql(u8, arg, "--hide-dock-icon")) {
             options.hide_dock_icon = true;
+        } else if (std.mem.eql(u8, arg, "--headless")) {
+            options.headless = true;
         } else if (std.mem.eql(u8, arg, "--menubar-only")) {
             options.menubar_only = true;
             options.system_tray = true; // Menubar-only implies system tray
@@ -560,6 +592,8 @@ fn printHelp() void {
         \\      --system-tray        Show system tray icon
         \\      --hide-dock-icon     Hide dock icon (menubar-only mode, macOS)
         \\      --menubar-only       Menubar-only mode (no window, system tray only)
+        \\      --dev-tools          Enable WebKit DevTools and make the webview
+        \\                           inspectable from Safari's Develop menu
         \\      --no-devtools        Disable WebKit DevTools
         \\      --titlebar-hidden    Hide window titlebar
         \\      --native-sidebar     Use native macOS sidebar (Finder-style)
@@ -572,6 +606,13 @@ fn printHelp() void {
         \\      --sidebar-config <J> Sidebar JSON configuration
         \\      --sidebar-width <W>  Sidebar width in pixels (default: 220)
         \\      --icon <PATH>        Path to dock icon image (PNG/JPG/ICNS)
+        \\      --headless           Build the window without showing it (macOS).
+        \\                           The page loads and runs JavaScript as normal.
+        \\                           It does NOT animate: an unshown window does
+        \\                           not drive the compositor, so requestAnimation-
+        \\                           Frame stops after one frame and page timers
+        \\                           fall to roughly 1Hz. Drive the page with
+        \\                           explicit calls; do not wait for it to settle.
         \\      --app-name <NAME>    Name in the menu bar and in About/Hide/Quit
         \\                           (macOS; defaults to the executable name)
         \\      --frame-autosave <NAME>

--- a/packages/zig/src/macos.zig
+++ b/packages/zig/src/macos.zig
@@ -92,6 +92,13 @@ pub const WindowStyle = struct {
     web_sidebar_width: u32 = 286,
     web_sidebar_material_opacity: f64 = 0.78,
     benchmark: bool = false, // Benchmark mode: skip bridge setup for fastest window creation
+    /// Build the window and never put it on screen.
+    ///
+    /// Deliberately *not* folded into `benchmark`: that mode strips the user
+    /// content controller, the injected craft script, the message handler and
+    /// both webview globals, so nothing can talk to the page afterwards.
+    /// Headless needs the full construction path and one less call at the end.
+    headless: bool = false,
     /// Name under which AppKit remembers this window's frame across launches.
     /// Null leaves the window forgetting its geometry every time, which is
     /// what craft did until now.
@@ -390,6 +397,13 @@ pub fn msgSendFloat(target: anytype, selector: [*:0]const u8) f64 {
 }
 
 /// Message send that returns bool
+/// `-[NSObject respondsToSelector:]` and friends: a BOOL-returning message
+/// whose one argument is itself a selector.
+pub fn msgSendBool1Sel(target: anytype, selector: [*:0]const u8, arg: objc.SEL) bool {
+    const msg = @as(*const fn (@TypeOf(target), objc.SEL, objc.SEL) callconv(.c) bool, @ptrCast(&objc.objc_msgSend));
+    return msg(target, sel(selector), arg);
+}
+
 pub fn msgSendBool(target: anytype, selector: [*:0]const u8) bool {
     const msg = @as(*const fn (@TypeOf(target), objc.SEL) callconv(.c) bool, @ptrCast(&objc.objc_msgSend));
     return msg(target, sel(selector));
@@ -550,6 +564,30 @@ fn applyFrameAutosave(window: objc.id, name: []const u8) void {
     const key = createNSString(name);
     _ = msgSend1(window, "setFrameUsingName:", key);
     _ = msgSend1(window, "setFrameAutosaveName:", key);
+}
+
+/// Make a webview inspectable from Safari's Develop menu.
+///
+/// `developerExtrasEnabled` alone stopped being enough at macOS 13.3, which
+/// introduced `isInspectable` defaulting to **NO**. Measured on 26.3.1: a
+/// webview with `developerExtrasEnabled = YES` and nothing else reports
+/// `isInspectable = 0`, so craft's `--dev-tools` has been setting a preference
+/// with no effect for the whole of that range — while a comment in the View
+/// menu asserted the opposite.
+///
+/// Guarded by `respondsToSelector:` rather than a version check: the selector
+/// is absent before 13.3 and sending it unguarded would raise
+/// `doesNotRecognizeSelector`.
+///
+/// Note this is a *debugging affordance*, not automation. It puts the app in
+/// Safari's Develop menu; it opens no port and prints no endpoint. WebKit on
+/// macOS has no socket-based inspector server — verified by observing that an
+/// inspectable webview holds no internet sockets at all — so there is nothing
+/// for a WebDriver-style tool to attach to.
+fn setWebViewInspectable(webview: objc.id) void {
+    const selector = sel("setInspectable:");
+    if (!msgSendBool1Sel(webview, "respondsToSelector:", selector)) return;
+    msgSendVoid1(webview, "setInspectable:", true);
 }
 
 pub fn createWindow(title: []const u8, width: u32, height: u32, html: []const u8) !objc.id {
@@ -778,6 +816,9 @@ pub fn createWindowWithStyle(title: []const u8, width: u32, height: u32, html: ?
     // Create WKWebView with configuration
     const webview_alloc = msgSend0(WKWebView, "alloc");
     const webview = msgSend2(webview_alloc, "initWithFrame:configuration:", frame, config);
+    // `developerExtrasEnabled` above is necessary and, since macOS 13.3, not
+    // sufficient. See `setWebViewInspectable`.
+    if (style.dev_tools) setWebViewInspectable(webview);
     startup_timing.mark(.webview_created);
     // Start the load before any cosmetic setup.
     //
@@ -932,8 +973,10 @@ pub fn createWindowWithStyle(title: []const u8, width: u32, height: u32, html: ?
             setAppearance(window, is_dark);
         }
 
-        // Center window if no custom position specified
-        if (style.x == null or style.y == null) {
+        // Center window if no custom position specified. Not when headless:
+        // centring is positioning relative to a screen, and there is no screen
+        // in play.
+        if (!style.headless and (style.x == null or style.y == null)) {
             msgSendVoid0(window, "center");
         }
 
@@ -6237,8 +6280,10 @@ const edit_menu_items = [_]DefaultItem{
 
 /// Reload and Force Reload land on the focused WKWebView, which implements
 /// `reload:` and `reloadFromOrigin:` as action selectors. Dev consoles stay
-/// reachable by right-click when `dev_tools` is enabled (the webview sets
-/// `setInspectable:YES`).
+/// reachable by right-click when `dev_tools` is enabled — which needs both
+/// `developerExtrasEnabled` *and* `setInspectable:` since macOS 13.3. This
+/// comment used to claim the webview set the latter; nothing did, and the
+/// string appeared nowhere else in the repository.
 const view_menu_items = [_]DefaultItem{
     .{ .title = "Reload", .selector = menuRole("reload"), .key = "r" },
     .{ .title = "Force Reload", .selector = menuRole("forceReload"), .key = "r", .extra_modifiers = modifier_shift },
@@ -6442,6 +6487,17 @@ pub fn runApp() void {
 /// activation policy when launched outside an .app bundle, so the window
 /// stays behind other apps with no Dock icon and never becomes key.
 /// Tray/menubar apps must NOT call this — see the runApp() comment above.
+/// Run with no Dock icon and no app-switcher entry.
+///
+/// `NSApplicationActivationPolicyAccessory`, the same policy menubar apps use.
+/// For a headless run this is the difference between invisible and "invisible
+/// except for the icon bouncing in the Dock".
+pub fn setAccessoryActivationPolicy() void {
+    const NSApplication = getClass("NSApplication");
+    const app = msgSend0(NSApplication, "sharedApplication");
+    _ = msgSend1(app, "setActivationPolicy:", @as(c_long, 1));
+}
+
 pub fn activateWindowedApp() void {
     const NSApplication = getClass("NSApplication");
     const app = msgSend0(NSApplication, "sharedApplication");

--- a/packages/zig/src/main.zig
+++ b/packages/zig/src/main.zig
@@ -108,6 +108,9 @@ pub const WindowStyle = if (builtin.os.tag == .macos) macos.WindowStyle else str
     /// and ignored: remembering a window frame is `setFrameAutosaveName:`, an
     /// AppKit facility with no counterpart wired up on GTK or Win32 yet.
     frame_autosave: ?[]const u8 = null,
+    /// Same: not showing a window is a macOS-side decision about ordering and
+    /// activation, and GTK and Win32 have their own.
+    headless: bool = false,
 };
 
 pub const Window = struct {
@@ -182,6 +185,8 @@ pub const App = struct {
     system_trays: std.ArrayList(*SystemTray),
     bridge: ?*BridgeAPI = null,
     notifications: ?*Notifications = null,
+    /// Run without putting anything on screen. See `runMacOS`.
+    headless: bool = false,
 
     const Self = @This();
 
@@ -370,12 +375,31 @@ pub const App = struct {
             // Show windows if we don't have a system tray
             // If we have a system tray, windows were already shown in the correct order
             // (after tray creation) by the caller
-            if (self.system_tray == null) {
+            // Headless is these two calls not happening, and almost nothing
+            // else: `createWindowWithStyle` has never ordered its window on
+            // screen — that is `showAllWindows`'s job, and activation is what
+            // gives the process a Dock icon. Skip both and the window exists,
+            // loads, runs JavaScript and can be captured, without ever being
+            // drawn anywhere. Measured, including that a snapshot taken after
+            // JavaScript mutates the DOM reflects the mutation.
+            //
+            // What it costs is in `--help` and the docs, because it is not
+            // obvious and it is not recoverable: an unoccluded window is what
+            // drives the compositor, so `requestAnimationFrame` never fires a
+            // second time and page timers fall to about 1Hz. Anything that
+            // advances itself — animations, canvas loops, "wait for the
+            // spinner to stop" — sees frame one forever. Driving the page with
+            // explicit calls works; waiting for it to drive itself does not.
+            if (self.system_tray == null and !self.headless) {
                 macos.showAllWindows();
                 // Windowed app: claim regular activation (Dock icon, key
                 // window, foreground) — launching from a bare binary would
                 // otherwise leave the window buried with no Dock presence.
                 macos.activateWindowedApp();
+            } else if (self.headless) {
+                // No Dock icon and no app-switcher entry either; the point is
+                // to be invisible, and a bouncing Dock icon is not that.
+                macos.setAccessoryActivationPolicy();
             }
 
             // Now run the event loop

--- a/packages/zig/src/minimal.zig
+++ b/packages/zig/src/minimal.zig
@@ -48,6 +48,14 @@ pub fn main(init: std.process.Init) !void {
         if (options.app_name) |name| craft.macos.setProcessName(name);
     }
 
+    // A menubar-only app has no window by definition, so asking for both is a
+    // contradiction rather than a no-op. Saying so beats silently ignoring one
+    // of them and leaving the operator to work out which.
+    if (options.headless and options.menubar_only) {
+        std.debug.print("Error: --headless and --menubar-only are contradictory — a menubar app has no window to hide\n", .{});
+        std.process.exit(1);
+    }
+
     // In benchmark mode, disable dev_tools for lower overhead
     const effective_dev_tools = if (options.benchmark) false else options.dev_tools;
 
@@ -68,6 +76,7 @@ pub fn main(init: std.process.Init) !void {
     }
 
     var app = craft.App.init(allocator);
+    app.headless = options.headless;
     defer app.deinit();
 
     // Initialize platform FIRST (must be called before creating windows or system tray)
@@ -112,6 +121,7 @@ pub fn main(init: std.process.Init) !void {
                 .dev_tools = effective_dev_tools,
                 .native_sidebar = true,
                 .benchmark = options.benchmark,
+                .headless = options.headless,
                 .frame_autosave = options.frame_autosave,
             },
         );
@@ -150,6 +160,7 @@ pub fn main(init: std.process.Init) !void {
                 .dev_tools = effective_dev_tools,
                 .native_sidebar = true,
                 .benchmark = options.benchmark,
+                .headless = options.headless,
                 .frame_autosave = options.frame_autosave,
             },
         );
@@ -190,6 +201,7 @@ pub fn main(init: std.process.Init) !void {
                 .system_tray = options.system_tray,
                 .dev_tools = effective_dev_tools,
                 .benchmark = options.benchmark,
+                .headless = options.headless,
                 .frame_autosave = options.frame_autosave,
                 .web_sidebar_material = options.web_sidebar_material,
                 .web_sidebar_width = options.web_sidebar_width,
@@ -224,6 +236,7 @@ pub fn main(init: std.process.Init) !void {
                 .system_tray = options.system_tray,
                 .dev_tools = effective_dev_tools,
                 .benchmark = options.benchmark,
+                .headless = options.headless,
                 .frame_autosave = options.frame_autosave,
                 .web_sidebar_material = options.web_sidebar_material,
                 .web_sidebar_width = options.web_sidebar_width,
@@ -417,6 +430,7 @@ fn runWithSystemTray(allocator: std.mem.Allocator, options: cli.WindowOptions) !
                     .system_tray = options.system_tray,
                     .dev_tools = options.dev_tools,
                     .frame_autosave = options.frame_autosave,
+                    .headless = options.headless,
                 },
             );
         } else if (options.html) |html| {
@@ -440,6 +454,7 @@ fn runWithSystemTray(allocator: std.mem.Allocator, options: cli.WindowOptions) !
                     .system_tray = options.system_tray,
                     .dev_tools = options.dev_tools,
                     .frame_autosave = options.frame_autosave,
+                    .headless = options.headless,
                 },
             );
         }
@@ -461,7 +476,8 @@ fn runWithSystemTray(allocator: std.mem.Allocator, options: cli.WindowOptions) !
     // Using orderFront (in showWindows) prevents app activation which would hide the tray
     // IMPORTANT: We must show windows even in menubar-only mode to trigger WebView loading
     // Without this, the WebView won't load its HTML/JavaScript content
-    app.showWindows();
+    // The tray path shows its windows itself, after the status item exists.
+    if (!options.headless) app.showWindows();
 
     // Benchmark mode measures time-to-ready and exits. The windowed paths
     // already honour it; the tray path did not, so `--benchmark` on a menubar

--- a/packages/zig/test/cli_test.zig
+++ b/packages/zig/test/cli_test.zig
@@ -312,3 +312,61 @@ test "parseArgs - --frame-autosave leaves the explicit geometry alone" {
 test "parseArgs - --frame-autosave without a value is an error, not a silent skip" {
     try testing.expectError(cli.CliError.MissingValue, parse(&.{ "craft", "--frame-autosave" }));
 }
+
+test "parseArgs - --headless is off unless asked for" {
+    var options = try parse(&.{ "craft", "http://localhost:3000" });
+    defer freeOptions(&options);
+    try testing.expect(!options.headless);
+}
+
+test "parseArgs - --headless" {
+    var options = try parse(&.{ "craft", "--headless" });
+    defer freeOptions(&options);
+    try testing.expect(options.headless);
+}
+
+test "parseArgs - --headless leaves the window's own options alone" {
+    // Headless is about whether the window is shown, not about what it is.
+    // A headless run has to build the same window a visible one would, or a
+    // screenshot of it is not evidence about the visible case.
+    var options = try parse(&.{ "craft", "--headless", "--width", "900", "--height", "700", "--title", "T" });
+    defer freeOptions(&options);
+    try testing.expect(options.headless);
+    try testing.expectEqual(@as(u32, 900), options.width);
+    try testing.expectEqual(@as(u32, 700), options.height);
+    try testing.expectEqualStrings("T", options.title);
+}
+
+test "parseArgs - DevTools can be turned on" {
+    // The regression this exists for: `dev_tools` defaults to false and the
+    // only flag that existed set it false again, so the inspector was
+    // unreachable from the command line entirely.
+    var options = try parse(&.{ "craft", "--dev-tools" });
+    defer freeOptions(&options);
+    try testing.expect(options.dev_tools);
+
+    var alias = try parse(&.{ "craft", "--devtools" });
+    defer freeOptions(&alias);
+    try testing.expect(alias.dev_tools);
+}
+
+test "parseArgs - DevTools stay off by default, and --no-devtools still wins" {
+    var off = try parse(&.{"craft"});
+    defer freeOptions(&off);
+    try testing.expect(!off.dev_tools);
+
+    // Last flag wins, in both orders.
+    var on_then_off = try parse(&.{ "craft", "--dev-tools", "--no-devtools" });
+    defer freeOptions(&on_then_off);
+    try testing.expect(!on_then_off.dev_tools);
+
+    var off_then_on = try parse(&.{ "craft", "--no-devtools", "--dev-tools" });
+    defer freeOptions(&off_then_on);
+    try testing.expect(off_then_on.dev_tools);
+}
+
+test "parseArgs - a manifest can ask for headless" {
+    var options = try parse(&.{ "craft", "--headless" });
+    defer freeOptions(&options);
+    try testing.expect(options.headless);
+}


### PR DESCRIPTION
Closes #48.

## The issue's first ask cannot be built as written

> `--remote-debugging` / `--automation`: enable WebKit's remote inspector … and print the port/UUID. **That alone makes every existing WebDriver-ish tool usable.**

There is no port and no UUID. Measured, not inferred:

- `_setRemoteInspectionAllowed:` — named in the issue — **no longer exists in the runtime**. `respondsToSelector:` → 0. Sending it unguarded would crash.
- No endpoint accessor of any kind: `_inspectorURL`, `_remoteInspectorURL`, `_remoteInspectionPort`, `_webInspectorURL`, `inspectorURL` — all absent.
- `WEBKIT_INSPECTOR_SERVER` is a WebKitGTK/WPE variable — **0 hits** in macOS's WebKit.
- An inspectable `WKWebView` with loaded content holds **zero internet sockets** across the host process and all three WebKit XPC children. Discovery is Mach/XPC to `webinspectord`.
- `safaridriver` refuses any `browserName` other than Safari, by design.

So the closing claim is false, and I'd suggest striking it from the issue — it's the premise the rest of item 1 rests on. What's actually available is `setInspectable:`, which puts the app in Safari's **Develop** menu: a human debugging affordance, not automation.

## What that turned up instead: DevTools have never worked

Two independent reasons, either alone sufficient:

1. **No flag turned them on.** `dev_tools` defaults to `false`; the only flag, `--no-devtools`, sets it `false` again. The sole other writer was `craft.json`. The SDK compounded it — it pushes only the negative, so `devTools: detectDevMode()` being `true` sent *nothing*.
2. **Even when enabled, it didn't work on macOS 13.3+**, which introduced `isInspectable` defaulting to `NO`. Measured on 26.3.1:

```
developerExtrasEnabled=YES  ->  isInspectable = 0
```

And `macos.zig:6149` asserted the opposite — "the webview sets `setInspectable:YES`" — while that string appeared **only in that comment**, repo-wide. Someone reading it would reasonably close this issue as already done.

Fixed: `--dev-tools`, a `respondsToSelector:`-guarded `setInspectable:`, the SDK pushing both directions, comment corrected. Confirmed in the shipped binary — with the flag, `isInspectable = true`; without it the call isn't reached.

## `--headless`

Mostly two calls *not happening*: `createWindowWithStyle` has never ordered its window on screen — `showAllWindows` and `activateWindowedApp` do, later — so skipping both plus setting the accessory activation policy is the mechanism.

Verified against the shipped binary, with a control:

```
craft --headless   -> on-screen craft windows: 0
craft (shown)      -> on-screen craft windows: 1
```

and a headless run's page reached a local HTTP server carrying the right `document.title`, so it loaded and ran script while invisible.

**Not folded into `--benchmark`**, deliberately: that mode strips the user content controller, the injected script, the message handler and both webview globals, so nothing could talk to the page afterwards.

### The cost, which is documented because it is not recoverable

An unshown window doesn't drive the compositor, so `requestAnimationFrame` stops after one frame and page timers fall to ~1Hz. Animations, canvas loops, and "wait until the spinner stops" see frame one forever.

No invisible configuration avoids this. What drives the compositor is the window being *unoccluded*, which needs activation — stealing focus and showing a Dock icon. That's a worse trade for exactly the operator this mode exists to help, so it's in `--help` and the docs rather than papered over.

`--headless --menubar-only` exits 1 instead of silently ignoring one.

## A correction from my own testing

My first probe reported that a never-shown window **doesn't load the page at all** — `loaded=0`, and JS failing on an empty DOM. That was wrong: it was cold-start latency, the WebContent process launching. At a 2s budget every configuration loads; at 0.3s *none* do, including the visible control. I'd have designed around a constraint that doesn't exist.

## Scope

`eval-in-page` and `screenshot` **against a running instance** need a control channel craft owns — transport, discovery, and an auth boundary for something that evaluates arbitrary JavaScript in an app's page. None of that exists today. It's a separate change, and half-building it here would be worse than not starting.

Worth recording for that follow-up: `takeSnapshotWithConfiguration:` works with no visible window and returns *fresh* pixels after DOM mutation, so headless screenshots are viable. But craft's shipped capture path is not the way to get them — `CGWindowListCreateImage` returns NIL for a never-shown window, and it's marked obsoleted in the macOS 15 SDK, linking today only because `bridge_screen_capture.zig:120` declares it by hand and bypasses the availability annotation.

`zig build test` clean, `bun test` 476 pass, Windows cross-build clean, `tsc --noEmit` clean, pickier 38 warnings — identical to main. All new tests control-checked; the `devTools` one caught a wrong premise in my own test, which is fixed.