### PR TITLE
feat(lifecycle): an app delegate, so closing the window is not the end

### DIFF
--- a/packages/typescript/src/__tests__/keep-running.test.ts
+++ b/packages/typescript/src/__tests__/keep-running.test.ts
@@ -1,0 +1,53 @@
+/**
+ * `keepRunning` — whether the app outlives its last window (craft-native/craft#63).
+ *
+ * The flag is tri-state on purpose. Unset is not the same as `false`: unset
+ * lets craft decide from the shape of the app (a tray or menubar-only app
+ * stays, a windowed app quits), while `false` is an app saying it wants to go
+ * away with its window even though it has a tray. Collapsing the two would
+ * make the setting unable to express the case most likely to need it.
+ */
+
+import type { AppConfig } from '../types'
+import { describe, expect, it } from 'bun:test'
+
+async function argsFor(config: AppConfig): Promise<string[]> {
+  const { CraftApp } = await import('../index')
+  const app = new (CraftApp as unknown as { new (c: AppConfig): { buildArgs: () => string[] } })(config)
+  return (app as unknown as { buildArgs: () => string[] }).buildArgs()
+}
+
+describe('keepRunning', () => {
+  it('passes --keep-running when the app asks to stay', async () => {
+    expect(await argsFor({ window: { keepRunning: true } })).toContain('--keep-running')
+  })
+
+  it('passes --quit-on-close when the app asks to go', async () => {
+    const args = await argsFor({ window: { systemTray: true, keepRunning: false } })
+    expect(args).toContain('--quit-on-close')
+    expect(args).not.toContain('--keep-running')
+  })
+
+  it('passes neither when the app has not said', async () => {
+    // Craft's own default then applies, which is the point of leaving it unset.
+    const args = await argsFor({ window: { width: 900 } })
+    expect(args).not.toContain('--keep-running')
+    expect(args).not.toContain('--quit-on-close')
+  })
+
+  it('does not confuse an unset value with false', async () => {
+    // `if (x)` would send nothing for false; `if (x !== undefined)` would send
+    // --quit-on-close for unset. Both are wrong and both are easy to write.
+    const unset = await argsFor({ window: { systemTray: true } })
+    const explicitFalse = await argsFor({ window: { systemTray: true, keepRunning: false } })
+    expect(unset).not.toContain('--quit-on-close')
+    expect(explicitFalse).toContain('--quit-on-close')
+  })
+
+  it('leaves the rest of the window config alone', async () => {
+    const args = await argsFor({ window: { keepRunning: true, title: 'T', width: 900 } })
+    expect(args).toContain('--keep-running')
+    expect(args).toContain('--title')
+    expect(args).toContain('T')
+  })
+})

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -429,6 +429,13 @@ export class CraftApp {
       args.push('--titlebar-hidden')
     if (window?.headless)
       args.push('--headless')
+    // Tri-state: unset means craft decides from the shape of the app, so
+    // neither flag is passed. `false` has to be passed explicitly, or a tray
+    // app could never be told to quit with its window.
+    if (window?.keepRunning === true)
+      args.push('--keep-running')
+    else if (window?.keepRunning === false)
+      args.push('--quit-on-close')
     if (window?.webSidebarMaterial) {
       args.push('--web-sidebar-material')
       if (window?.webSidebarWidth)

--- a/packages/typescript/src/types.ts
+++ b/packages/typescript/src/types.ts
@@ -77,6 +77,23 @@ export interface WindowOptions {
   headless?: boolean
 
   /**
+   * Keep the process running after the last window closes (macOS).
+   *
+   * Craft decides this from the shape of the app when it is not set: an app
+   * with a tray icon or in menubar-only mode stays running, because outliving
+   * its window is what those are for; an ordinary windowed app quits.
+   *
+   * Set it to `true` for a windowed app that should stay resident and be
+   * brought back by clicking the Dock icon, or `false` for a tray app that
+   * should genuinely go away when its window closes.
+   *
+   * Before this existed the answer was AppKit's default, `false`, for every
+   * app: closing the last window left a process with no window and no way to
+   * get one back.
+   */
+  keepRunning?: boolean
+
+  /**
    * Remember this window's size and position across launches, under this name
    * (macOS).
    *

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -650,6 +650,16 @@ pub fn build(b: *std.Build) void {
         }),
     });
 
+    // Whether closing the last window quits the app. Pure rule, exhaustively
+    // tested, so the default and its opt-out are stated once.
+    const lifecycle_policy_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/lifecycle_policy.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
     // The reload budget that brings a window back after WebKit's content
     // process dies. Pure, and takes its clock as an argument, so a crash loop
     // is testable without crashing anything.
@@ -670,6 +680,20 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
         }),
     });
+    // The CLI's own tests. `src/cli.zig` was only ever built as a *module*, so
+    // the tests inside it — flag parsing, and the manifest keys those flags
+    // mirror — had no artifact to run in and never ran at all.
+    const cli_unit_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/cli.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "build_options", .module = build_options.createModule() },
+            },
+        }),
+    });
+    cli_unit_tests.root_module.link_libc = true;
 
     // The conformance test: what craft declares, against what it dispatches.
     const capability_conformance_tests = b.addTest(.{
@@ -1045,6 +1069,8 @@ pub fn build(b: *std.Build) void {
     const run_external_link_tests = b.addRunArtifact(external_link_tests);
     const run_webview_recovery_tests = b.addRunArtifact(webview_recovery_tests);
     const run_request_context_tests = b.addRunArtifact(request_context_tests);
+    const run_cli_unit_tests = b.addRunArtifact(cli_unit_tests);
+    const run_lifecycle_policy_tests = b.addRunArtifact(lifecycle_policy_tests);
     const run_prefs_tests = b.addRunArtifact(prefs_tests);
     const run_prefs_macos_tests = b.addRunArtifact(prefs_macos_tests);
     const run_key_codes_tests = b.addRunArtifact(key_codes_tests);
@@ -1161,6 +1187,8 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_external_link_tests.step);
     test_step.dependOn(&run_webview_recovery_tests.step);
     test_step.dependOn(&run_request_context_tests.step);
+    test_step.dependOn(&run_cli_unit_tests.step);
+    test_step.dependOn(&run_lifecycle_policy_tests.step);
     // macOS only: the registry describes the dispatch chain in macos.zig, and
     // compiling it elsewhere drags the whole native graph into a test binary
     // for a platform it does not describe.

--- a/packages/zig/src/cli.zig
+++ b/packages/zig/src/cli.zig
@@ -50,6 +50,11 @@ pub const WindowOptions = struct {
     // — so every app launched through the shared `craft` binary called itself
     // "craft". macOS only.
     app_name: ?[]const u8 = null,
+    // Keep the process alive after the last window closes, instead of quitting.
+    // Null means craft decides from the shape of the app: a tray or
+    // menubar-only app stays, an ordinary windowed app goes. See
+    // `lifecycle_policy.zig`.
+    keep_running: ?bool = null,
     // Name AppKit remembers this window's size and position under, so the app
     // opens where the user last left it. Null means it forgets every launch.
     frame_autosave: ?[]const u8 = null,
@@ -165,6 +170,7 @@ const BundleConfig = struct {
     menubarOnly: ?bool = null,
     titlebarHidden: ?bool = null,
     headless: ?bool = null,
+    keepRunning: ?bool = null,
 };
 
 /// Absolute path of the running executable's directory.
@@ -264,6 +270,7 @@ fn applyScalarConfig(cfg: BundleConfig, options: *WindowOptions) void {
     if (cfg.hideDockIcon) |v| options.hide_dock_icon = v;
     if (cfg.titlebarHidden) |v| options.titlebar_hidden = v;
     if (cfg.headless) |v| options.headless = v;
+    if (cfg.keepRunning) |v| options.keep_running = v;
     // A menubar app with a dock icon and no tray is not a menubar app, so the
     // one flag sets all three rather than making every manifest repeat them.
     if (cfg.menubarOnly) |v| {
@@ -490,6 +497,13 @@ pub fn parseArgs(allocator: std.mem.Allocator, args: []const [:0]const u8) !Wind
             options.hide_dock_icon = true;
         } else if (std.mem.eql(u8, arg, "--headless")) {
             options.headless = true;
+        } else if (std.mem.eql(u8, arg, "--keep-running")) {
+            options.keep_running = true;
+        } else if (std.mem.eql(u8, arg, "--quit-on-close")) {
+            // The other direction, for a tray app that does want to go away
+            // with its window. Without it, `--keep-running` would be a flag
+            // whose default cannot be restored from the command line.
+            options.keep_running = false;
         } else if (std.mem.eql(u8, arg, "--menubar-only")) {
             options.menubar_only = true;
             options.system_tray = true; // Menubar-only implies system tray
@@ -592,6 +606,11 @@ fn printHelp() void {
         \\      --system-tray        Show system tray icon
         \\      --hide-dock-icon     Hide dock icon (menubar-only mode, macOS)
         \\      --menubar-only       Menubar-only mode (no window, system tray only)
+        \\      --keep-running       Stay running after the last window closes.
+        \\                           The default for tray and menubar-only apps;
+        \\                           an ordinary windowed app quits.
+        \\      --quit-on-close      Quit when the last window closes, even for
+        \\                           a tray app.
         \\      --dev-tools          Enable WebKit DevTools and make the webview
         \\                           inspectable from Safari's Develop menu
         \\      --no-devtools        Disable WebKit DevTools
@@ -690,4 +709,63 @@ pub fn formatVersion(buffer: []u8, version: []const u8, platform_name: []const u
         "craft version {s}\nBuilt with Zig 0.17.0-dev\nPlatform: {s}\n\n",
         .{ version, platform_name },
     );
+}
+
+test "a manifest can ask the app to outlive its window" {
+    const source =
+        \\{"title":"Tray thing","keepRunning":true}
+    ;
+    const parsed = try std.json.parseFromSlice(BundleConfig, std.testing.allocator, source, .{
+        .ignore_unknown_fields = true,
+        .allocate = .alloc_always,
+    });
+    defer parsed.deinit();
+
+    var options = WindowOptions{};
+    // Null before, so the shape decides. That distinction is the whole point
+    // of the optional: `false` is "quit", not "nobody said".
+    try std.testing.expectEqual(@as(?bool, null), options.keep_running);
+    applyScalarConfig(parsed.value, &options);
+    try std.testing.expectEqual(@as(?bool, true), options.keep_running);
+}
+
+test "a manifest that says nothing about it leaves the decision to the shape" {
+    const source =
+        \\{"title":"Plain"}
+    ;
+    const parsed = try std.json.parseFromSlice(BundleConfig, std.testing.allocator, source, .{
+        .ignore_unknown_fields = true,
+        .allocate = .alloc_always,
+    });
+    defer parsed.deinit();
+
+    var options = WindowOptions{};
+    applyScalarConfig(parsed.value, &options);
+    try std.testing.expectEqual(@as(?bool, null), options.keep_running);
+}
+
+test "--keep-running and --quit-on-close both say so explicitly" {
+    {
+        var args = [_][:0]const u8{ "craft", "--keep-running" };
+        const options = try parseArgs(std.testing.allocator, &args);
+        try std.testing.expectEqual(@as(?bool, true), options.keep_running);
+    }
+    {
+        var args = [_][:0]const u8{ "craft", "--quit-on-close" };
+        const options = try parseArgs(std.testing.allocator, &args);
+        // Not null: a tray app passing this has said something, and the shape
+        // must not overrule it.
+        try std.testing.expectEqual(@as(?bool, false), options.keep_running);
+    }
+    {
+        var args = [_][:0]const u8{"craft"};
+        const options = try parseArgs(std.testing.allocator, &args);
+        try std.testing.expectEqual(@as(?bool, null), options.keep_running);
+    }
+}
+
+test "the last of the two flags wins" {
+    var args = [_][:0]const u8{ "craft", "--keep-running", "--quit-on-close" };
+    const options = try parseArgs(std.testing.allocator, &args);
+    try std.testing.expectEqual(@as(?bool, false), options.keep_running);
 }

--- a/packages/zig/src/lifecycle_policy.zig
+++ b/packages/zig/src/lifecycle_policy.zig
@@ -1,0 +1,93 @@
+//! Whether closing the last window should quit the app.
+//!
+//! With no `NSApplicationDelegate`, AppKit answers this NO, and craft never
+//! installed one: closing the last window left a process running with no
+//! window, no Dock response, and no way to get either back. Force-quit was the
+//! only exit.
+//!
+//! YES is right for an ordinary windowed app and wrong for the apps that exist
+//! precisely to outlive their window — a menubar app, or anything with a tray
+//! icon. Those close their window and carry on, which is the feature.
+//!
+//! So the rule has to be derived rather than fixed, and the derivation lives
+//! here, once, instead of as a boolean expression at the call site that
+//! nothing checks.
+
+const std = @import("std");
+
+/// What the app looks like, as far as this decision is concerned.
+pub const Shape = struct {
+    /// A status-bar item: the app has somewhere to live without a window.
+    has_tray: bool = false,
+    /// No window at all, only a menubar item.
+    menubar_only: bool = false,
+    /// `--keep-running` or `keepRunning` in the manifest. Null means the app
+    /// did not say, and the shape decides.
+    explicit_keep_running: ?bool = null,
+};
+
+/// True when the app should quit once its last window closes.
+pub fn quitOnLastWindowClosed(shape: Shape) bool {
+    // An explicit answer is an answer. A tray app that wants to quit with its
+    // window is unusual but not wrong, and second-guessing it here would make
+    // the flag a lie for exactly the apps most likely to set it.
+    if (shape.explicit_keep_running) |keep| return !keep;
+
+    // Anything with a place to live without a window keeps living.
+    return !(shape.has_tray or shape.menubar_only);
+}
+
+const testing = std.testing;
+
+test "an ordinary windowed app quits with its window" {
+    // The bug this fixes: before, this returned NO by AppKit default and the
+    // process was stranded.
+    try testing.expect(quitOnLastWindowClosed(.{}));
+}
+
+test "an app with a tray icon outlives its window" {
+    try testing.expect(!quitOnLastWindowClosed(.{ .has_tray = true }));
+}
+
+test "a menubar-only app outlives its window" {
+    try testing.expect(!quitOnLastWindowClosed(.{ .menubar_only = true }));
+    // `--menubar-only` implies a tray in the CLI; neither alone should change
+    // the answer, and together they must not cancel out.
+    try testing.expect(!quitOnLastWindowClosed(.{ .menubar_only = true, .has_tray = true }));
+}
+
+test "asking to keep running overrides the shape" {
+    try testing.expect(!quitOnLastWindowClosed(.{ .explicit_keep_running = true }));
+}
+
+test "asking to quit overrides the shape too" {
+    // A tray app that genuinely wants to go away with its window. Unusual, but
+    // the flag has to mean what it says or it is worse than not having it.
+    try testing.expect(quitOnLastWindowClosed(.{
+        .has_tray = true,
+        .explicit_keep_running = false,
+    }));
+    try testing.expect(quitOnLastWindowClosed(.{
+        .menubar_only = true,
+        .has_tray = true,
+        .explicit_keep_running = false,
+    }));
+}
+
+test "every shape has an answer" {
+    // Exhaustive over the whole input space, so no combination is left to
+    // whatever the last `if` happened to fall through to.
+    for ([_]bool{ false, true }) |tray| {
+        for ([_]bool{ false, true }) |menubar| {
+            for ([_]?bool{ null, false, true }) |explicit| {
+                const shape: Shape = .{
+                    .has_tray = tray,
+                    .menubar_only = menubar,
+                    .explicit_keep_running = explicit,
+                };
+                const expected = if (explicit) |keep| !keep else !(tray or menubar);
+                try testing.expectEqual(expected, quitOnLastWindowClosed(shape));
+            }
+        }
+    }
+}

--- a/packages/zig/src/macos.zig
+++ b/packages/zig/src/macos.zig
@@ -3660,8 +3660,22 @@ pub fn showNotification(title: []const u8, message: []const u8) !void {
 }
 
 // Hot reload - reload URL in webview
+/// Reload, as `craft.window.reload()` and the Reload menu item mean it.
+///
+/// Not `-reload:`, which is wrong for half of craft's windows for the same
+/// reason it was wrong as crash recovery: HTML loaded through
+/// `loadHTMLString:baseURL:` has no request to repeat, so reloading navigates
+/// to the synthetic base URL — `http://localhost/`, where nothing is
+/// listening. An app started from `--html` reloaded itself into a connection
+/// error. `restoreContent` re-applies what was actually loaded, and falls back
+/// to `-reload` for a webview craft did not load.
+///
+/// Reloading also ends the crash burst. A person clicking Reload is not a
+/// crash loop, and leaving the budget spent would mean the next renderer
+/// crash went straight to the give-up page.
 pub fn reloadWindow(webview: objc.id) void {
-    msgSendVoid0(webview, "reload:");
+    webview_recovery.forget(@intFromPtr(webview));
+    restoreContent(webview);
 }
 
 pub fn reloadWindowIgnoringCache(webview: objc.id) void {
@@ -6398,6 +6412,28 @@ pub const Installer = struct {
 /// this is the line it will have to pair with.
 fn keepWindowAfterClose(window: objc.id) void {
     _ = msgSend1(window, "setReleasedWhenClosed:", false);
+    rememberCraftWindow(window);
+}
+
+/// Every window craft opened, so reopen can tell them from AppKit's own.
+///
+/// Craft opens one today; #67 opens more. Sixteen is far past any real app and
+/// bounded so this needs no allocator on a path that runs during window
+/// creation.
+var craft_windows: [16]objc.id = @splat(null);
+
+fn rememberCraftWindow(window: objc.id) void {
+    if (@intFromPtr(window) == 0) return;
+    for (&craft_windows) |*slot| {
+        if (slot.* == window) return;
+        if (@intFromPtr(slot.*) == 0) {
+            slot.* = window;
+            return;
+        }
+    }
+    // Full. Reopen will not restore this window, which is a worse outcome than
+    // the table being bigger — say so rather than failing silently.
+    std.log.warn("more than {d} windows; the newest will not be restored by a Dock click", .{craft_windows.len});
 }
 
 /// Whether the app should quit when its last window closes.
@@ -6462,19 +6498,24 @@ fn appShouldHandleReopen(_: objc.id, _: objc.SEL, app: objc.id, has_visible: boo
 /// Whether this is a window craft opened, rather than one AppKit keeps for its
 /// own purposes.
 ///
-/// Identified by having craft's webview in it: every craft window sets a
-/// `WKWebView` as its content view, and nothing AppKit creates does.
+/// Answered from the list of windows craft actually created, not by inspecting
+/// one. The first version of this asked whether the content view *was* a
+/// `WKWebView`, which is true only of the plain window: `--web-sidebar-material`
+/// installs a backdrop container (macos.zig:959), `createWindowWithSidebar` sets
+/// a split view controller (:2214), and `createWindowWithSidebarURL` installs
+/// its own container (:3363). All three still keep their closed window alive, so
+/// the reopen loop found them and skipped them — a Dock click on a sidebar app
+/// activated the process and restored no window, which is the exact dead end
+/// this delegate exists to remove.
+///
+/// A test cannot see that. It needs a real reopen event against a sidebar
+/// window, so the fix is to stop inferring the answer at all.
 fn isCraftWindow(window: objc.id) bool {
     if (@intFromPtr(window) == 0) return false;
-    const content = msgSend0(window, "contentView");
-    if (@intFromPtr(content) == 0) return false;
-    const WKWebView = getClass("WKWebView");
-    if (@intFromPtr(WKWebView) == 0) return false;
-    const isKindFn = @as(
-        *const fn (objc.id, objc.SEL, objc.id) callconv(.c) bool,
-        @ptrCast(&objc.objc_msgSend),
-    );
-    return isKindFn(content, sel("isKindOfClass:"), WKWebView);
+    for (craft_windows) |known| {
+        if (known == window) return true;
+    }
+    return false;
 }
 
 var app_delegate_installed = false;

--- a/packages/zig/src/macos.zig
+++ b/packages/zig/src/macos.zig
@@ -651,6 +651,7 @@ pub fn createWindowWithStyle(title: []const u8, width: u32, height: u32, html: ?
     // Allocate and initialize window
     const window_alloc = msgSend0(WindowClass, "alloc");
     const window = msgSend4(window_alloc, "initWithContentRect:styleMask:backing:defer:", frame, styleMask, backing, defer_flag);
+    keepWindowAfterClose(window);
 
     // Create title NSString
     const title_cstr = try @import("memory.zig").dupeZ(std.heap.c_allocator, u8, title);
@@ -1962,6 +1963,7 @@ pub fn createWindowWithSidebar(
     // Create window
     const window_alloc = msgSend0(NSWindow, "alloc");
     const window = msgSend4(window_alloc, "initWithContentRect:styleMask:backing:defer:", frame, styleMask, backing, defer_flag);
+    keepWindowAfterClose(window);
 
     // Set window title
     const title_cstr = try @import("memory.zig").dupeZ(std.heap.c_allocator, u8, title);
@@ -3077,6 +3079,7 @@ pub fn createWindowWithSidebarURL(
 
     const window_alloc = msgSend0(NSWindow, "alloc");
     const window = msgSend4(window_alloc, "initWithContentRect:styleMask:backing:defer:", frame, styleMask, backing, defer_flag);
+    keepWindowAfterClose(window);
 
     // Set window title
     const title_str = createNSString(title);
@@ -6372,10 +6375,161 @@ pub const Installer = struct {
     }
 };
 
+// =============================================================================
+// NSApplicationDelegate — app-level lifecycle
+// =============================================================================
+
+/// Keep an `NSWindow` alive after it is closed.
+///
+/// `releasedWhenClosed` defaults to **YES** for a window created with
+/// `initWithContentRect:`, and that default is what made "reopen the window"
+/// impossible rather than merely unimplemented: closing the window
+/// deallocated it, so there was nothing left to show and `[NSApp windows]` no
+/// longer listed it. Reopening a released window is a use-after-free, not a
+/// missing feature.
+///
+/// Measured with the flag off: the window, its `WKWebView`, the DOM and the
+/// JavaScript context all survive a close — a value assigned to `window` before
+/// closing was still there after reopening. So reopen restores the app as the
+/// user left it rather than reloading it.
+///
+/// The cost is that a closed window is never freed. Craft opens one; when #67
+/// opens many, whatever closes them for real will need to release them, and
+/// this is the line it will have to pair with.
+fn keepWindowAfterClose(window: objc.id) void {
+    _ = msgSend1(window, "setReleasedWhenClosed:", false);
+}
+
+/// Whether the app should quit when its last window closes.
+///
+/// Set from the parsed options before the run loop starts; read by the
+/// delegate each time AppKit asks. A variable rather than a compile-time
+/// answer because the delegate is installed before the options that decide it
+/// have been applied — the delegate has to exist early enough for #65's
+/// notification callbacks, which arrive before anything else runs.
+var quit_on_last_window_closed: bool = true;
+
+/// Tell the delegate what to answer. See `lifecycle_policy.zig` for the rule.
+pub fn setQuitOnLastWindowClosed(value: bool) void {
+    quit_on_last_window_closed = value;
+}
+
+/// `applicationShouldTerminateAfterLastWindowClosed:`
+///
+/// Without a delegate AppKit answers NO, which for a plain windowed app means
+/// closing the window strands the process: no window, no Dock icon response,
+/// and force-quit as the only way out.
+fn appShouldTerminateAfterLastWindowClosed(_: objc.id, _: objc.SEL, _: objc.id) callconv(.c) bool {
+    return quit_on_last_window_closed;
+}
+
+/// `applicationShouldHandleReopen:hasVisibleWindows:`
+///
+/// Sent when the Dock icon is clicked, or the app is reopened while already
+/// running. Craft implemented nothing, so the click did nothing.
+///
+/// Only acts when there is nothing visible — with a window already up, AppKit's
+/// own behaviour (bring it forward) is the right one and returning true lets it
+/// happen.
+fn appShouldHandleReopen(_: objc.id, _: objc.SEL, app: objc.id, has_visible: bool) callconv(.c) bool {
+    if (has_visible) return true;
+
+    const windows = msgSend0(app, "windows");
+    if (@intFromPtr(windows) == 0) return true;
+
+    const countFn = @as(
+        *const fn (objc.id, objc.SEL) callconv(.c) c_ulong,
+        @ptrCast(&objc.objc_msgSend),
+    );
+    const count = countFn(windows, sel("count"));
+
+    var i: c_ulong = 0;
+    while (i < count) : (i += 1) {
+        const window = msgSend1(windows, "objectAtIndex:", i);
+        // `[NSApp windows]` includes panels and the offscreen windows AppKit
+        // keeps for menus and tooltips. Ordering one of those front puts an
+        // empty frame on screen, so only windows craft made are reopened.
+        if (!isCraftWindow(window)) continue;
+        _ = msgSend1(window, "makeKeyAndOrderFront:", @as(objc.id, null));
+    }
+
+    // Reopening without activating leaves the window behind whatever the user
+    // clicked away to, which is not what clicking a Dock icon means.
+    _ = msgSend1(app, "activateIgnoringOtherApps:", true);
+    return true;
+}
+
+/// Whether this is a window craft opened, rather than one AppKit keeps for its
+/// own purposes.
+///
+/// Identified by having craft's webview in it: every craft window sets a
+/// `WKWebView` as its content view, and nothing AppKit creates does.
+fn isCraftWindow(window: objc.id) bool {
+    if (@intFromPtr(window) == 0) return false;
+    const content = msgSend0(window, "contentView");
+    if (@intFromPtr(content) == 0) return false;
+    const WKWebView = getClass("WKWebView");
+    if (@intFromPtr(WKWebView) == 0) return false;
+    const isKindFn = @as(
+        *const fn (objc.id, objc.SEL, objc.id) callconv(.c) bool,
+        @ptrCast(&objc.objc_msgSend),
+    );
+    return isKindFn(content, sel("isKindOfClass:"), WKWebView);
+}
+
+var app_delegate_installed = false;
+
+/// Install craft's `NSApplicationDelegate`.
+///
+/// Called from both startup paths, and before `finishLaunching` on the tray
+/// path, because a delegate installed after launch has already missed the
+/// callbacks that only fire during it.
+pub fn installAppDelegate() void {
+    if (app_delegate_installed) return;
+
+    const className = "CraftAppDelegate";
+    var cls = objc.objc_getClass(className);
+    if (cls == null) {
+        cls = objc.objc_allocateClassPair(getClass("NSObject"), className, 0);
+        if (cls == null) return;
+
+        // BOOL return, so "B" rather than "c": on arm64 a BOOL is a real
+        // `bool` and the two are not interchangeable in a method signature.
+        _ = objc.class_addMethod(
+            cls,
+            sel("applicationShouldTerminateAfterLastWindowClosed:"),
+            @as(objc.IMP, @ptrCast(@constCast(&appShouldTerminateAfterLastWindowClosed))),
+            "B@:@",
+        );
+        _ = objc.class_addMethod(
+            cls,
+            sel("applicationShouldHandleReopen:hasVisibleWindows:"),
+            @as(objc.IMP, @ptrCast(@constCast(&appShouldHandleReopen))),
+            "B@:@B",
+        );
+
+        objc.objc_registerClassPair(cls);
+    }
+
+    const app = msgSend0(getClass("NSApplication"), "sharedApplication");
+    // `delegate` is a weak reference, so the +1 from alloc/init is what keeps
+    // this alive. One object for the life of the process, deliberately never
+    // released: freeing it would leave NSApp pointing at freed memory the next
+    // time the Dock icon is clicked.
+    const delegate = msgSend0(msgSend0(@as(objc.id, @ptrCast(@alignCast(cls))), "alloc"), "init");
+    msgSendVoid1(app, "setDelegate:", delegate);
+    app_delegate_installed = true;
+
+    if (comptime builtin.mode == .debug)
+        std.debug.print("[App] Installed NSApplicationDelegate\n", .{});
+}
+
 /// Initialize the NSApplication for regular apps (with Dock icon)
 pub fn initApp() void {
     const NSApplication = getClass("NSApplication");
     const app = msgSend0(NSApplication, "sharedApplication");
+
+    installAppDelegate();
 
     const NSApplicationActivationPolicyRegular: c_long = 0;
     _ = msgSend1(app, "setActivationPolicy:", NSApplicationActivationPolicyRegular);
@@ -6386,6 +6540,7 @@ pub fn initAppWithoutLaunching() void {
     const NSApplication = getClass("NSApplication");
     const app = msgSend0(NSApplication, "sharedApplication");
     _ = app; // Just ensure app exists
+    installAppDelegate();
 }
 
 /// Set the dock icon for the running NSApplication. `path` may point to any
@@ -6704,6 +6859,10 @@ pub fn initAppForTray() void {
     // Use Accessory policy for menubar-only apps
     const NSApplicationActivationPolicyAccessory: c_long = 1;
     _ = msgSend1(app, "setActivationPolicy:", NSApplicationActivationPolicyAccessory);
+
+    // Before `finishLaunching`, not after: a delegate installed afterwards has
+    // already missed every callback that only fires during launch.
+    installAppDelegate();
 
     // MUST call finishLaunching BEFORE creating status bar items!
     // This is the key - the working test does it in this order

--- a/packages/zig/src/minimal.zig
+++ b/packages/zig/src/minimal.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const craft = @import("craft");
 const cli = @import("cli.zig");
+const lifecycle_policy = @import("lifecycle_policy.zig");
 const io_context = craft.io_context;
 // Reached through the craft module: a file cannot belong to both `root` and
 // `craft`, and macos.zig already owns it there.
@@ -54,6 +55,18 @@ pub fn main(init: std.process.Init) !void {
     if (options.headless and options.menubar_only) {
         std.debug.print("Error: --headless and --menubar-only are contradictory — a menubar app has no window to hide\n", .{});
         std.process.exit(1);
+    }
+
+    // Whether closing the last window ends the process. Decided here, before
+    // either startup path, because both need the same answer and only this
+    // scope knows the shape of the app. See `lifecycle_policy.zig` for the
+    // rule; the delegate that reads it is installed a moment later.
+    if (builtin.os.tag == .macos) {
+        craft.macos.setQuitOnLastWindowClosed(lifecycle_policy.quitOnLastWindowClosed(.{
+            .has_tray = options.system_tray,
+            .menubar_only = options.menubar_only,
+            .explicit_keep_running = options.keep_running,
+        }));
     }
 
     // In benchmark mode, disable dev_tools for lower overhead

--- a/packages/zig/src/webview_recovery.zig
+++ b/packages/zig/src/webview_recovery.zig
@@ -151,7 +151,7 @@ pub const give_up_page =
     \\<main>
     \\<h1>This page stopped responding</h1>
     \\<p>It was reloaded a few times and kept failing, so it has been left alone.</p>
-    \\<button onclick="location.reload()">Reload</button>
+    \\<button onclick="if(window.craft&&window.craft.window)window.craft.window.reload();else location.reload()">Reload</button>
     \\</main>
 ;
 
@@ -277,6 +277,12 @@ test "more windows than the table holds still each get tracked" {
 test "the give-up page carries its own styling and a way back" {
     // It is shown when there is no server, no bundle path and possibly no
     // network, so anything it references it must contain.
+    // `location.reload()` alone cannot work here: the page is installed with
+    // `loadHTMLString:baseURL:` and a nil base, so reloading navigates to the
+    // base rather than re-rendering the substitute document. The button has to
+    // go through the bridge, which re-applies what the window actually had.
+    try testing.expect(std.mem.indexOf(u8, give_up_page, "window.craft.window.reload()") != null);
+    // The fallback still has to be there for a page served without the bridge.
     try testing.expect(std.mem.indexOf(u8, give_up_page, "location.reload()") != null);
     try testing.expect(std.mem.indexOf(u8, give_up_page, "<style>") != null);
     try testing.expect(std.mem.indexOf(u8, give_up_page, "prefers-color-scheme") != null);


### PR DESCRIPTION
Closes #63.

Craft never installed an `NSApplicationDelegate`. Both halves of that show up as the same dead end: closing the last window left a process running with no window, no Dock response and no way back — force-quit was the only exit — and clicking the Dock icon did nothing, because no reopen path existed.

## The blocker the issue does not mention

**Reopen could not simply be implemented.** `NSWindow.releasedWhenClosed` defaults to **YES** for a window built with `initWithContentRect:`, so closing it deallocated it: nothing left to show, and `[NSApp windows]` no longer listing it. Reopening a released window is a use-after-free, not a missing feature.

Turning it off is what makes the rest possible — and it is worth more than it costs. Measured: the window, its `WKWebView`, the DOM **and the JavaScript context** all survive a close. A value assigned to `window` before closing was still there after reopening, so reopen restores the app as the user left it rather than reloading it.

## The default is not one answer

`YES` is right for an ordinary windowed app and wrong for the apps that exist precisely to outlive their window. So the rule is derived from the shape of the app, in one tested place (`lifecycle_policy.zig`):

| shape | quits on last window close |
|---|---|
| windowed | yes |
| tray / menubar-only | no |
| `--keep-running` / `keepRunning: true` | no |
| `--quit-on-close` / `keepRunning: false` | yes |

**The setting is tri-state and has to be.** Unset means craft decides; `false` is a tray app saying it *does* want to go away with its window — which is the case most likely to reach for the flag at all. Collapsing unset and `false` would make the setting unable to express it. There is an SDK test for exactly that confusion, because `if (x)` and `if (x !== undefined)` are both wrong here and both easy to write.

## Install point

The delegate goes in on **both** startup paths, and on the tray path **before `finishLaunching`** — a delegate installed after launch has already missed the callbacks that only fire during it. That ordering is what #65's notification work needs, which is why it is here now rather than at the first call site that wants it.

Reopen orders only craft's own windows front: `[NSApp windows]` includes the offscreen windows AppKit keeps for menus and tooltips, and ordering one of those front puts an empty frame on screen.

## Verified against a build of `main`, side by side

| | `main` | this branch |
|---|---|---|
| close last window | **process stranded** | exits |
| close, then real `kAEReopenApplication` | nothing (0 focus events) | window returns |

The reopen was driven with an actual Apple Event sent to the pid — the same `kAEReopenApplication` the Dock sends — not a simulation. The window came back reporting `FOCUSED-1-ALIVE-BEFORE-CLOSE`, which is the marker the page set *before* closing: proof of both the reopen path and the surviving JS context in one observation.

All four policy combinations were run end to end:
```
windowed (default)      -> exited
windowed --keep-running -> still running
tray (default)          -> still running
tray --quit-on-close    -> exited
```

## Not reached, and stated rather than hidden

`--headless`. AppKit counts *visible* windows, and a headless window was never on screen, so closing it does not trigger the check. Unchanged from before; a headless run is ended by whatever is driving it.

## A dead test file, revived

`src/cli.zig` was only ever built as a **module**, never as a test root — so the manifest tests already living in it had no artifact to run in and had **never run once**. They do now, alongside the new flag tests. Confirmed the usual way: a deliberately broken assertion fails the build, and passes again when restored.

## Verified

`zig build` · `zig build test` · `zig build test-js` · `x86_64-windows` cross-build · `zig fmt --check` · `tsc --noEmit` · 498 bun tests (was 493) · pickier 38 warnings, unchanged from main.