### PR TITLE
fix(capabilities): stop the channel manifest claiming knowledge it does not have

### DIFF
--- a/docs/BRIDGE_API.md
+++ b/docs/BRIDGE_API.md
@@ -559,11 +559,15 @@ holds a ceiling on how many may remain that only ever goes down.
 
 ### `channels`
 
-Every `craft:*` event, and whether anything native emits on it. This cannot be
-derived from the action tables — an emitter is a separate piece of code that may
-or may not have been written — so a channel is reported live only because the
-code that emits on it took out a permit at startup. Sixteen channels the JS
-surface subscribes to currently have no emitter at all.
+Every `craft:*` event, and what craft can say about it: `'live'` when something
+in this build took out a permit to emit on it, `'unknown'` when craft cannot
+prove it either way.
+
+There is no `'dead'`, deliberately. Craft cannot establish absence — the
+`craft:window:*` names are composed in JavaScript from
+`__craftDeliverWindowEvent('focus')`, so no source scan finds the literal even
+though the emitter is right there. Treat `'unknown'` as "subscribe and see", not
+as "this will never fire".
 
 ### `supports()` fails open
 

--- a/packages/typescript/src/types.ts
+++ b/packages/typescript/src/types.ts
@@ -1247,13 +1247,18 @@ export interface CapabilityNamespace {
 export interface CraftCapabilities {
   namespaces: Record<string, CapabilityNamespace>
   /**
-   * Every `craft:*` event channel, and whether anything native emits on it.
+   * Every `craft:*` event channel, and what craft can say about it.
    *
-   * A `false` here means subscribing would work and never fire — which cannot
-   * be derived from the action tables, so it is tracked separately by the
-   * emitters themselves.
+   * `'live'` means something in this build took out a permit to emit on it.
+   * `'unknown'` means craft cannot prove it either way — subscribe and see, and
+   * do **not** disable a feature over it.
+   *
+   * There is deliberately no `'dead'`. Craft cannot establish absence: the
+   * `craft:window:*` names are composed in JavaScript from
+   * `__craftDeliverWindowEvent('focus')`, so no source scan finds the literal
+   * even though the emitter is right there.
    */
-  channels: Record<string, boolean>
+  channels: Record<string, 'live' | 'unknown'>
 }
 
 

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -666,6 +666,7 @@ pub fn build(b: *std.Build) void {
         "src/bridge_screen.zig",
         "src/bridge_capabilities.zig",
         "src/bridge_capabilities_actions.zig",
+        "src/js/craft-bridge.js",
     }) |source_path| {
         capability_conformance_tests.root_module.addAnonymousImport(source_path, .{
             .root_source_file = b.path(source_path),

--- a/packages/zig/src/bridge_menu.zig
+++ b/packages/zig/src/bridge_menu.zig
@@ -4,6 +4,7 @@ const bridge_error = @import("bridge_error.zig");
 const icons = @import("icons.zig");
 const menu_roles = @import("menu_roles.zig");
 const logging = @import("logging.zig");
+const capabilities = @import("capabilities.zig");
 
 const BridgeError = bridge_error.BridgeError;
 const log = logging.menu;
@@ -617,6 +618,7 @@ fn menuActionCallback(_: ?*anyopaque, _: ?*anyopaque, sender: ?*anyopaque) callc
 }
 
 fn ensureMenuTarget() ?*anyopaque {
+    _ = capabilities.registerEmitter(.menu_action);
     if (comptime builtin.os.tag != .macos) return null;
     if (menu_target != null) return menu_target;
 

--- a/packages/zig/src/bridge_shortcuts.zig
+++ b/packages/zig/src/bridge_shortcuts.zig
@@ -29,6 +29,7 @@ const bridge_error = @import("bridge_error.zig");
 const logging = @import("logging.zig");
 const registry_mod = @import("shortcut_registry.zig");
 const accel = @import("accelerator.zig");
+const capabilities = @import("capabilities.zig");
 
 const log = logging.shortcuts;
 
@@ -149,6 +150,8 @@ pub const ShortcutsBridge = struct {
     /// idempotent, so it runs before every registration rather than depending
     /// on an initialisation order.
     fn ensureDelivery(self: *Self) void {
+        _ = capabilities.registerEmitter(.shortcut);
+        _ = capabilities.registerEmitter(.shortcut_error);
         const global_state = @import("global_state.zig");
         global_state.instance.setShortcutsBridge(self);
         if (comptime builtin.os.tag == .macos) {

--- a/packages/zig/src/capabilities.zig
+++ b/packages/zig/src/capabilities.zig
@@ -91,54 +91,103 @@ pub const NamespaceDecl = struct {
 /// deriving from: `craft:menu:action` is colon-separated and `craft:powerSleep`
 /// is camel-cased, and both are load-bearing spellings a page already listens
 /// for. Renaming them to be consistent would break every app.
+///
+/// `test/capabilities_test.zig` checks this list against every `_evt('craft:…')`
+/// in `craft-bridge.js`. It shipped with 22 of the 44 and claimed to be
+/// complete, which is the same overclaiming this whole mechanism exists to
+/// stop — so now the claim is enforced.
 pub const Channel = enum {
-    menu_action,
-    theme,
-    settings_open,
-    window_focus,
-    window_blur,
-    window_resize,
-    window_move,
-    screen_change,
-    deep_link,
-    file_drop,
-    shortcut,
+    bluetooth_deviceconnected,
+    bluetooth_devicedisconnected,
+    bluetooth_devicefound,
+    bonjour_found,
+    bonjour_lost,
+    deeplink,
+    filedrop,
     fs_change,
-    power_sleep,
-    power_wake,
-    network_change,
-    bluetooth_device_found,
-    bluetooth_device_connected,
-    bluetooth_device_disconnected,
-    touchbar_action,
+    handoff_incoming,
+    iap_failed,
+    iap_productsloaded,
+    iap_purchased,
+    iap_restored,
+    localserver_request,
+    location_authchanged,
+    location_error,
+    location_update,
+    menu_action,
+    menubar_statechange,
+    midi_message,
+    networkchange,
+    powersleep,
+    powerwake,
+    screen_change,
+    screensharing_change,
     serial_data,
-    speech_partial,
-    speech_final,
+    servicemenu_invoked,
+    settings_open,
+    shortcut,
+    shortcut_error,
+    speechrecognition_final,
+    speechrecognition_partial,
+    theme,
+    touchbar_action,
+    tray_menuaction,
+    updateavailable,
+    updatedownloaded,
+    window_blur,
+    window_close,
+    window_focus,
+    window_minimize,
+    window_move,
+    window_resize,
+    window_restore,
 
     pub fn eventName(self: Channel) []const u8 {
         return switch (self) {
-            .menu_action => "craft:menu:action",
-            .theme => "craft:theme",
-            .settings_open => "craft:settings:open",
-            .window_focus => "craft:window:focus",
-            .window_blur => "craft:window:blur",
-            .window_resize => "craft:window:resize",
-            .window_move => "craft:window:move",
-            .screen_change => "craft:screen:change",
-            .deep_link => "craft:deepLink",
-            .file_drop => "craft:fileDrop",
-            .shortcut => "craft:shortcut",
+            .bluetooth_deviceconnected => "craft:bluetooth:deviceConnected",
+            .bluetooth_devicedisconnected => "craft:bluetooth:deviceDisconnected",
+            .bluetooth_devicefound => "craft:bluetooth:deviceFound",
+            .bonjour_found => "craft:bonjour:found",
+            .bonjour_lost => "craft:bonjour:lost",
+            .deeplink => "craft:deepLink",
+            .filedrop => "craft:fileDrop",
             .fs_change => "craft:fs:change",
-            .power_sleep => "craft:powerSleep",
-            .power_wake => "craft:powerWake",
-            .network_change => "craft:networkChange",
-            .bluetooth_device_found => "craft:bluetooth:deviceFound",
-            .bluetooth_device_connected => "craft:bluetooth:deviceConnected",
-            .bluetooth_device_disconnected => "craft:bluetooth:deviceDisconnected",
-            .touchbar_action => "craft:touchbar:action",
+            .handoff_incoming => "craft:handoff:incoming",
+            .iap_failed => "craft:iap:failed",
+            .iap_productsloaded => "craft:iap:productsLoaded",
+            .iap_purchased => "craft:iap:purchased",
+            .iap_restored => "craft:iap:restored",
+            .localserver_request => "craft:localServer:request",
+            .location_authchanged => "craft:location:authChanged",
+            .location_error => "craft:location:error",
+            .location_update => "craft:location:update",
+            .menu_action => "craft:menu:action",
+            .menubar_statechange => "craft:menubar:stateChange",
+            .midi_message => "craft:midi:message",
+            .networkchange => "craft:networkChange",
+            .powersleep => "craft:powerSleep",
+            .powerwake => "craft:powerWake",
+            .screen_change => "craft:screen:change",
+            .screensharing_change => "craft:screenSharing:change",
             .serial_data => "craft:serial:data",
-            .speech_partial => "craft:speechRecognition:partial",
-            .speech_final => "craft:speechRecognition:final",
+            .servicemenu_invoked => "craft:serviceMenu:invoked",
+            .settings_open => "craft:settings:open",
+            .shortcut => "craft:shortcut",
+            .shortcut_error => "craft:shortcut:error",
+            .speechrecognition_final => "craft:speechRecognition:final",
+            .speechrecognition_partial => "craft:speechRecognition:partial",
+            .theme => "craft:theme",
+            .touchbar_action => "craft:touchbar:action",
+            .tray_menuaction => "craft:tray:menuAction",
+            .updateavailable => "craft:updateAvailable",
+            .updatedownloaded => "craft:updateDownloaded",
+            .window_blur => "craft:window:blur",
+            .window_close => "craft:window:close",
+            .window_focus => "craft:window:focus",
+            .window_minimize => "craft:window:minimize",
+            .window_move => "craft:window:move",
+            .window_resize => "craft:window:resize",
+            .window_restore => "craft:window:restore",
         };
     }
 };
@@ -171,6 +220,33 @@ pub const Emitter = struct {
 pub fn registerEmitter(channel: Channel) Emitter {
     live_channels[@backingInt(channel)] = true;
     return .{ .channel = channel };
+}
+
+/// What craft can honestly say about a channel.
+///
+/// There is no `dead`. A source scan cannot establish absence: `craft:window:*`
+/// names are composed in JavaScript from `__craftDeliverWindowEvent('focus')`,
+/// so no Zig file contains the literal even though the emitter is right there.
+/// The shipped version reported a bare `false` for anything unregistered, which
+/// a page reasonably reads as "this will never fire" — and 21 of 22 channels
+/// said it, including `craft:menu:action` and `craft:theme`, both of which work.
+pub const Liveness = enum {
+    /// Something in this build took out a permit to emit on it.
+    live,
+    /// Craft cannot prove it either way. Subscribe and see; do not disable a
+    /// feature over it.
+    unknown,
+
+    pub fn text(self: Liveness) []const u8 {
+        return switch (self) {
+            .live => "live",
+            .unknown => "unknown",
+        };
+    }
+};
+
+pub fn liveness(channel: Channel) Liveness {
+    return if (live_channels[@backingInt(channel)]) .live else .unknown;
 }
 
 pub fn isLive(channel: Channel) bool {
@@ -257,8 +333,9 @@ pub fn buildManifest(gpa: std.mem.Allocator, registry: []const NamespaceDecl) ![
         if (index > 0) try out.append(gpa, ',');
         try out.append(gpa, '"');
         try appendEscaped(gpa, &out, channel.eventName());
-        try out.appendSlice(gpa, "\":");
-        try out.appendSlice(gpa, if (isLive(channel)) "true" else "false");
+        try out.appendSlice(gpa, "\":\"");
+        try out.appendSlice(gpa, liveness(channel).text());
+        try out.append(gpa, '"');
     }
     try out.appendSlice(gpa, "}}");
 
@@ -281,17 +358,20 @@ test "a channel has no emitter until something registers one" {
     try testing.expectEqualStrings("craft:fs:change", emitter.eventName());
 
     // Registering one channel says nothing about any other.
-    try testing.expect(!isLive(.power_sleep));
+    try testing.expect(!isLive(.powersleep));
 }
 
 test "every channel has a distinct event name" {
     // A duplicate would make one of the two silently unreportable: the manifest
     // is keyed by event name, so the second would overwrite the first.
+    //
+    // Runtime rather than `inline for`: at 44 channels the nested comptime loop
+    // exceeds Zig's backwards-branch budget.
     const all = std.enums.values(Channel);
-    inline for (all, 0..) |left, i| {
-        inline for (all, 0..) |right, j| {
-            if (i < j) try testing.expect(!std.mem.eql(u8, left.eventName(), right.eventName()));
-        }
+    var names: [all.len][]const u8 = undefined;
+    for (all, 0..) |ch, i| names[i] = ch.eventName();
+    for (names, 0..) |a, i| {
+        for (names[i + 1 ..]) |b| try testing.expect(!std.mem.eql(u8, a, b));
     }
 }
 
@@ -388,8 +468,10 @@ test "the manifest reports every channel, live or not" {
     // Every channel is present — a dead one has to be reported as dead, not
     // omitted, or an app cannot tell "no emitter" from "channel I misspelled".
     try testing.expectEqual(@as(usize, channel_count), channels.count());
-    try testing.expect(channels.get("craft:menu:action").?.bool);
-    try testing.expect(!channels.get("craft:fs:change").?.bool);
+    try testing.expectEqualStrings("live", channels.get("craft:menu:action").?.string);
+    // Not "dead" — craft cannot prove a channel has no emitter, and saying so
+    // is what made the shipped manifest tell pages to disable working features.
+    try testing.expectEqualStrings("unknown", channels.get("craft:fs:change").?.string);
 }
 
 test "a reason cannot break the manifest out of its JSON" {

--- a/packages/zig/src/js/craft-bridge.js
+++ b/packages/zig/src/js/craft-bridge.js
@@ -748,11 +748,13 @@
   //   const caps = await craft.capabilities()
   //   caps.namespaces.updater.status   // 'unavailable'
   //   caps.namespaces.updater.reason   // 'the Sparkle framework is not linked…'
-  //   caps.channels['craft:fs:change'] // false — subscribing would never fire
+  //   caps.channels['craft:fs:change'] // 'live' | 'unknown'
   //
   // A namespace craft has not audited reports `undeclared`, which means exactly
   // that: craft will not claim anything either way. Treat it as "try it and
-  // handle failure", not as "missing".
+  // handle failure", not as "missing". Channels answer 'live' or 'unknown' for
+  // the same reason — there is no 'dead', because craft cannot prove a channel
+  // has no emitter.
   window.craft.capabilities = function () {
     return _req('capabilities', 'capabilities:get', '{}', 5000).then(function (manifest) {
       window.__craftCapabilities = manifest

--- a/packages/zig/src/macos_deep_link.zig
+++ b/packages/zig/src/macos_deep_link.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const macos = @import("macos.zig");
+const capabilities = @import("capabilities.zig");
 
 const objc = macos.objc;
 
@@ -77,6 +78,7 @@ pub fn install() void {
     );
 
     installed = true;
+    _ = capabilities.registerEmitter(.deeplink);
 
     if (comptime builtin.mode == .debug) {
         std.debug.print("[DeepLink] Installed AppleEvent handler for kAEGetURL\n", .{});

--- a/packages/zig/src/macos_file_drop.zig
+++ b/packages/zig/src/macos_file_drop.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const macos = @import("macos.zig");
+const capabilities = @import("capabilities.zig");
 
 const objc = macos.objc;
 
@@ -32,6 +33,7 @@ const PerformDragFn = *const fn (objc.id, objc.SEL, objc.id) callconv(.c) c_char
 ///
 /// Idempotent — safe to call from every window create. macOS-only.
 pub fn install() void {
+    _ = capabilities.registerEmitter(.filedrop);
     if (swizzled) return;
     if (builtin.target.os.tag != .macos) return;
 

--- a/packages/zig/src/macos_theme.zig
+++ b/packages/zig/src/macos_theme.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const macos = @import("macos.zig");
+const capabilities = @import("capabilities.zig");
 
 const objc = macos.objc;
 
@@ -59,6 +60,7 @@ pub fn install() void {
     }
 
     installed = true;
+    _ = capabilities.registerEmitter(.theme);
 
     if (comptime builtin.mode == .debug) {
         std.debug.print("[Theme] Installed NSAppearance observer\n", .{});

--- a/packages/zig/src/macos_window_events.zig
+++ b/packages/zig/src/macos_window_events.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const macos = @import("macos.zig");
+const capabilities = @import("capabilities.zig");
 
 const objc = macos.objc;
 
@@ -50,6 +51,11 @@ pub fn install(window: objc.id) void {
 
         delegate_instance = macos.msgSend0(macos.msgSend0(cls, "alloc"), "init");
         installed = true;
+        // Five channels, one delegate. The names are composed in JS from
+        // `__craftDeliverWindowEvent`, so no source scan could ever find them.
+        inline for ([_]capabilities.Channel{ .window_focus, .window_blur, .window_resize, .window_move, .window_close }) |ch| {
+            _ = capabilities.registerEmitter(ch);
+        }
 
         if (comptime builtin.mode == .debug) {
             std.debug.print("[WindowEvents] Installed NSWindowDelegate\n", .{});

--- a/packages/zig/test/capabilities_test.zig
+++ b/packages/zig/test/capabilities_test.zig
@@ -56,6 +56,52 @@ const dispatcher_source = @embedFile("src/macos.zig");
 /// lowered, and lowering it is what "declaring a namespace" costs.
 const max_undeclared: usize = 45;
 
+/// The injected bridge script, so the channel list can be checked against the
+/// events the page actually subscribes to.
+const bridge_js = @embedFile("src/js/craft-bridge.js");
+
+test "every event the page subscribes to is a declared channel" {
+    // The check that was missing. `Channel` shipped with 22 entries and a doc
+    // comment claiming it listed every `craft:*` the JS surface subscribes to;
+    // there were 44. A manifest that omits a channel answers nothing about it,
+    // which is the same overclaiming this mechanism exists to stop — so the
+    // claim is now enforced rather than asserted.
+    var search: usize = 0;
+    var checked: usize = 0;
+    while (std.mem.indexOfPos(u8, bridge_js, search, "_evt('craft:")) |at| {
+        const name_start = at + "_evt('".len;
+        const name_end = std.mem.indexOfScalarPos(u8, bridge_js, name_start, '\'') orelse break;
+        const name = bridge_js[name_start..name_end];
+        search = name_end;
+
+        var known = false;
+        for (std.enums.values(capabilities.Channel)) |ch| {
+            if (std.mem.eql(u8, ch.eventName(), name)) known = true;
+        }
+        if (!known) {
+            std.debug.print(
+                "craft-bridge.js subscribes to '{s}' but it is not in the Channel enum,\n" ++
+                    "  so craft.capabilities() says nothing about it at all.\n",
+                .{name},
+            );
+            return error.SubscribedChannelNotDeclared;
+        }
+        checked += 1;
+    }
+    // A regex that silently matched nothing would make this test vacuous.
+    try testing.expect(checked >= 40);
+}
+
+test "no channel is reported as definitely dead" {
+    // `false` was never knowledge — it only ever meant "no emitter has
+    // registered", and a page reasonably read it as "this will never fire".
+    // Absence of proof is reported as `unknown` now, and there is deliberately
+    // no third value to regress to.
+    try testing.expectEqualStrings("live", capabilities.Liveness.live.text());
+    try testing.expectEqualStrings("unknown", capabilities.Liveness.unknown.text());
+    try testing.expectEqual(@as(usize, 2), std.enums.values(capabilities.Liveness).len);
+}
+
 test "nothing is marked declared without being enforced" {
     // Closes the obvious loophole: marking a namespace `.declared` in the
     // registry buys the app's trust, and it must cost a `declared_sources` row,

--- a/packages/zig/test/cli_test.zig
+++ b/packages/zig/test/cli_test.zig
@@ -297,8 +297,8 @@ test "parseArgs - --frame-autosave leaves the explicit geometry alone" {
     // The two are not alternatives: the geometry flags are what the window
     // opens at the first time, before anything has been saved to restore.
     var options = try parse(&.{
-        "craft",           "--frame-autosave", "main", "--width", "900",
-        "--height",        "700",              "--x",  "40",      "--y",
+        "craft",    "--frame-autosave", "main", "--width", "900",
+        "--height", "700",              "--x",  "40",      "--y",
         "60",
     });
     defer freeOptions(&options);

--- a/packages/zig/test/injected_js_test.zig
+++ b/packages/zig/test/injected_js_test.zig
@@ -614,7 +614,7 @@ test "every wire action the prefs facade posts is namespaced" {
         try fx.text("String(posted.every(function (m) { return m.a.indexOf('prefs:') === 0 }))"),
     );
     for ([_][]const u8{
-        prefs_actions.get,  prefs_actions.set,  prefs_actions.delete,
+        prefs_actions.get,   prefs_actions.set,  prefs_actions.delete,
         prefs_actions.clear, prefs_actions.keys, prefs_actions.info,
     }, 0..) |want, index| {
         var buf: [64]u8 = undefined;
@@ -886,7 +886,10 @@ test "the manifest native builds is the shape the facade reads" {
     // The reason is the difference between an app hunting a bug in its own code
     // and an app knowing the answer.
     try testing.expect(std.mem.indexOf(u8, try fx.text("caps.namespaces.updater.reason"), "Sparkle") != null);
-    try testing.expectEqualStrings("false", try fx.text("String(caps.channels['craft:fs:change'])"));
+    // Not "false" — craft cannot prove a channel has no emitter, and saying it
+    // could is what made the shipped manifest tell pages to disable working
+    // features. The only two answers are "live" and "unknown".
+    try testing.expectEqualStrings("unknown", try fx.text("caps.channels['craft:fs:change']"));
 }
 
 test "craft.supports answers from the manifest, and fails open without one" {

--- a/packages/zig/test/logging_test.zig
+++ b/packages/zig/test/logging_test.zig
@@ -3,12 +3,12 @@ const testing = std.testing;
 const logging = @import("../src/logging.zig");
 
 test "LogLevel ordering" {
-    try testing.expect(@intFromEnum(logging.LogLevel.trace) < @intFromEnum(logging.LogLevel.debug));
-    try testing.expect(@intFromEnum(logging.LogLevel.debug) < @intFromEnum(logging.LogLevel.info));
-    try testing.expect(@intFromEnum(logging.LogLevel.info) < @intFromEnum(logging.LogLevel.warn));
-    try testing.expect(@intFromEnum(logging.LogLevel.warn) < @intFromEnum(logging.LogLevel.err));
-    try testing.expect(@intFromEnum(logging.LogLevel.err) < @intFromEnum(logging.LogLevel.fatal));
-    try testing.expect(@intFromEnum(logging.LogLevel.fatal) < @intFromEnum(logging.LogLevel.off));
+    try testing.expect(@backingInt(logging.LogLevel.trace) < @backingInt(logging.LogLevel.debug));
+    try testing.expect(@backingInt(logging.LogLevel.debug) < @backingInt(logging.LogLevel.info));
+    try testing.expect(@backingInt(logging.LogLevel.info) < @backingInt(logging.LogLevel.warn));
+    try testing.expect(@backingInt(logging.LogLevel.warn) < @backingInt(logging.LogLevel.err));
+    try testing.expect(@backingInt(logging.LogLevel.err) < @backingInt(logging.LogLevel.fatal));
+    try testing.expect(@backingInt(logging.LogLevel.fatal) < @backingInt(logging.LogLevel.off));
 }
 
 test "LogLevel asText" {


### PR DESCRIPTION
I shipped this in #60 and it was wrong in two ways at once. Found while surveying #62–#67; reporting it before building anything else on top.

## It told pages that working features were dead

Only **one** call site ever registered an emitter (`bridge_screen.zig:158`), so `craft.capabilities().channels` reported **21 of 22 channels as `false`** — including `craft:menu:action`, `craft:theme`, `craft:deepLink`, `craft:fileDrop` and the whole `craft:window:*` family. Every one of those works.

A page feature-detecting honestly — the entire point of #49 — would have read that and disabled working features.

## And the enum listed 22 of 44

Its doc comment claimed to enumerate every `craft:*` the JS surface subscribes to. It enumerated half, and nothing checked the claim.

Both are the bug class #49 exists to end, committed by the fix for #49.

## `false` was never knowledge

It only ever meant "no emitter has registered". Craft **cannot** establish absence — I wrote a source scan to find dead channels and it called all five `craft:window:*` dead, because those names are composed in JavaScript from `__craftDeliverWindowEvent('focus')` and no `.zig` file contains the literal. The emitter is right there.

So liveness is two-valued now, `live` or `unknown`, with deliberately no third value to regress to:

```js
caps.channels['craft:menu:action']  // 'live'
caps.channels['craft:fs:change']    // 'unknown' — subscribe and see
```

`'unknown'` means *craft cannot prove it either way*, not *it will not fire*.

## Emitters register at install, not first fire

"This build contains an emitter" is a property of the binary. Registering when a subsystem first *emits* means a lazily-initialised one reports `unknown` merely because nobody has used it yet — which is the same false-negative in slower motion.

## The durable part

A test that every `_evt('craft:…')` in `craft-bridge.js` has a `Channel` entry, checked against the embedded script. That is what was missing; it would have caught 22-vs-44 on day one.

It also carries a floor assertion (`checked >= 40`), so a regex that silently stops matching fails instead of passing vacuously. Control-checked both ways:

- removing an unreferenced channel from the enum → `craft-bridge.js subscribes to 'craft:bonjour:found' but it is not in the Channel enum`
- breaking the search string → the floor assertion fires

My first attempt at the first control removed `menu_action`, which is referenced elsewhere and didn't compile, so it proved nothing. Redone with an unreferenced channel.

**Channel enum 22 → 44. Emitter registrations 1 → 13.**

`zig build test` clean, 27 JS contract tests, Windows cross-build clean, `zig fmt` clean, `tsc` clean, pickier 38 warnings — same as main.

This is a breaking change to `channels`' value type, one day after it shipped. Worth taking now rather than leaving a manifest that lies.