### PR TITLE
fix(webview): recover from renderer crashes, and stop dropping window.open()

### DIFF
--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -640,6 +640,27 @@ pub fn build(b: *std.Build) void {
         }),
     });
 
+    // Where a link that asks for a new window is allowed to go. Pure policy,
+    // so the whole drop list is provable without a browser.
+    const external_link_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/external_link.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
+    // The reload budget that brings a window back after WebKit's content
+    // process dies. Pure, and takes its clock as an argument, so a crash loop
+    // is testable without crashing anything.
+    const webview_recovery_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/webview_recovery.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
     // The conformance test: what craft declares, against what it dispatches.
     const capability_conformance_tests = b.addTest(.{
         .root_module = b.createModule(.{
@@ -1010,6 +1031,8 @@ pub fn build(b: *std.Build) void {
     const run_local_tls_tests = b.addRunArtifact(local_tls_tests);
     const run_menu_roles_tests = b.addRunArtifact(menu_roles_tests);
     const run_capabilities_tests = b.addRunArtifact(capabilities_tests);
+    const run_external_link_tests = b.addRunArtifact(external_link_tests);
+    const run_webview_recovery_tests = b.addRunArtifact(webview_recovery_tests);
     const run_prefs_tests = b.addRunArtifact(prefs_tests);
     const run_prefs_macos_tests = b.addRunArtifact(prefs_macos_tests);
     const run_key_codes_tests = b.addRunArtifact(key_codes_tests);
@@ -1123,6 +1146,8 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_local_tls_tests.step);
     test_step.dependOn(&run_menu_roles_tests.step);
     test_step.dependOn(&run_capabilities_tests.step);
+    test_step.dependOn(&run_external_link_tests.step);
+    test_step.dependOn(&run_webview_recovery_tests.step);
     // macOS only: the registry describes the dispatch chain in macos.zig, and
     // compiling it elsewhere drags the whole native graph into a test binary
     // for a platform it does not describe.

--- a/packages/zig/src/external_link.zig
+++ b/packages/zig/src/external_link.zig
@@ -1,0 +1,146 @@
+//! Where a link that wants a new window is allowed to go.
+//!
+//! `window.open()` and `target="_blank"` ask WKWebView for a second webview.
+//! Craft has nowhere to put one, so the request is answered by handing the URL
+//! to the system browser and creating nothing — the convention Electron
+//! settled on, and what a person clicking a link expects.
+//!
+//! Which URLs, though, is a security question rather than a routing one. The
+//! page asking is not necessarily trusted: an app that renders a chat
+//! transcript, a feed, or any third-party HTML is asking on behalf of whoever
+//! wrote that content. `NSWorkspace openURL:` is not a browser call — it is
+//! "ask LaunchServices to do whatever this URL means", and what it means is
+//! decided by whatever is installed on the machine.
+//!
+//! So this allows exactly `http` and `https` and drops everything else:
+//!
+//!   - `file://` would hand LaunchServices a local path, which for a `.app`,
+//!     a `.command`, or anything with a registered handler is a launch. The
+//!     `shell.openExternal` bridge does allow `file://`, and should — the app
+//!     itself is calling it, on a path it chose. This is a page calling it, on
+//!     a URL nobody vetted, and the two do not deserve the same list.
+//!   - Custom schemes reach any registered app: `x-apple.systempreferences:`
+//!     opens System Settings panes, and every installed app that claims a
+//!     scheme is one `window.open` away.
+//!   - `javascript:` and `data:` are not the browser's to open at all.
+//!
+//! An app that genuinely wants a wider policy has `shell.openExternal`, where
+//! its own code decides. That is the difference this file is drawing.
+
+const std = @import("std");
+
+pub const Decision = enum {
+    /// Hand it to the system browser and create no webview.
+    open_externally,
+    /// Create nothing and go nowhere. Logged, never silent.
+    drop,
+};
+
+/// The schemes a page may send to the system browser, lower-case and with the
+/// colon, so a prefix match cannot accept `https-evil:`.
+const allowed = [_][]const u8{ "http:", "https:" };
+
+/// What to do with a URL a page asked to open in a new window.
+///
+/// Nothing here parses the URL beyond its scheme: the scheme is the whole
+/// decision, and a parser that tried to do more would be a second place for
+/// the two sides to disagree about what a URL is.
+pub fn decide(url: []const u8) Decision {
+    const scheme_end = std.mem.indexOfScalar(u8, url, ':') orelse return .drop;
+    const scheme = url[0 .. scheme_end + 1];
+
+    // A URL is not required to be short, but a scheme is: RFC 3986 gives no
+    // limit, yet nothing legitimate is close, and this bounds the buffer.
+    if (scheme.len > 16) return .drop;
+
+    var lowered: [16]u8 = undefined;
+    for (scheme, 0..) |c, i| lowered[i] = std.ascii.toLower(c);
+
+    for (allowed) |ok| {
+        if (std.mem.eql(u8, lowered[0..scheme.len], ok)) return .open_externally;
+    }
+    return .drop;
+}
+
+const testing = std.testing;
+
+test "ordinary web links go to the browser" {
+    try testing.expectEqual(Decision.open_externally, decide("https://example.com/a"));
+    try testing.expectEqual(Decision.open_externally, decide("http://example.com"));
+    try testing.expectEqual(Decision.open_externally, decide("https://example.com:8443/a?b=c#d"));
+}
+
+test "the scheme is matched without regard to case" {
+    // `Https://` is a perfectly ordinary link, and a case-sensitive check is
+    // also a bypass: the drop list would be trivially escaped by shifting one
+    // letter.
+    try testing.expectEqual(Decision.open_externally, decide("HTTPS://example.com"));
+    try testing.expectEqual(Decision.open_externally, decide("HtTp://example.com"));
+}
+
+test "a file URL from a page is not opened" {
+    // `shell.openExternal` allows these because the app is calling it about a
+    // path it chose. A page is not the app.
+    try testing.expectEqual(Decision.drop, decide("file:///Applications/Calculator.app"));
+    try testing.expectEqual(Decision.drop, decide("FILE:///etc/passwd"));
+}
+
+test "script and inline-data URLs are not the browser's to open" {
+    try testing.expectEqual(Decision.drop, decide("javascript:alert(1)"));
+    try testing.expectEqual(Decision.drop, decide("JavaScript:alert(1)"));
+    try testing.expectEqual(Decision.drop, decide("data:text/html,<script>alert(1)</script>"));
+}
+
+test "custom schemes cannot reach installed apps" {
+    // Each of these is a real handler on a stock or common macOS install.
+    for ([_][]const u8{
+        "x-apple.systempreferences:com.apple.preference.security",
+        "ftp://example.com",
+        "smb://server/share",
+        "vnc://host",
+        "ssh://host",
+        "itms-apps://apps.apple.com/app/id1",
+        "zoommtg://zoom.us/join?confno=1",
+        "slack://open",
+        "craft://whatever",
+        "mailto:someone@example.com",
+        "tel:+15551234",
+    }) |url| {
+        try testing.expectEqual(Decision.drop, decide(url));
+    }
+}
+
+test "a scheme that merely starts with an allowed one is not allowed" {
+    // The colon is part of the match for this reason.
+    try testing.expectEqual(Decision.drop, decide("https-evil://example.com"));
+    try testing.expectEqual(Decision.drop, decide("httpx://example.com"));
+    try testing.expectEqual(Decision.drop, decide("httpsx:"));
+}
+
+test "something with no scheme at all goes nowhere" {
+    try testing.expectEqual(Decision.drop, decide(""));
+    try testing.expectEqual(Decision.drop, decide("example.com"));
+    try testing.expectEqual(Decision.drop, decide("//example.com"));
+    try testing.expectEqual(Decision.drop, decide("/relative/path"));
+}
+
+test "a leading space does not smuggle a scheme past the check" {
+    // WKWebView hands over an NSURL that has already been parsed, so this
+    // should not arise — but the check must not be the reason it is safe.
+    try testing.expectEqual(Decision.drop, decide(" https://example.com"));
+    try testing.expectEqual(Decision.drop, decide("\thttps://example.com"));
+    try testing.expectEqual(Decision.drop, decide("\nhttps://example.com"));
+}
+
+test "an absurdly long scheme is refused rather than truncated" {
+    var buf: [64]u8 = undefined;
+    @memset(&buf, 'a');
+    buf[63] = ':';
+    try testing.expectEqual(Decision.drop, decide(&buf));
+}
+
+test "a bare scheme with nothing after it is still a web link" {
+    // Degenerate, and NSWorkspace will do nothing useful with it, but it is
+    // not this file's job to invent a second opinion about URL syntax.
+    try testing.expectEqual(Decision.open_externally, decide("https:"));
+}

--- a/packages/zig/src/macos.zig
+++ b/packages/zig/src/macos.zig
@@ -4,6 +4,8 @@ const javascript = @import("javascript.zig");
 const native_sidebar_bootstrap = @import("native_sidebar_bootstrap.zig");
 const local_tls = @import("local_tls.zig");
 const menu_roles = @import("menu_roles.zig");
+const external_link = @import("external_link.zig");
+const webview_recovery = @import("webview_recovery.zig");
 
 // Objective-C runtime types and functions (manual declarations to avoid @cImport issues)
 pub const objc = struct {
@@ -843,6 +845,7 @@ pub fn createWindowWithStyle(title: []const u8, width: u32, height: u32, html: ?
         const nsurl = msgSend1(getClass("NSURL"), "URLWithString:", url_str);
         const request = msgSend1(getClass("NSURLRequest"), "requestWithURL:", nsurl);
         _ = msgSend1(webview, "loadRequest:", request);
+        rememberContent(webview, .{ .request = request });
         startup_timing.mark(.load_started);
     } else if (html) |h| {
         if (style.benchmark) {
@@ -866,6 +869,7 @@ pub fn createWindowWithStyle(title: []const u8, width: u32, height: u32, html: ?
             const base_url = msgSend1(getClass("NSURL"), "URLWithString:", base_url_string);
 
             _ = msgSend2(webview, "loadHTMLString:baseURL:", html_str, base_url);
+            rememberContent(webview, .{ .html = .{ .string = html_str, .base_url = base_url } });
         }
     }
 
@@ -882,21 +886,34 @@ pub fn createWindowWithStyle(title: []const u8, width: u32, height: u32, html: ?
         @import("macos_file_drop.zig").install();
     }
 
-    // Set up UI delegate for camera/microphone permission handling (skip if not needed)
-    if (style.dev_tools) {
+    // Both delegates, in every non-benchmark window.
+    //
+    // The UI delegate used to be installed only with `--dev-tools`, which is
+    // not a condition any of its callbacks have anything to do with: a
+    // packaged app calling `getUserMedia()` got no delegate and so was denied
+    // the camera outright, and `window.open()` had nowhere to be handled. The
+    // navigation delegate used to install only under `CRAFT_ALLOW_LOCAL_TLS`,
+    // which left every shipped window without the callback that notices the
+    // content process has died.
+    //
+    // Skipped in benchmark mode alongside the file-drop hook and the bridge,
+    // so the startup numbers keep measuring the same window they always did.
+    //
+    // After the load, not before, and that is safe: `loadRequest:` only
+    // schedules the fetch, and every delegate callback arrives through the run
+    // loop, which is not entered until much later. (The note that used to be
+    // here said "before the load below" — the load moved above it.)
+    if (!style.benchmark) {
         setupUIDelegate(webview) catch |err| {
             if (comptime builtin.mode == .debug)
                 std.debug.print("[Media] Failed to setup UI delegate: {}\n", .{err});
         };
-    }
 
-    // Not gated on dev_tools: whether the inspector is available and whether a
-    // local certificate is trusted are unrelated questions. Before the load
-    // below, so it is in place for the first request's challenge.
-    setupNavigationDelegate(webview) catch |err| {
-        if (comptime builtin.mode == .debug)
-            std.debug.print("[Nav] Failed to setup navigation delegate: {}\n", .{err});
-    };
+        setupNavigationDelegate(webview) catch |err| {
+            if (comptime builtin.mode == .debug)
+                std.debug.print("[Nav] Failed to setup navigation delegate: {}\n", .{err});
+        };
+    }
 
     if (style.benchmark) {
         // Benchmark mode: minimal setup — just set content view and return
@@ -5153,7 +5170,69 @@ fn handleMediaCapturePermission(
     }
 }
 
-/// Set up WKUIDelegate to handle media capture permission requests
+/// `webView:createWebViewWithConfiguration:forNavigationAction:windowFeatures:`
+///
+/// WKWebView asks for this whenever the page wants a second window —
+/// `window.open()`, `target="_blank"`, `<form target>`. If the delegate does
+/// not implement it, WebKit's answer is to do nothing at all: `window.open()`
+/// returns null and the link dies with no error, no console message and no
+/// log. Every link in a rendered transcript or feed simply did nothing.
+///
+/// Craft has no second window to give (that is #67), so the answer is the one
+/// Electron settled on: hand the URL to the system browser and return nil, so
+/// no child webview is created.
+///
+/// Which URLs get handed over is decided by `external_link.zig`, and it is
+/// deliberately narrower than `shell.openExternal`: this is a *page* asking,
+/// possibly on behalf of content nobody vetted, and `NSWorkspace openURL:`
+/// means "ask LaunchServices to do whatever this URL means".
+fn handleCreateWebView(
+    _: objc.id,
+    _: objc.SEL,
+    _: objc.id,
+    _: objc.id,
+    navigationAction: objc.id,
+    _: objc.id,
+) callconv(.c) objc.id {
+    // Returning nil is the point of the method, so every path out returns nil.
+    const request = msgSend0(navigationAction, "request");
+    if (request == null) return null;
+    const nsurl = msgSend0(request, "URL");
+    if (nsurl == null) return null;
+
+    const absolute = msgSend0(nsurl, "absoluteString");
+    if (absolute == null) return null;
+    const raw = msgSend0(absolute, "UTF8String") orelse return null;
+    const cstr: [*:0]const u8 = @ptrCast(@alignCast(raw));
+    const url = std.mem.span(cstr);
+
+    switch (external_link.decide(url)) {
+        .open_externally => {
+            const NSWorkspace = getClass("NSWorkspace");
+            const workspace = msgSend0(NSWorkspace, "sharedWorkspace");
+            _ = msgSend1(workspace, "openURL:", nsurl);
+        },
+        // Logged, never silent: a dropped link that says nothing is the bug
+        // this method exists to fix, and refusing one quietly is the same
+        // experience by a different route.
+        .drop => std.log.warn(
+            "refused to open a new window for a URL the page cannot send to the browser: {s}",
+            .{url},
+        ),
+    }
+
+    return null;
+}
+
+/// Attach craft's `WKUIDelegate`.
+///
+/// Two callbacks, neither of which has anything to do with the other:
+/// `getUserMedia()` permission, and the page asking for a second window.
+///
+/// Installed in every non-benchmark window. It used to be installed only under
+/// `--dev-tools`, which meant a packaged app was denied the camera outright
+/// and had `window.open()` silently dropped — neither of which is a debugging
+/// concern.
 pub fn setupUIDelegate(webview: objc.id) !void {
     if (comptime builtin.mode == .debug)
         std.debug.print("[Media] Setting up WKUIDelegate for media permissions...\n", .{});
@@ -5195,6 +5274,19 @@ pub fn setupUIDelegate(webview: objc.id) !void {
             } else {
                 std.debug.print("[Media] Added webView:requestMediaCapturePermissionForOrigin:... method\n", .{});
             }
+        }
+
+        // `window.open()` / `target="_blank"`. Returns an object (the child
+        // webview, or nil): @ = id return, self, _cmd, webView, configuration,
+        // navigationAction, windowFeatures.
+        if (!objc.class_addMethod(
+            @ptrCast(@alignCast(delegateClass)),
+            objc.sel_registerName("webView:createWebViewWithConfiguration:forNavigationAction:windowFeatures:"),
+            @as(objc.IMP, @ptrCast(@constCast(&handleCreateWebView))),
+            "@@:@@@@",
+        )) {
+            if (comptime builtin.mode == .debug)
+                std.debug.print("[UI] Failed to add createWebView method\n", .{});
         }
 
         // Register the class
@@ -5289,6 +5381,14 @@ fn handleAuthChallenge(
     challenge: objc.id,
     completionHandler: objc.id,
 ) callconv(.c) void {
+    // The opt-in used to be enforced by not installing the delegate at all.
+    // The delegate is installed in every window now — it is what notices the
+    // content process has died — so the check has to live here instead.
+    // Without this line, ungating the delegate would silently start trusting
+    // local development certificates in every craft app ever shipped.
+    if (!allowsLocalDevTLS())
+        return finishAuthChallenge(completionHandler, .perform_default_handling, null);
+
     const protectionSpace = msgSend0(challenge, "protectionSpace");
     if (protectionSpace == null)
         return finishAuthChallenge(completionHandler, .perform_default_handling, null);
@@ -5309,19 +5409,154 @@ fn handleAuthChallenge(
     finishAuthChallenge(completionHandler, .use_credential, credential);
 }
 
-/// Attach a `WKNavigationDelegate` that trusts local development certificates.
-///
-/// A no-op unless the process opted in: without `CRAFT_ALLOW_LOCAL_TLS` craft
-/// installs no navigation delegate at all, which is exactly the behaviour it
-/// has always had. Implementing only the auth-challenge method leaves every
-/// other navigation decision — policy, redirects, provisional failures — at its
-/// AppKit default.
-///
-/// Call before loading, so the delegate is in place for the first request's
-/// challenge.
-pub fn setupNavigationDelegate(webview: objc.id) !void {
-    if (!allowsLocalDevTLS()) return;
+// =============================================================================
+// Recovering a window after the WebKit content process dies
+// =============================================================================
 
+/// What craft put in a webview, kept so it can be put back.
+///
+/// `-reload` is Apple's documented recovery and it is wrong for half of
+/// craft's windows. HTML loaded through `loadHTMLString:baseURL:` has no
+/// request to repeat: reloading navigates to the synthetic base URL,
+/// `http://localhost/`, where there is usually nothing listening — so a window
+/// started from `--html` would come back as a connection error instead of the
+/// app it was showing. Re-applying what was loaded is right for both paths.
+const LoadedContent = union(enum) {
+    none,
+    request: objc.id,
+    html: struct { string: objc.id, base_url: objc.id },
+};
+
+const ContentSlot = struct {
+    key: usize = 0,
+    content: LoadedContent = .none,
+};
+
+/// Sized to match `webview_recovery`'s budget table: the two are keyed the
+/// same way and a window in one should be in the other.
+var content_slots: [8]ContentSlot = @splat(.{});
+
+/// Hold on to what a webview was given, retaining it for as long as the window
+/// might need it back.
+///
+/// `requestWithURL:` and `URLWithString:` both hand back autoreleased objects,
+/// so without the retain these are dangling by the time the run loop next
+/// drains — which is long before any crash. The matching release would be at
+/// window teardown; craft never tears one down today, and one request or one
+/// HTML string per window is not a leak worth the risk of releasing early.
+fn rememberContent(webview: objc.id, content: LoadedContent) void {
+    switch (content) {
+        .none => {},
+        .request => |r| _ = msgSend0(r, "retain"),
+        .html => |h| {
+            _ = msgSend0(h.string, "retain");
+            if (h.base_url != null) _ = msgSend0(h.base_url, "retain");
+        },
+    }
+
+    const key = @intFromPtr(webview);
+    // Existing entry first, then a free one. Taking whichever comes first would
+    // leave a stale duplicate behind for a webview that loads twice.
+    for (&content_slots) |*slot| {
+        if (slot.key == key) {
+            slot.content = content;
+            return;
+        }
+    }
+    for (&content_slots) |*slot| {
+        if (slot.key == 0) {
+            slot.* = .{ .key = key, .content = content };
+            return;
+        }
+    }
+    // Full. Slot zero holds the earliest window registered, which is the one
+    // least likely to still be around.
+    content_slots[0] = .{ .key = key, .content = content };
+}
+
+fn contentFor(webview: objc.id) LoadedContent {
+    const key = @intFromPtr(webview);
+    for (&content_slots) |slot| {
+        if (slot.key == key) return slot.content;
+    }
+    return .none;
+}
+
+/// Put the window's content back after the content process was replaced.
+fn restoreContent(webview: objc.id) void {
+    switch (contentFor(webview)) {
+        .request => |r| _ = msgSend1(webview, "loadRequest:", r),
+        .html => |h| _ = msgSend2(webview, "loadHTMLString:baseURL:", h.string, h.base_url),
+        // Nothing recorded — a webview craft did not load. `reload` is the
+        // best available guess and does no harm if there is nothing to reload.
+        .none => _ = msgSend0(webview, "reload"),
+    }
+}
+
+/// `webViewWebContentProcessDidTerminate:`
+///
+/// WKWebView renders in a separate process, and when that process is killed
+/// the view does not error or close — it goes white and stays white. This is
+/// the only notification of it. Without this method craft had no route back
+/// except the Reload menu item, which a user has to know to look for, and
+/// which nothing on the blank screen suggests.
+///
+/// Logged at warning level rather than behind a debug check: an app that quietly
+/// reloaded itself at 3am is something whoever reads the logs should be able to
+/// find out about.
+fn handleContentProcessTerminated(_: objc.id, _: objc.SEL, webview: objc.id) callconv(.c) void {
+    const key = @intFromPtr(webview);
+    const state = webview_recovery.stateFor(key);
+    // `compat.nanoTimestamp` is CLOCK_MONOTONIC here, which is what a rate
+    // budget wants: a clock the user can move is a clock that can hand out
+    // extra reloads. It returns 0 if the clock cannot be read at all, which
+    // reads as "no time passed" and keeps the burst intact — the conservative
+    // direction.
+    const now = @import("compat.zig").nanoTimestamp();
+    const action = webview_recovery.onCrash(state, now, .{});
+
+    switch (action) {
+        .reload => {
+            std.log.warn(
+                "WebKit content process terminated; restoring the window (attempt {d})",
+                .{state.attempts},
+            );
+            restoreContent(webview);
+        },
+        .give_up => {
+            std.log.warn(
+                "WebKit content process terminated {d} times in quick succession; " ++
+                    "leaving the window alone so it stops looping",
+                .{state.attempts},
+            );
+            const NSString = getClass("NSString");
+            const html = msgSend1(
+                NSString,
+                "stringWithUTF8String:",
+                @as([*:0]const u8, webview_recovery.give_up_page),
+            );
+            _ = msgSend2(webview, "loadHTMLString:baseURL:", html, @as(objc.id, null));
+        },
+    }
+}
+
+/// Attach craft's `WKNavigationDelegate`.
+///
+/// Two methods, for two unrelated jobs:
+///
+///   - `webViewWebContentProcessDidTerminate:` — the only notification that
+///     WebKit's renderer died. Without it the window is white and stays white.
+///     Every window needs this.
+///   - `webView:didReceiveAuthenticationChallenge:completionHandler:` — trusts
+///     a local development CA, and only when `CRAFT_ALLOW_LOCAL_TLS` says so.
+///     That opt-in is enforced inside the handler, because the delegate itself
+///     is no longer optional.
+///
+/// It used to install only under `CRAFT_ALLOW_LOCAL_TLS`, which meant every
+/// shipped app ran without the crash notification. Everything not implemented
+/// here — navigation policy, redirects, provisional failures — stays at its
+/// AppKit default, as before.
+pub fn setupNavigationDelegate(webview: objc.id) !void {
     const superclass = getClass("NSObject");
     const className = "CraftNavigationDelegate";
 
@@ -5339,6 +5574,15 @@ pub fn setupNavigationDelegate(webview: objc.id) !void {
         if (!objc.class_addMethod(@ptrCast(@alignCast(delegateClass)), method_sel, method_imp, method_types))
             return error.MethodAdditionFailed;
 
+        // void; self, _cmd, webView
+        if (!objc.class_addMethod(
+            @ptrCast(@alignCast(delegateClass)),
+            objc.sel_registerName("webViewWebContentProcessDidTerminate:"),
+            @as(objc.IMP, @ptrCast(@constCast(&handleContentProcessTerminated))),
+            "v@:@",
+        ))
+            return error.MethodAdditionFailed;
+
         objc.objc_registerClassPair(@ptrCast(delegateClass));
     }
 
@@ -5350,8 +5594,10 @@ pub fn setupNavigationDelegate(webview: objc.id) !void {
     const delegate = msgSend0(msgSend0(delegate_class_id, "alloc"), "init");
     msgSendVoid1(webview, "setNavigationDelegate:", delegate);
 
-    if (comptime builtin.mode == .debug)
-        std.debug.print("[Nav] Local development TLS enabled via {s}\n", .{local_tls.env_var});
+    if (comptime builtin.mode == .debug) {
+        if (allowsLocalDevTLS())
+            std.debug.print("[Nav] Local development TLS enabled via {s}\n", .{local_tls.env_var});
+    }
 }
 
 // ============================================================================

--- a/packages/zig/src/webview_recovery.zig
+++ b/packages/zig/src/webview_recovery.zig
@@ -1,0 +1,289 @@
+//! Bringing a window back after WebKit's content process dies.
+//!
+//! WKWebView renders in a separate process. When that process is killed — out
+//! of memory, a GPU fault, a WebKit bug — the view does not error, close, or
+//! notify the page. It goes white and stays white, and the only route back is
+//! `reload`, which craft offered exclusively as a menu item the user had to
+//! know to click. For an app meant to sit open for days, a blip became a dead
+//! window.
+//!
+//! Reloading is the whole fix, and reloading unconditionally is the whole
+//! problem: a page that reliably kills the renderer — an OOM loop, a bad
+//! WebGL context — would be reloaded into the same crash forever, pinning a
+//! core. So the reloads are budgeted.
+//!
+//! ## Why the budget is a rate and not a count
+//!
+//! A plain "three tries and stop" is wrong for the case this exists to serve.
+//! An app open for a week that loses its renderer once a day is healthy, and
+//! it would spend its three lives in the first three days and then be a white
+//! window for the rest of the week. What distinguishes a crash loop from bad
+//! luck is not how many crashes there have been but how close together they
+//! are — so a window that has stayed up for `reset_after_ns` gets its budget
+//! back. `attempts` counts a burst, not a lifetime.
+//!
+//! This module is pure: the caller supplies the clock, and nothing here talks
+//! to Objective-C. That is what lets a crash loop be tested without crashing
+//! anything.
+
+const std = @import("std");
+
+pub const Action = enum {
+    /// Reload. The content process relaunches on the next load.
+    reload,
+    /// Stop reloading and show the page that says so. Reloading again would
+    /// just be the same crash.
+    give_up,
+};
+
+pub const Budget = struct {
+    /// Reloads allowed within one burst.
+    max_attempts: u8 = 3,
+    /// Stay up this long and the burst is over. A minute is far longer than a
+    /// crash loop takes to go round and far shorter than the gap between two
+    /// unrelated failures.
+    reset_after_ns: i128 = 60 * std.time.ns_per_s,
+};
+
+pub const State = struct {
+    attempts: u8 = 0,
+    last_crash_ns: ?i128 = null,
+};
+
+/// Record a crash and say what to do about it.
+pub fn onCrash(state: *State, now_ns: i128, budget: Budget) Action {
+    const in_same_burst = if (state.last_crash_ns) |last|
+        now_ns -| last < budget.reset_after_ns
+    else
+        false;
+
+    state.attempts = if (in_same_burst) state.attempts +| 1 else 1;
+    state.last_crash_ns = now_ns;
+
+    return if (state.attempts <= budget.max_attempts) .reload else .give_up;
+}
+
+// =============================================================================
+// Per-window state
+// =============================================================================
+
+/// One budget per webview, so a window in a crash loop cannot spend the budget
+/// of a window that is fine. Craft opens one window today; #67 opens more, and
+/// a single shared counter would be exactly the bug that lands then.
+const max_tracked = 8;
+
+const Slot = struct {
+    /// The webview this belongs to, as an opaque handle. Zero means free.
+    key: usize = 0,
+    state: State = .{},
+};
+
+var slots: [max_tracked]Slot = @splat(.{});
+
+/// The budget for `key`, creating one if this webview has not crashed before.
+///
+/// Full table: the least recently troubled slot is reused. Losing a count is
+/// the right failure — it costs one extra reload attempt for a window that is
+/// probably fine, where refusing to track would cost a window its recovery.
+pub fn stateFor(key: usize) *State {
+    for (&slots) |*slot| {
+        if (slot.key == key) return &slot.state;
+    }
+    for (&slots) |*slot| {
+        if (slot.key == 0) {
+            slot.* = .{ .key = key };
+            return &slot.state;
+        }
+    }
+
+    var oldest: *Slot = &slots[0];
+    for (&slots) |*slot| {
+        const slot_time = slot.state.last_crash_ns orelse std.math.minInt(i128);
+        const oldest_time = oldest.state.last_crash_ns orelse std.math.minInt(i128);
+        if (slot_time < oldest_time) oldest = slot;
+    }
+    oldest.* = .{ .key = key };
+    return &oldest.state;
+}
+
+/// Forget a webview's history. For window teardown, and for tests.
+pub fn forget(key: usize) void {
+    for (&slots) |*slot| {
+        if (slot.key == key) slot.* = .{};
+    }
+}
+
+pub fn resetAllForTesting() void {
+    slots = @splat(.{});
+}
+
+// =============================================================================
+// The page shown once craft stops trying
+// =============================================================================
+
+/// What the window shows after the budget runs out.
+///
+/// The alternative is the white window this whole file exists to prevent —
+/// bounded retries without this just reach the original bug more slowly. It
+/// says what happened and offers the reload craft will no longer do on its
+/// own, which is also how the burst gets broken: a person clicking it is not
+/// a crash loop.
+///
+/// Self-contained by necessity. There is no server, no bundle path, and no
+/// network guarantee at the point this is shown.
+pub const give_up_page =
+    \\<!doctype html><meta charset="utf-8">
+    \\<meta name="viewport" content="width=device-width,initial-scale=1">
+    \\<title>Page stopped responding</title>
+    \\<style>
+    \\:root{color-scheme:light dark}
+    \\body{margin:0;height:100vh;display:flex;align-items:center;justify-content:center;
+    \\background:#fff;color:#1d1d1f;
+    \\font:15px/1.5 -apple-system,BlinkMacSystemFont,"SF Pro Text",system-ui,sans-serif}
+    \\@media (prefers-color-scheme:dark){body{background:#1e1e1e;color:#f5f5f7}}
+    \\main{max-width:26rem;padding:2rem;text-align:center}
+    \\h1{font-size:1.0625rem;font-weight:600;margin:0 0 .5rem}
+    \\p{margin:0 0 1.25rem;opacity:.7}
+    \\button{font:inherit;font-weight:500;padding:.4rem 1.1rem;border-radius:.375rem;
+    \\border:1px solid rgba(0,0,0,.15);background:#fff;color:inherit;cursor:pointer}
+    \\@media (prefers-color-scheme:dark){button{background:#333;border-color:rgba(255,255,255,.15)}}
+    \\</style>
+    \\<main>
+    \\<h1>This page stopped responding</h1>
+    \\<p>It was reloaded a few times and kept failing, so it has been left alone.</p>
+    \\<button onclick="location.reload()">Reload</button>
+    \\</main>
+;
+
+const testing = std.testing;
+const second = std.time.ns_per_s;
+
+test "the first crash reloads" {
+    var state: State = .{};
+    try testing.expectEqual(Action.reload, onCrash(&state, 0, .{}));
+}
+
+test "a crash loop is cut off after the budget" {
+    var state: State = .{};
+    const budget: Budget = .{ .max_attempts = 3 };
+    try testing.expectEqual(Action.reload, onCrash(&state, 0, budget));
+    try testing.expectEqual(Action.reload, onCrash(&state, 1 * second, budget));
+    try testing.expectEqual(Action.reload, onCrash(&state, 2 * second, budget));
+    try testing.expectEqual(Action.give_up, onCrash(&state, 3 * second, budget));
+    try testing.expectEqual(Action.give_up, onCrash(&state, 4 * second, budget));
+}
+
+test "a window that stayed up gets its budget back" {
+    // The case a lifetime counter gets wrong: an app open for a week that
+    // loses its renderer once a day is healthy, and must not be a white window
+    // by Thursday.
+    var state: State = .{};
+    const budget: Budget = .{ .max_attempts = 3, .reset_after_ns = 60 * second };
+
+    var day: i128 = 0;
+    while (day < 7) : (day += 1) {
+        const t = day * 24 * 60 * 60 * second;
+        try testing.expectEqual(Action.reload, onCrash(&state, t, budget));
+        try testing.expectEqual(@as(u8, 1), state.attempts);
+    }
+}
+
+test "the reset boundary is exact" {
+    var state: State = .{};
+    const budget: Budget = .{ .max_attempts = 1, .reset_after_ns = 60 * second };
+
+    try testing.expectEqual(Action.reload, onCrash(&state, 0, budget));
+    // One nanosecond short of the window: still the same burst.
+    try testing.expectEqual(Action.give_up, onCrash(&state, 60 * second - 1, budget));
+    // Exactly the window, measured from the previous crash: a new burst.
+    try testing.expectEqual(Action.reload, onCrash(&state, 2 * 60 * second - 1, budget));
+}
+
+test "a burst is measured between crashes, not from the first one" {
+    // Crashes every 40 seconds never reset a 60-second window, however long it
+    // goes on — that is a slow loop, and it is still a loop.
+    var state: State = .{};
+    const budget: Budget = .{ .max_attempts = 3, .reset_after_ns = 60 * second };
+    try testing.expectEqual(Action.reload, onCrash(&state, 0, budget));
+    try testing.expectEqual(Action.reload, onCrash(&state, 40 * second, budget));
+    try testing.expectEqual(Action.reload, onCrash(&state, 80 * second, budget));
+    try testing.expectEqual(Action.give_up, onCrash(&state, 120 * second, budget));
+}
+
+test "a clock that goes backwards does not hand out extra reloads" {
+    // The caller passes CLOCK_MONOTONIC, so this should not happen on macOS or
+    // Linux — but `compat.nanoTimestamp` falls back to wall-clock on Windows,
+    // where an NTP correction can step backwards, and returns 0 outright if
+    // the clock cannot be read. Saturating subtraction makes all of that read
+    // as "no time passed", which keeps the burst intact rather than handing
+    // out a fresh budget on every backwards step.
+    var state: State = .{};
+    const budget: Budget = .{ .max_attempts = 2, .reset_after_ns = 60 * second };
+    try testing.expectEqual(Action.reload, onCrash(&state, 1000 * second, budget));
+    try testing.expectEqual(Action.reload, onCrash(&state, 500 * second, budget));
+    try testing.expectEqual(Action.give_up, onCrash(&state, 0, budget));
+}
+
+test "the attempt count cannot wrap around into a fresh budget" {
+    var state: State = .{};
+    const budget: Budget = .{ .max_attempts = 3, .reset_after_ns = 60 * second };
+    var i: usize = 0;
+    while (i < 1000) : (i += 1) {
+        _ = onCrash(&state, @as(i128, @intCast(i)), budget);
+    }
+    try testing.expectEqual(@as(u8, 255), state.attempts);
+    try testing.expectEqual(Action.give_up, onCrash(&state, 1000, budget));
+}
+
+test "each window has its own budget" {
+    resetAllForTesting();
+    const a = stateFor(0x1000);
+    const b = stateFor(0x2000);
+    const budget: Budget = .{ .max_attempts = 1 };
+
+    try testing.expectEqual(Action.reload, onCrash(a, 0, budget));
+    try testing.expectEqual(Action.give_up, onCrash(a, 1, budget));
+    // b has spent nothing, and a's loop must not have spent it for them.
+    try testing.expectEqual(Action.reload, onCrash(stateFor(0x2000), 2, budget));
+    _ = b;
+}
+
+test "the same window gets the same budget back" {
+    resetAllForTesting();
+    _ = onCrash(stateFor(0x1000), 0, .{});
+    try testing.expectEqual(@as(u8, 1), stateFor(0x1000).attempts);
+    _ = onCrash(stateFor(0x1000), second, .{});
+    try testing.expectEqual(@as(u8, 2), stateFor(0x1000).attempts);
+}
+
+test "a closed window is forgotten" {
+    resetAllForTesting();
+    _ = onCrash(stateFor(0x1000), 0, .{});
+    forget(0x1000);
+    try testing.expectEqual(@as(u8, 0), stateFor(0x1000).attempts);
+}
+
+test "more windows than the table holds still each get tracked" {
+    resetAllForTesting();
+    var i: usize = 1;
+    while (i <= max_tracked + 4) : (i += 1) {
+        const state = stateFor(i * 0x100);
+        try testing.expectEqual(Action.reload, onCrash(state, @intCast(i), .{}));
+    }
+    // The most recent windows are the ones still held.
+    try testing.expectEqual(@as(u8, 1), stateFor((max_tracked + 4) * 0x100).attempts);
+}
+
+test "the give-up page carries its own styling and a way back" {
+    // It is shown when there is no server, no bundle path and possibly no
+    // network, so anything it references it must contain.
+    try testing.expect(std.mem.indexOf(u8, give_up_page, "location.reload()") != null);
+    try testing.expect(std.mem.indexOf(u8, give_up_page, "<style>") != null);
+    try testing.expect(std.mem.indexOf(u8, give_up_page, "prefers-color-scheme") != null);
+    try testing.expect(std.mem.indexOf(u8, give_up_page, "src=") == null);
+    try testing.expect(std.mem.indexOf(u8, give_up_page, "href=") == null);
+    // No apostrophes: it is passed to Objective-C as a C string, but it is
+    // also the kind of literal that ends up inside an `evaluateJavaScript`
+    // single-quoted string one refactor later.
+    try testing.expect(std.mem.indexOfScalar(u8, give_up_page, '\'') == null);
+}


### PR DESCRIPTION
Closes #62. Closes #64.

Two dead ends in the same two delegates — and a third problem underneath both, which changes what the fixes had to be.

## Neither delegate was installed in a shipped app

- `setupUIDelegate` ran only `if (style.dev_tools)` (`macos.zig:888`)
- `setupNavigationDelegate` returned immediately unless `CRAFT_ALLOW_LOCAL_TLS` was set (`macos.zig:5335`)

Both issues ask for a method on "the existing delegate". Implemented literally, **both fixes would have been dead code in every packaged build.**

Ungating them also fixes a third bug nobody filed: with no `WKUIDelegate`, WKWebView denies media capture outright — so **`getUserMedia()` could not work in a packaged craft app at all.**

## #62 — the content process

WKWebView renders out of process. When that process dies the view does not error, close, or notify the page: it goes white and stays white, and the only route back was a Reload menu item the user had to know to look for.

**`-reload` is Apple's documented recovery and it is wrong for half of craft's windows.** HTML loaded through `loadHTMLString:baseURL:` has no request to repeat, so reloading navigates to the synthetic base URL `http://localhost/` — where nothing is listening. A window started from `--html` would have come back as a connection error instead of the app. So what was loaded is retained per window and re-applied.

**The budget is a rate, not a count.** "Three tries and stop" is wrong for exactly the case this exists to serve: an app open for a week that loses its renderer once a day is healthy, and would spend its three lives by Wednesday and be a white window for the rest of the week. A window that stays up for a minute gets its budget back, so `attempts` measures a burst rather than a lifetime.

When a burst does run out, the window loads a small self-contained page saying so, with a Reload button. Bounded retries without that just reach the original white window more slowly.

## #64 — `window.open()` and `target="_blank"`

WKWebView asks the UI delegate for a child webview; with the method absent, its answer is to drop the request. `window.open()` returned null, links died, and nothing was logged anywhere. The URL now goes to the system browser and the method returns nil — the Electron-conventional default, until #67 gives craft a real second window.

**Which URLs is a security question, and the answer is narrower than `shell.openExternal`.** That bridge allows `file://`, and should: the *app* is calling it, on a path it chose. Here a *page* is calling it, on a URL nobody vetted, and `NSWorkspace openURL:` is not a browser call — it means "ask LaunchServices to do whatever this URL means":

- `file:///Some.app` is a launch
- `x-apple.systempreferences:` opens System Settings panes
- every installed app that claims a scheme is one `window.open` away

So `http` and `https` only. Everything else is refused **with a log**, never silently — a link that quietly does nothing is the bug being fixed.

## The security detail in ungating

`handleAuthChallenge` was gated by the delegate not existing. The delegate is now installed in every window, so without an internal `allowsLocalDevTLS()` check, this change would have **started trusting local development certificates in every craft app ever shipped**. That check is in the same commit.

## How it's tested

Both policies are pure modules — the clock and the URL are passed in — so 22 unit tests cover the drop list and the crash-loop arithmetic without a browser or a crash.

The wiring is where ObjC fails silently, so it was verified by running it:

**`window.open`** — three refused schemes in a **non-dev-tools, headless** build:
```
warning: refused to open a new window ... craft-probe://payload
warning: refused to open a new window ... file:///Applications/Calculator.app
warning: refused to open a new window ... mailto:x@example.com
```

**Renderer crash** — killing the real `com.apple.WebKit.WebContent` process four times:
```
warning: WebKit content process terminated; restoring the window (attempt 1)
warning: WebKit content process terminated; restoring the window (attempt 2)
warning: WebKit content process terminated; restoring the window (attempt 3)
warning: WebKit content process terminated 4 times in quick succession; leaving the window alone so it stops looping
```
with **four loads of the app's own HTML** (1 initial + 3 restores), which is what proves the restore does not land on the base URL.

**Budget reset** — two kills 65 seconds apart both report `attempt 1`. That is also what proves the clock is in the units the budget thinks it is: at ms or s, 65 seconds would not have crossed a 60·10⁹ ns threshold and the second would have said `attempt 2`.

One link is not proven end to end: the `NSWorkspace openURL:` call itself, because proving it means launching a browser on the machine running the test. It is one line, character-identical to the shipping `bridge_shell.zig:398`, and the branch that reaches it is covered by `external_link`'s unit tests.

## Verified

`zig build` · `zig build test` · `zig build test-js` · `x86_64-windows` cross-build · `zig fmt --check` · `tsc --noEmit` · 493 bun tests · pickier 38 warnings, unchanged from main.

## Not done, deliberately

#62 also mentions `didFailProvisionalNavigation`/`didFail` as missing. That is a different failure with a visible cause, and an automatic retry there fights a legitimately offline app rather than helping it. The issue's actual ask was the process-termination handler.