### PR TITLE
fix(bridge): correlate replies by request id, not by action name

### DIFF
--- a/packages/typescript/src/__tests__/bridge-request-id.test.ts
+++ b/packages/typescript/src/__tests__/bridge-request-id.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from 'bun:test'
+
+/**
+ * The reply-correlation contract, exercised against the real
+ * `packages/zig/src/js/craft-bridge.js` — the file that ships inside the
+ * binary — rather than a reimplementation of it.
+ *
+ * This is behavioural, not a source scan. Every test here drives the actual
+ * promise machinery: call a facade, watch what goes out over
+ * `webkit.messageHandlers.craft`, answer it the way native would, and check
+ * which promise settles with what. A source scan cannot tell whether the
+ * right caller was resolved, and that is the entire bug.
+ */
+
+const BRIDGE_SRC = await Bun.file(
+  new URL('../../../zig/src/js/craft-bridge.js', import.meta.url),
+).text()
+
+interface Envelope { t: string, a: string, d?: string, i?: number }
+
+interface Harness {
+  craft: any
+  /** Every message the page posted to native, in order. */
+  sent: Envelope[]
+  /** Native answering a call, the way `sendResultToJS` does. */
+  reply: (action: string, payload: unknown, id: number | null) => void
+  /** Native failing a call, the way `sendErrorToJS` does. */
+  fail: (err: { action?: string, code?: string, message?: string, id?: number }) => void
+  win: any
+  errors: unknown[][]
+}
+
+/**
+ * Run craft-bridge.js in a synthetic window.
+ *
+ * The script is an IIFE that reads bare `window`, `document` and `console`, so
+ * they can simply be passed in as parameters — no DOM, no jsdom, and nothing
+ * shared between tests.
+ */
+function loadBridge(): Harness {
+  const sent: Envelope[] = []
+  const errors: unknown[][] = []
+  const win: any = {
+    webkit: {
+      messageHandlers: {
+        craft: { postMessage: (m: Envelope) => { sent.push(m) } },
+      },
+    },
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    // The script fires `craft:ready` on load.
+    dispatchEvent: () => true,
+  }
+  const doc: any = { readyState: 'complete', addEventListener: () => {} }
+  const console_: any = { ...console, error: (...a: unknown[]) => { errors.push(a) }, warn: () => {} }
+
+  // eslint-disable-next-line no-new-func
+  const run = new Function('window', 'document', 'console', 'setTimeout', 'clearTimeout', 'setInterval', BRIDGE_SRC)
+  run(win, doc, console_, setTimeout, clearTimeout, () => 0)
+
+  return {
+    craft: win.craft,
+    sent,
+    win,
+    errors,
+    reply: (action, payload, id) => {
+      // Mirrors formatResultJS: three arguments, `null` when there is no id.
+      win.__craftBridgeResult(action, payload, id)
+    },
+    fail: err => win.__craftBridgeError(err),
+  }
+}
+
+/** Let queued promise callbacks run. */
+const settle = () => new Promise(r => setTimeout(r, 0))
+
+/**
+ * Capture a promise's outcome now, so several promises can reject on the same
+ * tick without any of them being momentarily unhandled. Resolves to the
+ * rejection reason, or to `'resolved'` if it settled the other way.
+ */
+function settled(p: Promise<unknown>): Promise<unknown> {
+  return p.then(() => 'resolved', (e: unknown) => e)
+}
+
+describe('bridge reply correlation', () => {
+  it('gives each caller its own answer when two bridges share an action name', async () => {
+    // `get` is served by both keychain and tags. Before request ids, both
+    // callers queued under the string "get" and were matched by arrival order,
+    // so answering out of order swapped the payloads.
+    const h = loadBridge()
+
+    const keychain = h.craft.keychain.get('svc', 'acct')
+    const tags = h.craft.tags.get('/some/file')
+
+    expect(h.sent).toHaveLength(2)
+    const [keychainMsg, tagsMsg] = h.sent
+    expect(keychainMsg.t).toBe('keychain')
+    expect(tagsMsg.t).toBe('tags')
+    expect(keychainMsg.i).toBeDefined()
+    expect(tagsMsg.i).not.toBe(keychainMsg.i)
+
+    // Native answers the second call first — the case that used to swap.
+    h.reply('get', { tags: ['red'] }, tagsMsg.i!)
+    h.reply('get', { value: 'hunter2' }, keychainMsg.i!)
+
+    expect(await keychain).toBe('hunter2')
+    expect(await tags).toEqual(['red'])
+  })
+
+  it('would have swapped those payloads without the ids', async () => {
+    // The control. Same two calls, answered in the same order, but as a
+    // pre-id binary would answer them: no id, so the action-name queue picks
+    // the head. keychain asked first, so keychain is handed the tags payload
+    // and reads `undefined` off it. This is the bug, reproduced.
+    const h = loadBridge()
+
+    const keychain = h.craft.keychain.get('svc', 'acct')
+    const tags = h.craft.tags.get('/some/file')
+
+    h.reply('get', { tags: ['red'] }, null)
+    h.reply('get', { value: 'hunter2' }, null)
+
+    expect(await keychain).toBeUndefined()
+    expect(await tags).toEqual([])
+  })
+
+  it('resolves the right caller among several calls to one action on one bridge', async () => {
+    const h = loadBridge()
+    const a = h.craft.tags.get('/a')
+    const b = h.craft.tags.get('/b')
+    const c = h.craft.tags.get('/c')
+
+    const ids = h.sent.map(m => m.i!)
+    expect(new Set(ids).size).toBe(3)
+
+    // Answer middle, last, first.
+    h.reply('get', { tags: ['B'] }, ids[1])
+    h.reply('get', { tags: ['C'] }, ids[2])
+    h.reply('get', { tags: ['A'] }, ids[0])
+
+    expect(await a).toEqual(['A'])
+    expect(await b).toEqual(['B'])
+    expect(await c).toEqual(['C'])
+  })
+
+  it('rejects only the call that failed, not everything sharing its name', async () => {
+    // `isEnabled` is served by autoLaunch, bluetooth and crashReporter.
+    // Draining by action name rejected callers of all three.
+    const h = loadBridge()
+
+    const autoLaunch = h.craft.autoLaunch.isEnabled()
+    const bluetooth = h.craft.bluetooth.isEnabled()
+    const bluetoothId = h.sent[1].i!
+
+    h.fail({ action: 'isEnabled', code: 'NATIVE_CALL_FAILED', message: 'no bluetooth', id: bluetoothId })
+
+    await expect(bluetooth).rejects.toMatchObject({ message: 'no bluetooth' })
+
+    // autoLaunch never heard about it and still answers normally.
+    h.reply('isEnabled', { value: true }, h.sent[0].i!)
+    expect(await autoLaunch).toBe(true)
+  })
+
+  it('would have rejected the innocent caller without the id', async () => {
+    // The control for the test above.
+    const h = loadBridge()
+    // Outcomes are captured synchronously: both reject on the same tick, and
+    // awaiting them one after the other would leave the second unhandled.
+    const autoLaunch = settled(h.craft.autoLaunch.isEnabled())
+    const bluetooth = settled(h.craft.bluetooth.isEnabled())
+
+    h.fail({ action: 'isEnabled', code: 'NATIVE_CALL_FAILED', message: 'no bluetooth' })
+
+    expect(await bluetooth).toMatchObject({ message: 'no bluetooth' })
+    expect(await autoLaunch).toMatchObject({ message: 'no bluetooth' })
+  })
+
+  it('drops a reply for an id it does not know instead of giving it to someone else', async () => {
+    const h = loadBridge()
+    const pending = h.craft.tags.get('/a')
+    const id = h.sent[0].i!
+
+    // A late or duplicated reply for a call that already settled. The old code
+    // had no way to tell, and would have handed this to the waiting caller.
+    h.reply('get', { tags: ['GHOST'] }, id + 999)
+    await settle()
+
+    h.reply('get', { tags: ['MINE'] }, id)
+    expect(await pending).toEqual(['MINE'])
+  })
+
+  it('answers a call once — a duplicate reply changes nothing', async () => {
+    const h = loadBridge()
+    const p = h.craft.tags.get('/a')
+    const id = h.sent[0].i!
+
+    h.reply('get', { tags: ['first'] }, id)
+    h.reply('get', { tags: ['second'] }, id)
+
+    expect(await p).toEqual(['first'])
+  })
+
+  it('still resolves a reply that arrives without an id', async () => {
+    // Not version skew — this file is embedded in the binary, so the two
+    // always match. It is for replies raised outside any dispatch, where
+    // native has no request to name.
+    const h = loadBridge()
+    const p = h.craft.tags.get('/a')
+    h.reply('get', { tags: ['ok'] }, null)
+    expect(await p).toEqual(['ok'])
+  })
+
+  it('puts a distinct id on every message, fire-and-forget included', async () => {
+    const h = loadBridge()
+    h.craft.tags.get('/a')
+    h.craft.keychain.set('svc', 'acct', 'pw') // _send, no reply expected
+    h.craft.window.show?.()
+    h.craft.autoLaunch.isEnabled()
+
+    const ids = h.sent.map(m => m.i)
+    expect(ids.every(i => typeof i === 'number' && i > 0)).toBe(true)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('reports a fire-and-forget failure rather than rejecting a live call', async () => {
+    const h = loadBridge()
+    const live = h.craft.tags.get('/a')
+    const liveId = h.sent[0].i!
+
+    h.craft.keychain.set('svc', 'acct', 'pw')
+    const sendId = h.sent[1].i!
+    expect(sendId).not.toBe(liveId)
+
+    // `_send` registered no pending entry, so there is nobody to reject.
+    h.fail({ action: 'set', code: 'NATIVE_CALL_FAILED', message: 'keychain locked', id: sendId })
+    expect(h.errors).toHaveLength(1)
+
+    h.reply('get', { tags: ['fine'] }, liveId)
+    expect(await live).toEqual(['fine'])
+  })
+
+  it('forgets a timed-out call in both tables, and drops its late reply', async () => {
+    const h = loadBridge()
+    h.win.__craftBridgeRequestTimeoutMs = 1
+    const p = h.craft.tags.get('/a')
+    const id = h.sent[0].i!
+
+    await expect(p).rejects.toThrow(/timed out/)
+
+    expect(h.win.__craftBridgeById[id]).toBeUndefined()
+    expect(h.win.__craftBridgePending.get).toBeUndefined()
+
+    // The late reply lands on an empty table and goes nowhere. Nothing to
+    // assert but the absence of a throw — and that the next call is unaffected.
+    h.reply('get', { tags: ['late'] }, id)
+
+    h.win.__craftBridgeRequestTimeoutMs = 30000
+    const next = h.craft.tags.get('/b')
+    h.reply('get', { tags: ['next'] }, h.sent[1].i!)
+    expect(await next).toEqual(['next'])
+  })
+
+  it('leaves no entry behind after a call settles', async () => {
+    const h = loadBridge()
+    const p = h.craft.tags.get('/a')
+    h.reply('get', { tags: [] }, h.sent[0].i!)
+    await p
+
+    expect(Object.keys(h.win.__craftBridgeById)).toHaveLength(0)
+    expect(Object.keys(h.win.__craftBridgePending)).toHaveLength(0)
+  })
+
+  it('still drops every pending call when native reports an unattributable failure', async () => {
+    // An error with neither id nor action means the bridge itself is in
+    // trouble; nobody should be left hanging.
+    const h = loadBridge()
+    const a = settled(h.craft.tags.get('/a'))
+    const b = settled(h.craft.autoLaunch.isEnabled())
+
+    h.fail({ code: 'NATIVE_CALL_FAILED', message: 'bridge down' })
+
+    expect(await a).toMatchObject({ message: 'bridge down' })
+    expect(await b).toMatchObject({ message: 'bridge down' })
+    expect(Object.keys(h.win.__craftBridgeById)).toHaveLength(0)
+  })
+})

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -661,6 +661,16 @@ pub fn build(b: *std.Build) void {
         }),
     });
 
+    // Which bridge call a reply belongs to. A thread-local stack, so nesting
+    // (a modal run loop re-entering dispatch) is part of what gets tested.
+    const request_context_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/request_context.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
     // The conformance test: what craft declares, against what it dispatches.
     const capability_conformance_tests = b.addTest(.{
         .root_module = b.createModule(.{
@@ -1034,6 +1044,7 @@ pub fn build(b: *std.Build) void {
     const run_capabilities_tests = b.addRunArtifact(capabilities_tests);
     const run_external_link_tests = b.addRunArtifact(external_link_tests);
     const run_webview_recovery_tests = b.addRunArtifact(webview_recovery_tests);
+    const run_request_context_tests = b.addRunArtifact(request_context_tests);
     const run_prefs_tests = b.addRunArtifact(prefs_tests);
     const run_prefs_macos_tests = b.addRunArtifact(prefs_macos_tests);
     const run_key_codes_tests = b.addRunArtifact(key_codes_tests);
@@ -1149,6 +1160,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_capabilities_tests.step);
     test_step.dependOn(&run_external_link_tests.step);
     test_step.dependOn(&run_webview_recovery_tests.step);
+    test_step.dependOn(&run_request_context_tests.step);
     // macOS only: the registry describes the dispatch chain in macos.zig, and
     // compiling it elsewhere drags the whole native graph into a test binary
     // for a platform it does not describe.

--- a/packages/zig/src/bridge_contracts.zig
+++ b/packages/zig/src/bridge_contracts.zig
@@ -13,6 +13,10 @@
 //! its own directory, so this has to live here beside the code it re-exports
 //! rather than in `test/`.
 
+/// The reply formatter. `test/injected_js_test.zig` answers the page with the
+/// very string `sendResultToJS` evaluates, rather than a hand-written copy of
+/// it that cannot notice when the two drift apart.
+pub const errors = @import("bridge_error.zig");
 pub const menu = @import("bridge_menu.zig");
 pub const shortcuts = @import("shortcut_registry.zig");
 pub const prefs = @import("prefs.zig");

--- a/packages/zig/src/bridge_error.zig
+++ b/packages/zig/src/bridge_error.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const request_context = @import("request_context.zig");
 const builtin = @import("builtin");
 
 /// Common error types for all bridge operations
@@ -67,6 +68,13 @@ pub const ErrorContext = struct {
     err: BridgeError,
     action: []const u8,
     message: []const u8,
+    /// The page's id for the call that failed, when the failure happened while
+    /// serving one. Lets `craft-bridge.js` reject exactly that caller instead
+    /// of every caller queued under the same action name — which matters most
+    /// here, because six action names are served by more than one bridge, so
+    /// draining by name rejects unrelated calls with an error from a bridge
+    /// they never touched.
+    request_id: ?u64 = null,
 
     pub fn init(err: BridgeError, action: []const u8, message: []const u8) ErrorContext {
         return .{
@@ -90,7 +98,12 @@ pub const ErrorContext = struct {
         try appendJsonEscaped(allocator, &out, self.action);
         try out.appendSlice(allocator, "\",\"message\":\"");
         try appendJsonEscaped(allocator, &out, self.message);
-        try out.appendSlice(allocator, "\"}");
+        try out.append(allocator, '"');
+        if (self.request_id) |id| {
+            try out.appendSlice(allocator, ",\"id\":");
+            try out.print(allocator, "{d}", .{id});
+        }
+        try out.append(allocator, '}');
 
         return out.toOwnedSlice(allocator);
     }
@@ -165,7 +178,8 @@ pub fn errorMessage(err: BridgeError) []const u8 {
 
 /// Send error to JavaScript via eval
 pub fn sendErrorToJS(allocator: std.mem.Allocator, action: []const u8, err: BridgeError) void {
-    const ctx = ErrorContext.init(err, action, errorMessage(err));
+    var ctx = ErrorContext.init(err, action, errorMessage(err));
+    ctx.request_id = request_context.current();
     const json = ctx.toJSON(allocator) catch {
         if (comptime builtin.mode == .debug)
             std.debug.print("[BridgeError] Failed to serialize error\n", .{});
@@ -198,26 +212,48 @@ pub fn sendErrorToJS(allocator: std.mem.Allocator, action: []const u8, err: Brid
         std.debug.print("[BridgeError] {s}: {s} - {s}\n", .{ action, errorCodeString(err), errorMessage(err) });
 }
 
+/// Render the JS call that hands `result_json` back to the page as the answer
+/// to `request_id`.
+///
+/// Split out from `sendResultToJS` so the exact string that reaches the page
+/// can be asserted in a test. It could not be before, and the shape of this
+/// string is the whole reply contract.
+pub fn formatResultJS(
+    allocator: std.mem.Allocator,
+    action: []const u8,
+    result_json: []const u8,
+    request_id: ?u64,
+) ![]u8 {
+    // Null, not 0 or -1, for "no id": JSON has a real absent value and zero is
+    // a perfectly good id. A sentinel here is how the page ends up treating
+    // some real call as unidentified.
+    var id_buf: [24]u8 = undefined;
+    const id_text: []const u8 = if (request_id) |id|
+        try std.fmt.bufPrint(&id_buf, "{d}", .{id})
+    else
+        "null";
+
+    return std.fmt.allocPrint(
+        allocator,
+        "if(window.__craftBridgeResult)window.__craftBridgeResult('{s}',{s},{s});",
+        .{ action, result_json, id_text },
+    );
+}
+
 /// Send success result to JavaScript
 pub fn sendResultToJS(allocator: std.mem.Allocator, action: []const u8, result_json: []const u8) void {
     const bridge = @import("bridge.zig");
 
-    // Build JavaScript to call result handler
-    const js_template = "if(window.__craftBridgeResult)window.__craftBridgeResult('{s}',{s});";
-    const js_len = js_template.len + action.len + result_json.len;
-
-    const js_buf = allocator.alloc(u8, js_len) catch {
-        if (comptime builtin.mode == .debug)
-            std.debug.print("[BridgeResult] Failed to allocate JS buffer\n", .{});
-        return;
-    };
-    defer allocator.free(js_buf);
-
-    const js = std.fmt.bufPrint(js_buf, js_template, .{ action, result_json }) catch {
+    // Which call this answers. Null when there is no call to name: a reply
+    // raised outside any dispatch, or a message the page sent without an `i`
+    // (the tray and menubar polling `_post`s, which nobody awaits). The page
+    // then matches by action name exactly as it did before ids.
+    const js = formatResultJS(allocator, action, result_json, request_context.current()) catch {
         if (comptime builtin.mode == .debug)
             std.debug.print("[BridgeResult] Failed to format JS\n", .{});
         return;
     };
+    defer allocator.free(js);
 
     bridge.evalJS(js) catch |err| {
         // Was misleadingly logged as "failed to send error to JS" — this
@@ -403,4 +439,132 @@ test "ErrorContext.toJSON handles long messages without overflow" {
     defer allocator.free(json);
 
     try testing.expect(json.len > 4096);
+}
+
+test "a reply names the call it answers" {
+    const allocator = std.testing.allocator;
+    const js = try formatResultJS(allocator, "getDisplays", "{\"displays\":[]}", 7);
+    defer allocator.free(js);
+    try std.testing.expectEqualStrings(
+        "if(window.__craftBridgeResult)window.__craftBridgeResult('getDisplays',{\"displays\":[]},7);",
+        js,
+    );
+}
+
+test "a reply with no call to name says null, not a sentinel" {
+    // An old page, or a reply raised outside dispatch. The page falls back to
+    // matching by action name; it must not read this as "call number 0".
+    const allocator = std.testing.allocator;
+    const js = try formatResultJS(allocator, "getPrimary", "{}", null);
+    defer allocator.free(js);
+    try std.testing.expectEqualStrings(
+        "if(window.__craftBridgeResult)window.__craftBridgeResult('getPrimary',{},null);",
+        js,
+    );
+}
+
+test "call zero is answered as zero" {
+    const allocator = std.testing.allocator;
+    const js = try formatResultJS(allocator, "a", "{}", 0);
+    defer allocator.free(js);
+    try std.testing.expect(std.mem.endsWith(u8, js, "('a',{},0);"));
+}
+
+test "the largest id JavaScript can hold survives the round trip" {
+    // Number.MAX_SAFE_INTEGER. The page counts up from 1 and will never reach
+    // it, but a buffer sized for a small id is the kind of thing that only
+    // fails in the field.
+    const allocator = std.testing.allocator;
+    const js = try formatResultJS(allocator, "a", "{}", 9007199254740991);
+    defer allocator.free(js);
+    try std.testing.expect(std.mem.endsWith(u8, js, "('a',{},9007199254740991);"));
+}
+
+test "a failure names the call that failed" {
+    const allocator = std.testing.allocator;
+    var ctx = ErrorContext.init(BridgeError.NotFound, "get", "Resource not found");
+    ctx.request_id = 42;
+    const json = try ctx.toJSON(allocator);
+    defer allocator.free(json);
+    try std.testing.expectEqualStrings(
+        "{\"error\":true,\"code\":\"NOT_FOUND\",\"action\":\"get\",\"message\":\"Resource not found\",\"id\":42}",
+        json,
+    );
+
+    // Still valid JSON with the field appended, not just string-equal.
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json, .{});
+    defer parsed.deinit();
+    try std.testing.expectEqual(@as(i64, 42), parsed.value.object.get("id").?.integer);
+}
+
+test "a failure outside any call carries no id at all" {
+    // Not `"id":null` — absent. The page tells the two apart: an id it does not
+    // recognise is a call that already settled and the error is dropped, while
+    // no id at all is the old whole-action drain.
+    const allocator = std.testing.allocator;
+    const ctx = ErrorContext.init(BridgeError.NotFound, "get", "Resource not found");
+    const json = try ctx.toJSON(allocator);
+    defer allocator.free(json);
+    try std.testing.expect(std.mem.indexOf(u8, json, "id") == null);
+}
+
+test "the id survives an action name that needs escaping" {
+    const allocator = std.testing.allocator;
+    var ctx = ErrorContext.init(BridgeError.InvalidJSON, "we\"ird\\", "boom\nboom");
+    ctx.request_id = 5;
+    const json = try ctx.toJSON(allocator);
+    defer allocator.free(json);
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json, .{});
+    defer parsed.deinit();
+    try std.testing.expectEqual(@as(i64, 5), parsed.value.object.get("id").?.integer);
+    try std.testing.expectEqualStrings("we\"ird\\", parsed.value.object.get("action").?.string);
+}
+
+test "the reply to a dispatched message names that message's call" {
+    // The seam this whole change turns on, walked end to end: the id is read
+    // out of the envelope the way `handleBridgeMessageJSON` reads it, recorded
+    // the way the dispatcher records it, and read back the way
+    // `sendResultToJS` reads it — without any of the 267 reply sites in
+    // between being told about it.
+    const allocator = std.testing.allocator;
+    request_context.resetForTesting();
+
+    const parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        allocator,
+        \\{"t":"tags","a":"get","d":"{\"path\":\"/a\"}","i":12}
+    ,
+        .{},
+    );
+    defer parsed.deinit();
+
+    request_context.push(request_context.fromEnvelope(parsed.value.object));
+    defer request_context.pop();
+
+    const js = try formatResultJS(allocator, "get", "{\"tags\":[]}", request_context.current());
+    defer allocator.free(js);
+    try std.testing.expect(std.mem.endsWith(u8, js, ",12);"));
+}
+
+test "a dialog's reply is not stamped with the call it dispatched while it waited" {
+    // `runModal` spins a nested run loop that keeps delivering bridge
+    // messages, so a second call is served in the middle of the first. The
+    // dialog's own reply, sent after the inner one, still belongs to the outer
+    // call — this is why the dispatcher keeps a stack.
+    const allocator = std.testing.allocator;
+    request_context.resetForTesting();
+
+    request_context.push(4); // showOpenDialog, now blocked in runModal
+    defer request_context.pop();
+    {
+        request_context.push(5); // a getState the nested run loop delivered
+        defer request_context.pop();
+        const inner = try formatResultJS(allocator, "getState", "{}", request_context.current());
+        defer allocator.free(inner);
+        try std.testing.expect(std.mem.endsWith(u8, inner, ",5);"));
+    }
+
+    const outer = try formatResultJS(allocator, "showOpenDialog", "{}", request_context.current());
+    defer allocator.free(outer);
+    try std.testing.expect(std.mem.endsWith(u8, outer, ",4);"));
 }

--- a/packages/zig/src/bridge_menubar.zig
+++ b/packages/zig/src/bridge_menubar.zig
@@ -17,8 +17,6 @@ pub const MenubarCollapseBridge = struct {
     }
 
     pub fn handleMessage(self: *Self, action: []const u8, data: []const u8) !void {
-        _ = self;
-
         if (std.mem.eql(u8, action, "init")) {
             menubar_collapse.init();
         } else if (std.mem.eql(u8, action, "collapse")) {
@@ -28,20 +26,25 @@ pub const MenubarCollapseBridge = struct {
         } else if (std.mem.eql(u8, action, "toggle")) {
             menubar_collapse.toggle();
         } else if (std.mem.eql(u8, action, "getState")) {
-            // Return current state via JS callback
-            const collapsed = menubar_collapse.isCollapsed();
-            const initialized = menubar_collapse.isInitialized();
-            const sep_hidden = menubar_collapse.isSeparatorHidden();
+            // Answered through `sendResultToJS` like every other request, so it
+            // is stamped with the id of the call it answers. It used to hand
+            // the page a bespoke reply key — `menubarCollapse:getState` — which
+            // the JS side had to queue under by hand: its own pending entry,
+            // its own failure path, and no timeout, so a call native never
+            // answered held its resolver for the life of the page. The id makes
+            // the key irrelevant, so the bespoke queue is gone and this is an
+            // ordinary `_req`.
             var buf: [384]u8 = undefined;
-            const js = std.fmt.bufPrint(&buf, "window.__craftBridgeResult('menubarCollapse:getState',{{collapsed:{s},initialized:{s},separatorHidden:{s}}});", .{
-                if (collapsed) "true" else "false",
-                if (initialized) "true" else "false",
-                if (sep_hidden) "true" else "false",
-            }) catch return;
-            const bridge = @import("bridge.zig");
-            bridge.evalJS(js) catch |err| {
-                std.log.debug("JS eval failed for menubar status callback: {}", .{err});
-            };
+            const json = std.fmt.bufPrint(
+                &buf,
+                "{{\"collapsed\":{s},\"initialized\":{s},\"separatorHidden\":{s}}}",
+                .{
+                    if (menubar_collapse.isCollapsed()) "true" else "false",
+                    if (menubar_collapse.isInitialized()) "true" else "false",
+                    if (menubar_collapse.isSeparatorHidden()) "true" else "false",
+                },
+            ) catch return;
+            @import("bridge_error.zig").sendResultToJS(self.allocator, "getState", json);
         } else if (std.mem.eql(u8, action, "setAutoCollapse")) {
             // Parse delay from data (seconds as string)
             if (data.len > 0) {

--- a/packages/zig/src/js/craft-bridge.js
+++ b/packages/zig/src/js/craft-bridge.js
@@ -12,9 +12,10 @@
 //      when served outside a Craft window). Don't throw at module load.
 //
 // The native side dispatches messages by `t` (type) and answers async ones
-// via `window.__craftBridgeResult(action, payload)`. Promises are resolved
-// per-action — callers that need different per-call replies should pass an
-// `id` field through the `data` payload and correlate themselves.
+// via `window.__craftBridgeResult(action, payload, id)`, where `id` is the
+// `i` this file put on the outgoing message. Replies are matched by that id,
+// so concurrent calls to the same action — and to the same action name on two
+// different bridges — resolve their own callers and nobody else's.
 
 ;(function () {
   if (window.craft && window.craft.__craft_bridge_loaded) return
@@ -25,63 +26,143 @@
   // Core: pending-call queue, result/error delivery, send helpers.
   // -------------------------------------------------------------------------
 
+  // Calls in flight, queued per action name.
+  //
+  // Kept as the fallback for replies that arrive without an id. This file is
+  // `@embedFile`d into the binary and injected at document-start, so the page's
+  // bridge and the native side always ship together and cannot disagree about
+  // the protocol — the fallback is not for version skew. It is for replies
+  // raised outside any dispatch, where there is no request to name: a handler
+  // that answers from a callback after its message returned, or an error the
+  // bridge raises on its own behalf. Matching by name in order is the best
+  // guess available then, and it is exactly what this file did before ids.
   window.__craftBridgePending = window.__craftBridgePending || {}
 
-  // Native calls this with the same `action` string the JS facade enqueued
-  // under, so the queue is keyed by action name. Action collisions across
-  // bridges would confuse the queue — keep names unique on the Zig side.
-  window.__craftBridgeResult = function (action, payload) {
-    const q = window.__craftBridgePending[action] || []
-    if (q.length > 0) {
-      const e = q.shift()
-      if (e && e.resolve) e.resolve(payload || {})
+  // Calls in flight, indexed by the id native echoes back. This is the
+  // correlation that actually holds, and the one used whenever native gives us
+  // an id to use.
+  window.__craftBridgeById = window.__craftBridgeById || {}
+
+  // Monotonic, starting at 1, so `if (id)` is never true for a real call and
+  // zero is free to mean nothing at all.
+  window.__craftBridgeSeq = window.__craftBridgeSeq || 0
+  function _nextId() {
+    window.__craftBridgeSeq += 1
+    return window.__craftBridgeSeq
+  }
+
+  // Drop an entry from both tables. Both, always: an entry left in `byId`
+  // holds its resolver forever, and one left in the action queue shifts every
+  // later fallback reply onto the wrong caller.
+  function _forget(entry) {
+    if (!entry) return
+    if (entry.id) delete window.__craftBridgeById[entry.id]
+    const q = window.__craftBridgePending[entry.action]
+    if (Array.isArray(q)) {
+      const i = q.indexOf(entry)
+      if (i !== -1) q.splice(i, 1)
+      if (q.length === 0) delete window.__craftBridgePending[entry.action]
     }
   }
 
-  // Catastrophic native-side failure: drop every pending promise with the
-  // same error so callers don't hang forever.
-  // Native calls this when an action fails. The payload names the action that
-  // failed, so only that action's callers are rejected — this used to empty the
-  // whole pending table, so one bridge failing took down every unrelated call
-  // in flight at the time.
+  // Native's answer to one call. `id` is the `i` we sent, echoed back; a reply
+  // raised outside any dispatch has none and falls back to the action queue.
+  window.__craftBridgeResult = function (action, payload, id) {
+    if (id !== undefined && id !== null) {
+      const e = window.__craftBridgeById[id]
+      // An id we don't recognise is a call that has already settled — it timed
+      // out, or native answered it twice. Drop it. The old code had no id to
+      // check, so it shifted the action queue and handed this payload to
+      // whoever was at the head: another call's answer, delivered as that
+      // call's own, with nothing to indicate anything had gone wrong.
+      if (!e) return
+      _forget(e)
+      if (e.resolve) e.resolve(payload || {})
+      return
+    }
+
+    // No id to match on. Match by action name, in order, exactly as this file
+    // did before ids existed.
+    const q = window.__craftBridgePending[action]
+    if (!q || q.length === 0) return
+    const e = q[0]
+    _forget(e)
+    if (e.resolve) e.resolve(payload || {})
+  }
+
+  // Native calls this when an action fails.
   //
-  // Fire-and-forget calls (`_send`) never register a pending entry: native
-  // acknowledges nothing on success, so there is nothing to wait on and the
-  // promise has already resolved by the time a failure comes back. Those have
-  // no caller left to reject, so they are reported to the console instead —
+  // `err.id` names the exact call that failed, so exactly that caller is
+  // rejected. That matters more than it sounds: six action names are served by
+  // two or three bridges each (`get` by keychain and tags, `isEnabled` by
+  // autoLaunch, bluetooth and crashReporter, and four more), and rejecting by
+  // action name hands one bridge's failure to a caller waiting on a different
+  // bridge — `craft.bluetooth.isEnabled()` failing would reject an in-flight
+  // `craft.autoLaunch.isEnabled()` with bluetooth's error.
+  //
+  // Without an id, the old behaviour stands: drain that action's queue, or the
+  // whole table if the error does not even name an action, since an error that
+  // cannot be attributed is most likely the bridge itself being in trouble.
+  //
+  // Fire-and-forget calls (`_send`) carry an id but register no pending entry:
+  // native acknowledges nothing on success, so there is nothing to wait on and
+  // the promise resolved the moment the message was posted. Those have no
+  // caller left to reject, so they are reported to the console instead —
   // otherwise the only trace is in the native log, which is not where anyone
   // writing a web page is looking.
   window.__craftBridgeError = function (err) {
     const pending = window.__craftBridgePending || {}
     const action = err && err.action
+    const id = err && err.id
     let rejected = 0
+
+    const report = function () {
+      if (typeof console !== 'undefined' && console.error) {
+        console.error(
+          '[craft] bridge call failed: ' + (action || '(unnamed action)'),
+          (err && err.code) || '', (err && err.message) || '',
+        )
+      }
+    }
+
+    if (id !== undefined && id !== null) {
+      const e = window.__craftBridgeById[id]
+      // No entry means the call already settled, or it was a `_send` that
+      // never registered one. Nobody to tell — say so, rather than rejecting
+      // some other caller who is still waiting and would have succeeded.
+      if (!e) { report(); return }
+      _forget(e)
+      if (e.reject) e.reject(err)
+      return
+    }
 
     const drain = function (key) {
       const q = pending[key]
       if (!Array.isArray(q)) return
       while (q.length > 0) {
         const e = q.shift()
-        if (e && e.reject) { e.reject(err); rejected++ }
+        if (e) {
+          if (e.id) delete window.__craftBridgeById[e.id]
+          if (e.reject) { e.reject(err); rejected++ }
+        }
       }
       delete pending[key]
     }
 
     if (action) drain(action)
-    // An error that does not name its action cannot be targeted; the
-    // conservative reading is that the bridge itself is in trouble.
     else Object.keys(pending).forEach(drain)
 
-    if (rejected === 0 && typeof console !== 'undefined' && console.error) {
-      console.error(
-        '[craft] bridge call failed: ' + (action || '(unnamed action)'),
-        (err && err.code) || '', (err && err.message) || '',
-      )
-    }
+    if (rejected === 0) report()
   }
 
-  function _post(t, a, d) {
+  // `i` is the call id. Every message carries one, fire-and-forget included:
+  // a failure has to be able to name the exact call it came from, and native
+  // reads it back out of the envelope in `handleBridgeMessageJSON`.
+  function _post(t, a, d, i) {
     try {
-      window.webkit.messageHandlers.craft.postMessage({ t: t, a: a, d: d || '' })
+      const msg = { t: t, a: a, d: d || '' }
+      if (i) msg.i = i
+      window.webkit.messageHandlers.craft.postMessage(msg)
       return true
     }
     catch (e) {
@@ -103,19 +184,18 @@
   // can still `await craft.window.show()` without surprises.
   function _send(t, a, d) {
     return new Promise(function (ok, no) {
-      if (_post(t, a, d)) ok()
+      if (_post(t, a, d, _nextId())) ok()
       else no(new Error('craft bridge unavailable'))
     })
   }
 
   // Request-with-response. Native must call sendResultToJS(action, json)
-  // exactly once for each in-flight call. The action name must match.
+  // exactly once for each in-flight call; the dispatcher stamps the reply with
+  // the `i` this call sent, and that id is what resolves the promise.
   //
-  // Note: keyed by action only (not type+action) for compat with the
-  // existing `__craftBridgeResult(action, payload)` contract bridges
-  // have been using. Action collisions across bridges (e.g. two
-  // bridges both having `cancel`) would mix replies; in practice the
-  // action namespace is small and unique. Documented limitation.
+  // The call is registered in both tables: by id, which is exact, and on the
+  // action-name queue, which catches a reply that reaches us without one.
+  // Whichever settles it, `_forget` clears both.
   //
   // Each call is reaped after `__craftBridgeRequestTimeoutMs` (default
   // 30s) so a misbehaving native side can't strand callers forever.
@@ -124,21 +204,22 @@
   const DEFAULT_TIMEOUT_MS = 30000
   function _req(t, a, d, timeoutMs) {
     return new Promise(function (ok, no) {
+      const id = _nextId()
       const q = (window.__craftBridgePending[a] = window.__craftBridgePending[a] || [])
-      const entry = { resolve: ok, reject: no }
+      const entry = { id: id, action: a, resolve: ok, reject: no }
       q.push(entry)
+      window.__craftBridgeById[id] = entry
 
       const timeout = (typeof window.__craftBridgeRequestTimeoutMs === 'number')
         ? window.__craftBridgeRequestTimeoutMs
         : (typeof timeoutMs === 'number' ? timeoutMs : DEFAULT_TIMEOUT_MS)
       const timer = (timeout > 0)
         ? setTimeout(function () {
-            // Remove our entry (may be at any position since other
-            // calls might have arrived in the meantime) and reject.
-            // We only target our own entry, so concurrent calls for
-            // the same action stay healthy.
-            const idx = q.indexOf(entry)
-            if (idx !== -1) q.splice(idx, 1)
+            // Only ever our own entry, from both tables. A late reply then
+            // finds no entry under this id and is dropped, rather than being
+            // handed to whichever caller has since taken our place at the head
+            // of the action queue.
+            _forget(entry)
             no(new Error('craft bridge timed out for ' + t + '/' + a))
           }, timeout)
         : null
@@ -147,9 +228,8 @@
       entry.resolve = function (v) { if (timer) clearTimeout(timer); ok(v) }
       entry.reject  = function (e) { if (timer) clearTimeout(timer); no(e) }
 
-      if (!_post(t, a, d)) {
-        const pi = q.indexOf(entry)
-        if (pi !== -1) q.splice(pi, 1)
+      if (!_post(t, a, d, id)) {
+        _forget(entry)
         if (timer) clearTimeout(timer)
         no(new Error('craft bridge unavailable'))
       }
@@ -1402,19 +1482,13 @@
     collapse:              function ()      { return _send('menubarCollapse', 'collapse') },
     expand:                function ()      { return _send('menubarCollapse', 'expand') },
     toggle:                function ()      { return _send('menubarCollapse', 'toggle') },
-    getState:              function () {
-      // Native menubar uses a fully-qualified result key, so we have to
-      // queue under the same key to receive the response.
-      return new Promise(function (ok, no) {
-        const key = 'menubarCollapse:getState'
-        const q = (window.__craftBridgePending[key] = window.__craftBridgePending[key] || [])
-        q.push({ resolve: ok, reject: no })
-        if (!_post('menubarCollapse', 'getState', '')) {
-          q.pop()
-          no(new Error('craft bridge unavailable'))
-        }
-      })
-    },
+    // Was a hand-rolled pending entry queued under the reply key native used
+    // to invent for it, `menubarCollapse:getState` — with no timeout, so a
+    // call native never answered held its resolver until the page went away.
+    // Native answers by request id now, so the key carries no meaning and this
+    // is an ordinary request. `getState` is also served by screenSharing; the
+    // id is what keeps the two apart.
+    getState:              function ()      { return _req('menubarCollapse', 'getState') },
     // Seconds to wait before tidying up again, or 0 to leave the bar alone.
     // The native side parses this as a number: coercing it to a boolean here
     // sent "true", which parsed as 0 and quietly switched the feature off.

--- a/packages/zig/src/macos.zig
+++ b/packages/zig/src/macos.zig
@@ -6,6 +6,7 @@ const local_tls = @import("local_tls.zig");
 const menu_roles = @import("menu_roles.zig");
 const external_link = @import("external_link.zig");
 const webview_recovery = @import("webview_recovery.zig");
+const request_context = @import("request_context.zig");
 
 // Objective-C runtime types and functions (manual declarations to avoid @cImport issues)
 pub const objc = struct {
@@ -4584,6 +4585,17 @@ pub fn handleBridgeMessageJSON(json_str: []const u8) !void {
         .string => |value| value,
         else => return error.InvalidBridgeMessage,
     };
+
+    // The call this message is, so the reply can name it instead of leaving
+    // `craft-bridge.js` to guess by action name. Recorded here, once, rather
+    // than passed down through 267 reply sites that would each have to
+    // remember to forward it. See `request_context.zig`.
+    //
+    // Pushed unconditionally — a message with no `i` pushes null, so it
+    // shadows an enclosing request instead of inheriting an id that is not
+    // its own. The pop is deferred because dispatch below can fail anywhere.
+    request_context.push(request_context.fromEnvelope(root));
+    defer request_context.pop();
 
     // Extract data if present - could be string, object, array, or missing
     var data_json_str: []const u8 = "";

--- a/packages/zig/src/request_context.zig
+++ b/packages/zig/src/request_context.zig
@@ -1,0 +1,248 @@
+//! Which bridge call the current reply belongs to.
+//!
+//! The page can have several calls of the same action in flight at once, and
+//! six action names are served by more than one bridge (`get` by keychain and
+//! tags, `isEnabled` by autoLaunch, bluetooth and crashReporter, and four
+//! more). Until now a reply named only its action, so `craft-bridge.js` had to
+//! guess which caller it answered by shifting a per-action FIFO — a guess that
+//! is wrong the moment two calls settle out of the order they were made.
+//!
+//! Rather than thread an id parameter through 267 `sendResultToJS` call sites
+//! in 39 files — five different `handleMessage` signatures, most of them
+//! reached through helpers — the dispatcher records the id of the message it
+//! is serving here, and `bridge_error.zig` reads it back when it formats the
+//! reply. Handlers are untouched and cannot forget to pass it along.
+//!
+//! ## Why a stack and not one slot
+//!
+//! Bridge dispatch nests. `bridge_dialog.zig` runs `NSOpenPanel` and friends
+//! through `runModal`, which spins a nested run loop, and that run loop keeps
+//! delivering `WKScriptMessage`s — so a second bridge call is dispatched, and
+//! completes, in the middle of the first one. A single slot would be
+//! overwritten by the inner call and the outer dialog's reply would go out
+//! wearing the inner call's id, which is worse than no id at all: the page
+//! would resolve a stranger's promise and be certain it was right.
+//!
+//! ## Why every frame is pushed, even without an id
+//!
+//! `push` takes an optional. A message that carries no `i` — an older page, or
+//! the description-format fallback path — still pushes a frame, holding null.
+//! If id-less messages skipped the push instead, one dispatched inside a call
+//! that *does* have an id would inherit it, and the same misattribution
+//! follows. An absent id has to shadow the outer one.
+//!
+//! ## Threading
+//!
+//! Thread-local, and deliberately so. Every bridge message is dispatched on the
+//! main thread, and every one of the 267 reply sites is reached synchronously
+//! from that dispatch (verified: none sits inside a `callconv(.c)` callback).
+//! A reply that did somehow originate on a worker thread reads an empty stack,
+//! reports no id, and the page falls back to the action FIFO — exactly the
+//! behaviour it has today. Degrading to the old guess is acceptable; handing
+//! out an id belonging to whatever the main thread happens to be serving is
+//! not.
+
+const std = @import("std");
+
+/// Deep enough for any real nesting: frames are only added by a modal run loop
+/// re-entering dispatch, and those nest by user action — a file panel opened
+/// from a file panel. Sixteen is far past anything a person can drive.
+pub const max_depth = 16;
+
+threadlocal var frames: [max_depth]?u64 = undefined;
+threadlocal var depth: usize = 0;
+
+/// Begin serving `id`. Pass null when the message carried no id, so it shadows
+/// any enclosing request rather than inheriting it. Always pair with `pop`.
+pub fn push(id: ?u64) void {
+    if (depth < max_depth) frames[depth] = id;
+    // Counted past the array on purpose: `pop` stays balanced with `push`, and
+    // `current` reports the overflowed frames as unknown rather than reading a
+    // stale id from the top of the array.
+    depth += 1;
+}
+
+/// Finish serving the innermost request.
+pub fn pop() void {
+    if (depth == 0) return;
+    depth -= 1;
+}
+
+/// The id of the request being served on this thread, or null if there is
+/// none, if it carried none, or if nesting ran past `max_depth`. Null means
+/// "cannot say" — the page keeps its old FIFO behaviour — never "no such
+/// call".
+pub fn current() ?u64 {
+    if (depth == 0 or depth > max_depth) return null;
+    return frames[depth - 1];
+}
+
+/// How deep dispatch is nested right now. For tests and diagnostics.
+pub fn currentDepth() usize {
+    return depth;
+}
+
+/// Drop every frame. Tests only — production balances push/pop with `defer`.
+pub fn resetForTesting() void {
+    depth = 0;
+}
+
+/// The `i` field of a bridge envelope: the page's id for this call.
+///
+/// Absent for the tray and menubar polling `_post`s, which nobody awaits, and
+/// for the description-format fallback path — so a missing or unusable value
+/// is normal and means "no id", not a malformed message.
+/// Accepts a JSON number or a decimal string: JavaScript integers arrive as
+/// numbers, but an id that has been through a `JSON.stringify` round trip on
+/// the page's side could arrive as either.
+pub fn fromEnvelope(root: std.json.ObjectMap) ?u64 {
+    const v = root.get("i") orelse return null;
+    return switch (v) {
+        .integer => |n| if (n >= 0) @intCast(n) else null,
+        .string => |s| std.fmt.parseInt(u64, s, 10) catch null,
+        else => null,
+    };
+}
+
+const testing = std.testing;
+
+test "no request in flight reports no id" {
+    resetForTesting();
+    try testing.expectEqual(@as(?u64, null), current());
+}
+
+test "the id of the request being served is the one reported" {
+    resetForTesting();
+    push(7);
+    defer pop();
+    try testing.expectEqual(@as(?u64, 7), current());
+}
+
+test "a nested request does not leak its id to the enclosing reply" {
+    // This is the dialog case: runModal spins a nested run loop, another
+    // bridge message is dispatched and answered inside it, and only then does
+    // the dialog reply. The outer reply must still be id 1.
+    resetForTesting();
+    push(1);
+    {
+        push(2);
+        try testing.expectEqual(@as(?u64, 2), current());
+        pop();
+    }
+    try testing.expectEqual(@as(?u64, 1), current());
+    pop();
+    try testing.expectEqual(@as(?u64, null), current());
+}
+
+test "a nested message without an id shadows the enclosing one" {
+    // The failure this prevents: an older page, or the description-format
+    // fallback, dispatched inside a call that does have an id. Inheriting 1
+    // here would send that page's reply to a promise it never made.
+    resetForTesting();
+    push(1);
+    push(null);
+    try testing.expectEqual(@as(?u64, null), current());
+    pop();
+    try testing.expectEqual(@as(?u64, 1), current());
+    pop();
+}
+
+test "nesting past max_depth reports unknown rather than a stale id" {
+    resetForTesting();
+    var i: usize = 0;
+    while (i < max_depth) : (i += 1) push(@intCast(i));
+    try testing.expectEqual(@as(?u64, max_depth - 1), current());
+
+    push(999);
+    // 999 had nowhere to go. The answer is "cannot say", not frames[15].
+    try testing.expectEqual(@as(?u64, null), current());
+    pop();
+
+    try testing.expectEqual(@as(?u64, max_depth - 1), current());
+    i = 0;
+    while (i < max_depth) : (i += 1) pop();
+    try testing.expectEqual(@as(usize, 0), currentDepth());
+}
+
+test "push and pop stay balanced across overflow" {
+    resetForTesting();
+    const over = max_depth + 5;
+    var i: usize = 0;
+    while (i < over) : (i += 1) push(1);
+    try testing.expectEqual(@as(usize, over), currentDepth());
+    i = 0;
+    while (i < over) : (i += 1) pop();
+    try testing.expectEqual(@as(usize, 0), currentDepth());
+    try testing.expectEqual(@as(?u64, null), current());
+}
+
+test "pop on an empty stack is not an underflow" {
+    resetForTesting();
+    pop();
+    pop();
+    try testing.expectEqual(@as(usize, 0), currentDepth());
+    push(3);
+    try testing.expectEqual(@as(?u64, 3), current());
+    pop();
+}
+
+test "id zero is a real id, distinct from absent" {
+    // JS ids start at 1 so this should not arise, but the type must not quietly
+    // conflate the two — a `0 == none` sentinel is how this bug class returns.
+    resetForTesting();
+    push(0);
+    try testing.expectEqual(@as(?u64, 0), current());
+    pop();
+    try testing.expectEqual(@as(?u64, null), current());
+}
+
+fn envelopeId(json: []const u8) !?u64 {
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    return fromEnvelope(parsed.value.object);
+}
+
+test "the envelope's id is read as the call id" {
+    try testing.expectEqual(@as(?u64, 12), try envelopeId(
+        \\{"t":"tags","a":"get","d":"","i":12}
+    ));
+}
+
+test "a message with no id is not an error, it is a message nobody awaits" {
+    try testing.expectEqual(@as(?u64, null), try envelopeId(
+        \\{"t":"tray","a":"pollActions","d":""}
+    ));
+}
+
+test "an id that arrived as a string is still an id" {
+    try testing.expectEqual(@as(?u64, 900719925474099), try envelopeId(
+        \\{"t":"tags","a":"get","i":"900719925474099"}
+    ));
+}
+
+test "an unusable id is no id rather than a rejected message" {
+    // The message still has to be served. Refusing to dispatch it would turn a
+    // page that sends something odd into a page where nothing works at all.
+    for ([_][]const u8{
+        \\{"a":"get","i":-1}
+        ,
+        \\{"a":"get","i":null}
+        ,
+        \\{"a":"get","i":"abc"}
+        ,
+        \\{"a":"get","i":{"nested":1}}
+        ,
+        \\{"a":"get","i":[1]}
+        ,
+        \\{"a":"get","i":true}
+        ,
+    }) |json| {
+        try testing.expectEqual(@as(?u64, null), try envelopeId(json));
+    }
+}
+
+test "the largest id JavaScript can count to round-trips" {
+    try testing.expectEqual(@as(?u64, 9007199254740991), try envelopeId(
+        \\{"a":"get","i":9007199254740991}
+    ));
+}

--- a/packages/zig/test/injected_js_test.zig
+++ b/packages/zig/test/injected_js_test.zig
@@ -23,6 +23,7 @@ const capability_actions = contracts.capabilities_actions;
 const prefs = contracts.prefs;
 const prefs_actions = contracts.prefs_actions;
 const shortcut_registry = contracts.shortcuts;
+const bridge_error = contracts.errors;
 
 // Supplied by build.zig as named imports — a test module cannot embed
 // files outside its own package path.
@@ -934,4 +935,194 @@ test "craft.supports answers from the manifest, and fails open without one" {
     // passing.
     try testing.expectEqualStrings("false", try fx.text("String(window.craft.supports('marketplace'))"));
     try testing.expectEqualStrings("false", try fx.text("String(window.craft.supports('marketplace.list'))"));
+}
+
+// =============================================================================
+// Reply correlation (#66)
+// =============================================================================
+
+/// Answer a call the way native does: the exact string `sendResultToJS`
+/// evaluates in the page, built by the same function, id and all.
+fn answer(fx: *Fixture, action: []const u8, payload: []const u8, id: ?u64) !void {
+    const script = try bridge_error.formatResultJS(testing.allocator, action, payload, id);
+    defer testing.allocator.free(script);
+    _ = try fx.ctx.evaluate(script);
+}
+
+test "a call carries an id, and the reply that names it resolves that call" {
+    var fx = try Fixture.init();
+    defer fx.deinit();
+    _ = try fx.ctx.evaluate(WEBVIEW_HOST);
+    _ = try fx.ctx.evaluate(BRIDGE);
+
+    _ = try fx.ctx.evaluate(
+        \\var got = null;
+        \\window.craft.tags.get('/a').then(function (t) { got = t.join(',') });
+    );
+
+    // The page put its own id on the message; native reads it back out of the
+    // envelope in `handleBridgeMessageJSON` and hands it to `formatResultJS`.
+    const id_text = try fx.text("String(posted[0].i)");
+    const id = try std.fmt.parseInt(u64, id_text, 10);
+    try testing.expect(id > 0);
+
+    try answer(&fx, "get", "{\"tags\":[\"red\"]}", id);
+    try testing.expectEqualStrings("red", try fx.text("String(got)"));
+}
+
+test "two bridges sharing an action name do not swap replies" {
+    // `get` is served by keychain and tags both. Answered out of order, which
+    // is what a modal run loop or any slower handler produces, the action-name
+    // queue alone hands each caller the other's payload.
+    var fx = try Fixture.init();
+    defer fx.deinit();
+    _ = try fx.ctx.evaluate(WEBVIEW_HOST);
+    _ = try fx.ctx.evaluate(BRIDGE);
+
+    _ = try fx.ctx.evaluate(
+        \\var secret = 'unset';
+        \\var labels = 'unset';
+        \\window.craft.keychain.get('svc', 'acct').then(function (v) { secret = String(v) });
+        \\window.craft.tags.get('/a').then(function (t) { labels = t.join(',') });
+    );
+
+    try testing.expectEqualStrings("keychain", try fx.text("posted[0].t"));
+    try testing.expectEqualStrings("tags", try fx.text("posted[1].t"));
+
+    const keychain_id = try std.fmt.parseInt(u64, try fx.text("String(posted[0].i)"), 10);
+    const tags_id = try std.fmt.parseInt(u64, try fx.text("String(posted[1].i)"), 10);
+    try testing.expect(keychain_id != tags_id);
+
+    // Tags answers first — the ordering that used to swap them.
+    try answer(&fx, "get", "{\"tags\":[\"red\",\"blue\"]}", tags_id);
+    try answer(&fx, "get", "{\"value\":\"hunter2\"}", keychain_id);
+
+    try testing.expectEqualStrings("hunter2", try fx.text("secret"));
+    try testing.expectEqualStrings("red,blue", try fx.text("labels"));
+}
+
+test "a reply for an id nobody is waiting on resolves nobody" {
+    // A late reply, or a second reply to a call already answered. Without an id
+    // to check against, this payload went to whoever was at the head of the
+    // action queue — a different call's answer, delivered as correct.
+    var fx = try Fixture.init();
+    defer fx.deinit();
+    _ = try fx.ctx.evaluate(WEBVIEW_HOST);
+    _ = try fx.ctx.evaluate(BRIDGE);
+
+    _ = try fx.ctx.evaluate(
+        \\var got = 'unset';
+        \\window.craft.tags.get('/a').then(function (t) { got = t.join(',') });
+    );
+    const id = try std.fmt.parseInt(u64, try fx.text("String(posted[0].i)"), 10);
+
+    try answer(&fx, "get", "{\"tags\":[\"ghost\"]}", id + 1000);
+    try testing.expectEqualStrings("unset", try fx.text("got"));
+
+    try answer(&fx, "get", "{\"tags\":[\"mine\"]}", id);
+    try testing.expectEqualStrings("mine", try fx.text("got"));
+}
+
+test "a reply that arrives without an id still resolves its caller" {
+    // The fallback path, for a reply raised outside any dispatch — native has
+    // no request to name. `formatResultJS` renders `null` and the page matches
+    // by action name, exactly as it did before ids.
+    var fx = try Fixture.init();
+    defer fx.deinit();
+    _ = try fx.ctx.evaluate(WEBVIEW_HOST);
+    _ = try fx.ctx.evaluate(BRIDGE);
+
+    _ = try fx.ctx.evaluate(
+        \\var got = 'unset';
+        \\window.craft.tags.get('/a').then(function (t) { got = t.join(',') });
+    );
+    try answer(&fx, "get", "{\"tags\":[\"ok\"]}", null);
+    try testing.expectEqualStrings("ok", try fx.text("got"));
+}
+
+test "fire-and-forget messages carry an id too" {
+    // So a failure can name the exact send it came from instead of rejecting
+    // whatever request happens to share its action name.
+    var fx = try Fixture.init();
+    defer fx.deinit();
+    _ = try fx.ctx.evaluate(WEBVIEW_HOST);
+    _ = try fx.ctx.evaluate(BRIDGE);
+
+    _ = try fx.ctx.evaluate("window.craft.keychain.set('svc', 'acct', 'pw');");
+    try testing.expectEqualStrings("keychain", try fx.text("posted[0].t"));
+    try testing.expectEqualStrings("true", try fx.text("String(typeof posted[0].i === 'number' && posted[0].i > 0)"));
+}
+
+test "a failure rejects the call it names and leaves the others alone" {
+    // `isEnabled` is served by autoLaunch, bluetooth and crashReporter.
+    var fx = try Fixture.init();
+    defer fx.deinit();
+    _ = try fx.ctx.evaluate(WEBVIEW_HOST);
+    _ = try fx.ctx.evaluate(BRIDGE);
+
+    _ = try fx.ctx.evaluate(
+        \\var autoLaunch = 'pending';
+        \\var bluetooth = 'pending';
+        \\window.craft.autoLaunch.isEnabled().then(
+        \\  function (v) { autoLaunch = 'ok:' + v }, function (e) { autoLaunch = 'rejected' });
+        \\window.craft.bluetooth.isEnabled().then(
+        \\  function (v) { bluetooth = 'ok:' + v }, function (e) { bluetooth = 'rejected:' + e.message });
+    );
+
+    const bluetooth_id = try std.fmt.parseInt(u64, try fx.text("String(posted[1].i)"), 10);
+
+    var ctx = bridge_error.ErrorContext.init(
+        bridge_error.BridgeError.NativeCallFailed,
+        "isEnabled",
+        "no bluetooth",
+    );
+    ctx.request_id = bluetooth_id;
+    const json = try ctx.toJSON(testing.allocator);
+    defer testing.allocator.free(json);
+    const script = try std.fmt.allocPrint(testing.allocator, "window.__craftBridgeError({s});", .{json});
+    defer testing.allocator.free(script);
+    _ = try fx.ctx.evaluate(script);
+
+    try testing.expectEqualStrings("rejected:no bluetooth", try fx.text("bluetooth"));
+    // The other bridge never heard about it and still answers normally.
+    try testing.expectEqualStrings("pending", try fx.text("autoLaunch"));
+
+    const auto_id = try std.fmt.parseInt(u64, try fx.text("String(posted[0].i)"), 10);
+    try answer(&fx, "isEnabled", "{\"value\":true}", auto_id);
+    try testing.expectEqualStrings("ok:true", try fx.text("autoLaunch"));
+}
+
+test "the menubar state reply no longer needs a queue of its own" {
+    // `getState` used to be answered under an invented reply key,
+    // `menubarCollapse:getState`, with a hand-rolled pending entry on the JS
+    // side that had no timeout. It is an ordinary request now, and the reply
+    // is matched by id like every other — which also keeps it apart from
+    // screenSharing's `getState`, the seventh action name two bridges share.
+    var fx = try Fixture.init();
+    defer fx.deinit();
+    _ = try fx.ctx.evaluate(WEBVIEW_HOST);
+    _ = try fx.ctx.evaluate(BRIDGE);
+
+    _ = try fx.ctx.evaluate(
+        \\var menubar = 'pending';
+        \\var sharing = 'pending';
+        \\window.craft.menubar.getState().then(function (s) { menubar = String(s.collapsed) });
+        \\window.craft.screenSharing.getState().then(function (s) { sharing = String(s.sharing) });
+    );
+
+    try testing.expectEqualStrings("menubarCollapse", try fx.text("posted[0].t"));
+    try testing.expectEqualStrings("getState", try fx.text("posted[0].a"));
+    try testing.expectEqualStrings("screenSharing", try fx.text("posted[1].t"));
+
+    const menubar_id = try std.fmt.parseInt(u64, try fx.text("String(posted[0].i)"), 10);
+    const sharing_id = try std.fmt.parseInt(u64, try fx.text("String(posted[1].i)"), 10);
+
+    try answer(&fx, "getState", "{\"sharing\":true}", sharing_id);
+    try answer(&fx, "getState", "{\"collapsed\":true,\"initialized\":true,\"separatorHidden\":false}", menubar_id);
+
+    try testing.expectEqualStrings("true", try fx.text("menubar"));
+    try testing.expectEqualStrings("true", try fx.text("sharing"));
+
+    // And nothing is left queued under the key it used to invent.
+    try testing.expectEqualStrings("undefined", try fx.text("String(window.__craftBridgePending['menubarCollapse:getState'])"));
 }


### PR DESCRIPTION
Closes #66.

## The bug

`craft-bridge.js` matched native's replies to the callers waiting for them by shifting a FIFO keyed on the action name. That guess is wrong whenever two calls settle out of the order they were made, and it fails silently — the caller resolves, with somebody else's payload.

The issue frames this as a narrow same-action race. It is wider than that. **Six action names are served by more than one bridge:**

| action | bridges |
|---|---|
| `get` | keychain, tags |
| `isAvailable` | biometric, iap, speechRecognition |
| `isEnabled` | autoLaunch, bluetooth, crashReporter |
| `list` | serial, shortcuts |
| `requestPermission` | location, notification |
| `start` | localServer, speechRecognition |

Fifteen distinct `(type, action)` pairs collapse onto six queue keys. `Promise.all([craft.keychain.get(…), craft.tags.get(…)])` is enough to reach it.

The error path was worse than the reply path. `__craftBridgeError` drained the entire queue for an action name, so `craft.bluetooth.isEnabled()` failing rejected an in-flight `craft.autoLaunch.isEnabled()` with bluetooth's error — a bridge the caller never touched.

## The fix

The page puts an `i` on every message; native echoes it back; replies resolve by id.

Threading an id through the handlers would have meant touching **267 `sendResultToJS` call sites across 39 files**, reached through five different `handleMessage` signatures and a layer of per-bridge helpers — and every future one would have to remember. Instead the dispatcher records the id in a new `request_context.zig` and `bridge_error.zig` reads it back when it formats the reply. **`macos.zig` grows twelve lines. No handler changes at all.**

Three decisions worth the review time:

**A stack, not a slot.** Dispatch nests — `runModal` spins a nested run loop that keeps delivering bridge messages, so a second call is served in the middle of the first. A slot would be clobbered by the inner call and the dialog's reply would go out wearing the inner call's id. That is *worse* than no id: the page resolves a stranger's promise and is certain it was right.

**A message with no id pushes null, rather than skipping the push.** An absent id has to shadow the enclosing one. If id-less messages skipped, one dispatched inside a call that *does* have an id would inherit it — the same misattribution by another route.

**`null` for absent, never `0` or `-1`.** Zero is a perfectly good id, and a sentinel is how this bug class returns. Likewise, a reply carrying an id the page does not recognise is **dropped**, not fallen back to the queue — falling back *is* the swap.

## Also fixed

`menubar.getState` had a hand-rolled pending entry queued under a reply key native invented for it (`menubarCollapse:getState`), bypassing `_req` entirely — including its timeout, so a call native never answered held its resolver for the life of the page. The id makes the key meaningless, so it is an ordinary `_req` now. That puts it on `getState` alongside screenSharing — a seventh collision, which the ids handle.

## How it's tested

By driving the real bridge, not by reading it.

- **13 bun tests** (`bridge-request-id.test.ts`) run the embedded `craft-bridge.js` in a synthetic window and check *which promise settled with what*. Against the version on `main`, **9 of the 13 fail**; the 4 that pass are precisely the ones asserting the unchanged fallback. Two are inverted controls that reproduce the original swap.
- **8 tests in `injected_js_test.zig`** run it in a real JS engine via zig-js and answer it with the very string `sendResultToJS` emits — so the JS half and the native half cannot drift apart silently.
- **20 Zig unit tests** across `request_context.zig` and `bridge_error.zig`, including the nested-dialog case and the exact reply strings.

Every one of those was control-checked. Sabotaging the JS id branch fails the suite; making native emit `null` instead of the id fails it; renaming the menubar action fails it. Before this change, sabotaging the id branch changed nothing, because nothing exercised it.

## Verified

`zig build` · `zig build test` · `zig build test-js` · `x86_64-windows` cross-build · `zig fmt --check` · `tsc --noEmit` · 506 bun tests (was 493) · pickier 38 warnings, unchanged from main.

Linux is unbuildable on this machine (no gtk+-3.0 / webkit2gtk-4.1); it compiles and fails at link, as it does on `main`.