### PR TITLE
test(window): make "every window can be reopened" a property the build checks

### DIFF
--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -706,6 +706,32 @@ pub fn build(b: *std.Build) void {
         }),
     });
 
+    // Whether every window craft opens can be reopened. A source conformance
+    // test: constructing a window needs a live NSApplication and a WebContent
+    // process, but the two properties worth defending — every constructor
+    // registers, and nothing infers craft-ness from a window again — are
+    // properties of the source.
+    const window_lifecycle_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("test/window_lifecycle_test.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    window_lifecycle_tests.root_module.addAnonymousImport("src/macos.zig", .{
+        .root_source_file = b.path("src/macos.zig"),
+    });
+
+    // The window registry itself, free of Objective-C so the whole lifecycle
+    // is provable without AppKit.
+    const window_registry_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/window_registry.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
     // The conformance test: what craft declares, against what it dispatches.
     const capability_conformance_tests = b.addTest(.{
         .root_module = b.createModule(.{
@@ -1077,6 +1103,8 @@ pub fn build(b: *std.Build) void {
     const run_local_tls_tests = b.addRunArtifact(local_tls_tests);
     const run_menu_roles_tests = b.addRunArtifact(menu_roles_tests);
     const run_capabilities_tests = b.addRunArtifact(capabilities_tests);
+    const run_window_lifecycle_tests = b.addRunArtifact(window_lifecycle_tests);
+    const run_window_registry_tests = b.addRunArtifact(window_registry_tests);
     const run_external_link_tests = b.addRunArtifact(external_link_tests);
     const run_webview_recovery_tests = b.addRunArtifact(webview_recovery_tests);
     const run_request_context_tests = b.addRunArtifact(request_context_tests);
@@ -1196,6 +1224,8 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_local_tls_tests.step);
     test_step.dependOn(&run_menu_roles_tests.step);
     test_step.dependOn(&run_capabilities_tests.step);
+    test_step.dependOn(&run_window_lifecycle_tests.step);
+    test_step.dependOn(&run_window_registry_tests.step);
     test_step.dependOn(&run_external_link_tests.step);
     test_step.dependOn(&run_webview_recovery_tests.step);
     test_step.dependOn(&run_request_context_tests.step);

--- a/packages/zig/src/macos.zig
+++ b/packages/zig/src/macos.zig
@@ -6,6 +6,7 @@ const local_tls = @import("local_tls.zig");
 const menu_roles = @import("menu_roles.zig");
 const external_link = @import("external_link.zig");
 const webview_recovery = @import("webview_recovery.zig");
+const window_registry = @import("window_registry.zig");
 const request_context = @import("request_context.zig");
 
 // Objective-C runtime types and functions (manual declarations to avoid @cImport issues)
@@ -6415,25 +6416,15 @@ fn keepWindowAfterClose(window: objc.id) void {
     rememberCraftWindow(window);
 }
 
-/// Every window craft opened, so reopen can tell them from AppKit's own.
-///
-/// Craft opens one today; #67 opens more. Sixteen is far past any real app and
-/// bounded so this needs no allocator on a path that runs during window
-/// creation.
-var craft_windows: [16]objc.id = @splat(null);
-
 fn rememberCraftWindow(window: objc.id) void {
-    if (@intFromPtr(window) == 0) return;
-    for (&craft_windows) |*slot| {
-        if (slot.* == window) return;
-        if (@intFromPtr(slot.*) == 0) {
-            slot.* = window;
-            return;
-        }
-    }
-    // Full. Reopen will not restore this window, which is a worse outcome than
-    // the table being bigger — say so rather than failing silently.
-    std.log.warn("more than {d} windows; the newest will not be restored by a Dock click", .{craft_windows.len});
+    if (window_registry.remember(@intFromPtr(window))) return;
+    // Full. Reopen will not restore this window, which is worse than the table
+    // being bigger — say so rather than letting a window quietly stop being
+    // reopenable, which is the bug this registry exists to prevent.
+    std.log.warn(
+        "more than {d} windows open; the newest will not be restored by a Dock click",
+        .{window_registry.capacity},
+    );
 }
 
 /// Whether the app should quit when its last window closes.
@@ -6511,11 +6502,7 @@ fn appShouldHandleReopen(_: objc.id, _: objc.SEL, app: objc.id, has_visible: boo
 /// A test cannot see that. It needs a real reopen event against a sidebar
 /// window, so the fix is to stop inferring the answer at all.
 fn isCraftWindow(window: objc.id) bool {
-    if (@intFromPtr(window) == 0) return false;
-    for (craft_windows) |known| {
-        if (known == window) return true;
-    }
-    return false;
+    return window_registry.isKnown(@intFromPtr(window));
 }
 
 var app_delegate_installed = false;

--- a/packages/zig/src/window_registry.zig
+++ b/packages/zig/src/window_registry.zig
@@ -1,0 +1,160 @@
+//! Which windows craft opened.
+//!
+//! The Dock's reopen event arrives with no argument: AppKit hands over the
+//! application and craft has to work out, from `[NSApp windows]`, which of them
+//! are its own. That list also holds the offscreen windows AppKit keeps for
+//! menus, tooltips and its own bookkeeping, and ordering one of those front
+//! puts an empty frame on screen.
+//!
+//! ## Why this is a list and not a test
+//!
+//! The first version asked the window: is your content view a `WKWebView`?
+//! That is true of craft's plain window and false of three others —
+//! `--web-sidebar-material` installs a backdrop container, and both sidebar
+//! constructors install a container or a split view controller. All three kept
+//! their closed window alive, so reopen found them, skipped them, and left the
+//! app activated with nothing on screen: exactly the dead end the reopen
+//! handler exists to remove.
+//!
+//! Nothing caught it. It compiles, every test passes, and it fails only against
+//! a real reopen event on a window style no test constructs.
+//!
+//! Recording the answer instead of inferring it fixes that, and it does
+//! something else worth more: it turns an untestable property into a
+//! checkable one. "Does this window look like ours?" can only be answered by
+//! having the window. "Did every constructor register?" is a property of the
+//! source, and `test/window_lifecycle_test.zig` checks it.
+
+const std = @import("std");
+
+/// An opaque window handle — `@intFromPtr(NSWindow)` at the call site. Kept
+/// opaque so this module stays free of Objective-C and can be tested without
+/// AppKit.
+pub const Handle = usize;
+
+/// Craft opens one window today; #67 opens more. Far past any real app, and
+/// fixed so registration needs no allocator on the window-creation path.
+pub const capacity = 16;
+
+var windows: [capacity]Handle = @splat(0);
+
+/// Record a window craft created. Idempotent.
+///
+/// Returns false if the table was full and the window was not recorded — the
+/// caller is expected to say so rather than let a window silently become
+/// unreopenable.
+pub fn remember(handle: Handle) bool {
+    if (handle == 0) return false;
+    for (&windows) |*slot| {
+        if (slot.* == handle) return true;
+        if (slot.* == 0) {
+            slot.* = handle;
+            return true;
+        }
+    }
+    return false;
+}
+
+/// Whether craft opened this window.
+pub fn isKnown(handle: Handle) bool {
+    if (handle == 0) return false;
+    for (windows) |known| {
+        if (known == handle) return true;
+    }
+    return false;
+}
+
+/// Drop a window. For real teardown, whenever #67 introduces some.
+pub fn forget(handle: Handle) void {
+    for (&windows) |*slot| {
+        if (slot.* == handle) slot.* = 0;
+    }
+}
+
+pub fn count() usize {
+    var n: usize = 0;
+    for (windows) |w| {
+        if (w != 0) n += 1;
+    }
+    return n;
+}
+
+pub fn resetForTesting() void {
+    windows = @splat(0);
+}
+
+const testing = std.testing;
+
+test "a window craft opened is recognised" {
+    resetForTesting();
+    try testing.expect(remember(0x1000));
+    try testing.expect(isKnown(0x1000));
+}
+
+test "a window craft did not open is not" {
+    // The offscreen windows AppKit keeps for menus and tooltips land here.
+    // Ordering one of those front puts an empty frame on screen.
+    resetForTesting();
+    _ = remember(0x1000);
+    try testing.expect(!isKnown(0x2000));
+}
+
+test "registering twice does not consume two slots" {
+    resetForTesting();
+    try testing.expect(remember(0x1000));
+    try testing.expect(remember(0x1000));
+    try testing.expectEqual(@as(usize, 1), count());
+}
+
+test "a null window is neither recorded nor recognised" {
+    // `contentView` and friends return nil often enough that zero has to mean
+    // nothing rather than becoming a real entry that matches every other nil.
+    resetForTesting();
+    try testing.expect(!remember(0));
+    try testing.expect(!isKnown(0));
+    try testing.expectEqual(@as(usize, 0), count());
+}
+
+test "every window up to capacity is recorded" {
+    resetForTesting();
+    var i: usize = 1;
+    while (i <= capacity) : (i += 1) {
+        try testing.expect(remember(i * 0x100));
+    }
+    i = 1;
+    while (i <= capacity) : (i += 1) {
+        try testing.expect(isKnown(i * 0x100));
+    }
+    try testing.expectEqual(capacity, count());
+}
+
+test "past capacity the failure is reported, not swallowed" {
+    // The caller logs this. A window that quietly stopped being reopenable is
+    // the bug this whole module exists to prevent, so it must not be the
+    // silent outcome of a full table.
+    resetForTesting();
+    var i: usize = 1;
+    while (i <= capacity) : (i += 1) _ = remember(i * 0x100);
+    try testing.expect(!remember(0xDEAD));
+    try testing.expect(!isKnown(0xDEAD));
+}
+
+test "forgetting frees the slot for the next window" {
+    resetForTesting();
+    var i: usize = 1;
+    while (i <= capacity) : (i += 1) _ = remember(i * 0x100);
+    try testing.expect(!remember(0xDEAD));
+
+    forget(0x100);
+    try testing.expect(!isKnown(0x100));
+    try testing.expect(remember(0xDEAD));
+    try testing.expect(isKnown(0xDEAD));
+}
+
+test "forgetting a window that was never known changes nothing" {
+    resetForTesting();
+    _ = remember(0x1000);
+    forget(0x2000);
+    try testing.expect(isKnown(0x1000));
+    try testing.expectEqual(@as(usize, 1), count());
+}

--- a/packages/zig/test/window_lifecycle_test.zig
+++ b/packages/zig/test/window_lifecycle_test.zig
@@ -1,0 +1,232 @@
+//! Every window craft opens must be reopenable.
+//!
+//! This test exists because of a bug that nothing else could have caught.
+//! `isCraftWindow` decided whether a window was craft's by asking whether its
+//! content view was a `WKWebView`. That is true of the plain window and false
+//! of the other three: `--web-sidebar-material` installs a backdrop container,
+//! `createWindowWithSidebar` sets a split view controller, and
+//! `createWindowWithSidebarURL` installs its own container. All three keep
+//! their closed window alive, so the reopen handler found them, skipped them,
+//! and left the app activated with nothing on screen — the exact dead end the
+//! handler was added to remove.
+//!
+//! It compiled. Every test passed. It failed only against a real
+//! `kAEReopenApplication` on a window style no test constructs, and **no test
+//! in this repository constructs a window at all**.
+//!
+//! ## Why this is a source test
+//!
+//! Constructing a window means a live `NSApplication`, a `WKWebView` and the
+//! WebContent process behind it — heavy, and flaky on a runner with no
+//! display. The properties worth defending do not need any of that:
+//!
+//!   1. every window constructor registers its window, and
+//!   2. nothing infers craft-ness from the window's appearance again.
+//!
+//! Both are properties of the source, and they are only checkable *because*
+//! the fix replaced an inference with a registration. "Does this window look
+//! like ours?" can only be answered by holding a window. "Did every
+//! constructor register?" can be answered by reading. Making the property
+//! checkable was worth as much as fixing the bug.
+//!
+//! Each check carries a floor, because a scan that finds nothing passes
+//! vacuously, and a vacuous pass is how this class of bug returns.
+
+const std = @import("std");
+const testing = std.testing;
+
+const macos_source = @embedFile("src/macos.zig");
+
+/// The Objective-C initialiser every `NSWindow` in craft goes through.
+const window_init = "initWithContentRect:styleMask:backing:defer:";
+
+/// What a constructor must call on the window it just made.
+const register_call = "keepWindowAfterClose(";
+
+/// Whether `body` really calls `needle`, ignoring commented-out occurrences.
+///
+/// Substring matching alone cannot tell a call from a mention. Commenting a
+/// registration out would leave the text in place and satisfy a naive scan —
+/// which is exactly how this check was first found to be toothless, by
+/// commenting one out and watching it pass.
+fn callsFunction(body: []const u8, needle: []const u8) bool {
+    var search: usize = 0;
+    while (std.mem.indexOfPos(u8, body, search, needle)) |hit| {
+        search = hit + needle.len;
+        const start = lineStart(body, hit);
+        const before = std.mem.trimStart(u8, body[start..hit], " \t");
+        // `//` anywhere before it on the line makes it a comment, and `///`
+        // makes it documentation.
+        if (std.mem.startsWith(u8, before, "//")) continue;
+        if (std.mem.indexOf(u8, body[start..hit], "//") != null) continue;
+        return true;
+    }
+    return false;
+}
+
+/// Start of the line containing `needle`.
+fn lineStart(source: []const u8, at: usize) usize {
+    var i = at;
+    while (i > 0 and source[i - 1] != '\n') i -= 1;
+    return i;
+}
+
+/// The `fn` declaration enclosing byte `at`.
+///
+/// Zig indents declarations at column zero inside a file, so the nearest
+/// preceding line beginning with `fn ` or `pub fn ` is the enclosing
+/// top-level function. Container-level methods are indented and belong to a
+/// struct whose own declaration is found the same way.
+fn enclosingFn(source: []const u8, at: usize) ?[]const u8 {
+    var i = lineStart(source, at);
+    while (true) {
+        const line_end = std.mem.indexOfScalarPos(u8, source, i, '\n') orelse source.len;
+        const line = source[i..line_end];
+        if (std.mem.startsWith(u8, line, "fn ") or std.mem.startsWith(u8, line, "pub fn ")) return line;
+        if (i == 0) return null;
+        i = lineStart(source, i - 1);
+    }
+}
+
+/// Byte range of the function body enclosing `at`, from its `fn` line to the
+/// next top-level `fn` line (or end of file).
+fn enclosingFnBody(source: []const u8, at: usize) []const u8 {
+    var start = lineStart(source, at);
+    while (start > 0) {
+        const line_end = std.mem.indexOfScalarPos(u8, source, start, '\n') orelse source.len;
+        const line = source[start..line_end];
+        if (std.mem.startsWith(u8, line, "fn ") or std.mem.startsWith(u8, line, "pub fn ")) break;
+        start = lineStart(source, start - 1);
+    }
+
+    var end = at;
+    while (end < source.len) {
+        const line_end = std.mem.indexOfScalarPos(u8, source, end, '\n') orelse source.len;
+        const line = source[end..line_end];
+        if (end != start and (std.mem.startsWith(u8, line, "fn ") or std.mem.startsWith(u8, line, "pub fn "))) break;
+        if (line_end >= source.len) {
+            end = source.len;
+            break;
+        }
+        end = line_end + 1;
+    }
+    return source[start..end];
+}
+
+test "every window craft constructs is registered as one of its own" {
+    // The check that would have caught the bug this file exists for — had the
+    // answer been recorded rather than inferred. It is recorded now, so this
+    // is the property that keeps it recorded.
+    var constructors: usize = 0;
+    var unregistered: usize = 0;
+
+    var search: usize = 0;
+    while (std.mem.indexOfPos(u8, macos_source, search, window_init)) |hit| {
+        search = hit + window_init.len;
+
+        // The name is mentioned in prose as well as called. Only a real
+        // `msgSend4(...)` call constructs a window.
+        const line = macos_source[lineStart(macos_source, hit)..hit];
+        if (std.mem.indexOf(u8, line, "msgSend4") == null) continue;
+
+        constructors += 1;
+        const body = enclosingFnBody(macos_source, hit);
+        if (!callsFunction(body, register_call)) {
+            unregistered += 1;
+            const name = enclosingFn(macos_source, hit) orelse "(unknown)";
+            std.debug.print(
+                "\nwindow constructor does not call {s}: {s}\n",
+                .{ register_call, name },
+            );
+        }
+    }
+
+    // Floor: craft has three window constructors. If a refactor renames the
+    // initialiser this scan finds none and would otherwise pass having checked
+    // nothing at all.
+    try testing.expect(constructors >= 3);
+    try testing.expectEqual(@as(usize, 0), unregistered);
+}
+
+test "whether a window is craft's is recorded, never inferred from the window" {
+    // The specific regression. `isCraftWindow` asked the window what its
+    // content view was; three of craft's four window styles answer with a
+    // container rather than the webview, so those windows were silently
+    // skipped by reopen.
+    //
+    // Any re-introduction reads the window instead of the registry, and every
+    // way of doing that goes through one of these.
+    const start = std.mem.indexOf(u8, macos_source, "fn isCraftWindow(") orelse {
+        // Renamed or removed: this test can no longer defend anything and must
+        // say so rather than pass.
+        return error.IsCraftWindowNotFound;
+    };
+    const body = enclosingFnBody(macos_source, start);
+
+    for ([_][]const u8{
+        "contentView",
+        "isKindOfClass:",
+        "contentViewController",
+        "subviews",
+    }) |inference| {
+        if (std.mem.indexOf(u8, body, inference) != null) {
+            std.debug.print("\nisCraftWindow inspects the window ({s}) instead of the registry\n", .{inference});
+            return error.WindowIdentityInferred;
+        }
+    }
+
+    // And it must actually consult the registry, rather than being stubbed to
+    // a constant that passes the check above.
+    try testing.expect(callsFunction(body, "window_registry.isKnown"));
+}
+
+test "the reopen handler filters by that answer" {
+    // Registration is worth nothing if the reopen loop stops asking. This
+    // pins the one place the two meet.
+    const start = std.mem.indexOf(u8, macos_source, "fn appShouldHandleReopen(") orelse
+        return error.ReopenHandlerNotFound;
+    const body = enclosingFnBody(macos_source, start);
+
+    try testing.expect(callsFunction(body, "isCraftWindow("));
+    try testing.expect(callsFunction(body, "makeKeyAndOrderFront:"));
+}
+
+test "a closed window survives long enough to be reopened" {
+    // `releasedWhenClosed` defaults to YES for a window built with
+    // `initWithContentRect:`, so without this the window is deallocated on
+    // close and reopening it is a use-after-free rather than a missing
+    // feature. It is set in the same helper that registers, so that a
+    // constructor cannot get one without the other.
+    const start = std.mem.indexOf(u8, macos_source, "fn keepWindowAfterClose(") orelse
+        return error.HelperNotFound;
+    const body = enclosingFnBody(macos_source, start);
+
+    try testing.expect(callsFunction(body, "setReleasedWhenClosed:"));
+    try testing.expect(callsFunction(body, "rememberCraftWindow("));
+}
+
+test "the scan can actually find the constructors it claims to check" {
+    // Guards the guard: every test above depends on `enclosingFnBody` locating
+    // real function bodies. If the file's formatting changes such that it
+    // returns the whole file, the checks above pass regardless of the code.
+    const start = std.mem.indexOf(u8, macos_source, "fn isCraftWindow(").?;
+    const body = enclosingFnBody(macos_source, start);
+
+    try testing.expect(body.len > 0);
+    // A body that large means the scan lost its bearings and every check above
+    // is now looking at unrelated code.
+    try testing.expect(body.len < macos_source.len / 10);
+    try testing.expect(std.mem.startsWith(u8, body, "fn isCraftWindow("));
+}
+
+test "a commented-out call does not count as a call" {
+    // The weakness that made the constructor check toothless: substring
+    // matching cannot tell a call from a mention, so commenting a registration
+    // out satisfied it. Found by doing exactly that and watching the test pass.
+    try testing.expect(callsFunction("    keepWindowAfterClose(window);", "keepWindowAfterClose("));
+    try testing.expect(!callsFunction("    // keepWindowAfterClose(window);", "keepWindowAfterClose("));
+    try testing.expect(!callsFunction("    /// keepWindowAfterClose(window);", "keepWindowAfterClose("));
+    try testing.expect(!callsFunction("    _ = x; // keepWindowAfterClose(window);", "keepWindowAfterClose("));
+    // A real call on a line that also carries a trailing comment still counts.
+    try testing.expect(callsFunction("    keepWindowAfterClose(window); // why", "keepWindowAfterClose("));
+}


### PR DESCRIPTION
Closes the gap that let the `isCraftWindow` bug ship.

## The bug this exists for

`isCraftWindow` decided whether a window was craft's by asking whether its content view was a `WKWebView`. True of exactly one of craft's four window styles:

| constructor | content view | recognised? |
|---|---|---|
| plain window | the `WKWebView` | ✅ |
| `--web-sidebar-material` (`macos.zig:959`) | backdrop container | ❌ |
| `createWindowWithSidebar` (`:2214`) | split view controller | ❌ |
| `createWindowWithSidebarURL` (`:3363`) | its own container | ❌ |

All three keep their closed window alive, so reopen **found them and skipped them** — a Dock click on a sidebar app activated the process with nothing on screen, the exact dead end #63 was added to remove.

It compiled. Every test passed. It was caught by reading, not by running — and it *could not* have been caught by running, because **no test in this repository constructs a window at all.** Three constructors, six content-view installation sites, zero coverage.

## The half of the fix worth more than the fix

Recording the answer instead of inferring it turns an untestable property into a checkable one.

> *"Does this window look like ours?"* can only be answered by holding a window — a live `NSApplication`, a `WKWebView`, and the WebContent process behind it. Heavy, and flaky on a runner with no display.
>
> *"Did every constructor register?"* is a property of the source.

That is why this lands as a source conformance test rather than an integration test, and it is the same idiom `test/capabilities_test.zig` already uses for bridges.

## What is pinned

- **every window constructor registers its window** — with a floor of 3, so renaming the initialiser cannot make the scan pass having checked nothing
- **nothing infers craft-ness from a window again** — `contentView`, `isKindOfClass:`, `contentViewController`, `subviews` are all rejected inside `isCraftWindow`, and it must actually consult the registry
- **the reopen handler still filters by that answer** — registration is worthless if the loop stops asking
- **a closed window still survives to be reopened** — `releasedWhenClosed = NO` is set in the same helper that registers, so a constructor cannot get one without the other
- **the scan can find what it claims to check** — guards the guard, in case formatting changes make `enclosingFnBody` return the whole file and every check above start passing vacuously

The registry itself moves to `window_registry.zig`, free of Objective-C, with 8 unit tests covering capacity, idempotence, null handling, overflow reporting and slot reuse.

## Controls

Every check was verified to fail when the property is broken:

| control | result |
|---|---|
| restore the original `contentView` inference | fails ✓ |
| comment out one constructor's registration | fails ✓ — names `createWindowWithSidebarURL` |
| delete one constructor's registration | fails ✓ |
| stub `isCraftWindow` to always-true | fails ✓ |
| rename the initialiser (vacuous scan) | fails via the floor ✓ |

**The first version of the constructor check was toothless, and the controls are what found it.** Commenting a registration out left the text in place and satisfied a substring match — the check passed on broken code. Calls are now distinguished from mentions, and that helper has its own test.

## Verified

`zig build` · `zig build test` · `zig build test-js` · `x86_64-windows` cross-build · `zig fmt --check` · 511 bun tests · pickier 38 warnings, unchanged from main.