### PR TITLE
feat(log): --log-file, and a logger that survives being used

### DIFF
--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -744,6 +744,19 @@ pub fn build(b: *std.Build) void {
     });
     bridge_shell_tests.root_module.link_libc = true;
 
+    // The host logger's own internals. `test/log_test.zig` already exercises it
+    // through the module boundary, which cannot reach the config storage or the
+    // formatter — the three places it was wrong. Rooted at the source file so
+    // those are reachable.
+    const log_unit_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/log.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    log_unit_tests.root_module.link_libc = true;
+
     // The conformance test: what craft declares, against what it dispatches.
     const capability_conformance_tests = b.addTest(.{
         .root_module = b.createModule(.{
@@ -1115,6 +1128,7 @@ pub fn build(b: *std.Build) void {
     const run_local_tls_tests = b.addRunArtifact(local_tls_tests);
     const run_menu_roles_tests = b.addRunArtifact(menu_roles_tests);
     const run_capabilities_tests = b.addRunArtifact(capabilities_tests);
+    const run_log_unit_tests = b.addRunArtifact(log_unit_tests);
     const run_bridge_shell_tests = b.addRunArtifact(bridge_shell_tests);
     const run_window_lifecycle_tests = b.addRunArtifact(window_lifecycle_tests);
     const run_window_registry_tests = b.addRunArtifact(window_registry_tests);
@@ -1237,6 +1251,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_local_tls_tests.step);
     test_step.dependOn(&run_menu_roles_tests.step);
     test_step.dependOn(&run_capabilities_tests.step);
+    test_step.dependOn(&run_log_unit_tests.step);
     test_step.dependOn(&run_bridge_shell_tests.step);
     test_step.dependOn(&run_window_lifecycle_tests.step);
     test_step.dependOn(&run_window_registry_tests.step);

--- a/packages/zig/src/cli.zig
+++ b/packages/zig/src/cli.zig
@@ -50,6 +50,15 @@ pub const WindowOptions = struct {
     // — so every app launched through the shared `craft` binary called itself
     // "craft". macOS only.
     app_name: ?[]const u8 = null,
+    // Write craft's own log to this file, in addition to stderr. Null leaves
+    // logging where it has always been: stderr only.
+    log_file: ?[]const u8 = null,
+    // Emit each record as a JSON object rather than a human-readable line.
+    log_json: bool = false,
+    // Lowest level that gets recorded: debug, info, warn, error, fatal.
+    log_level: ?[]const u8 = null,
+    // Send records only to the log file, leaving the terminal quiet.
+    log_quiet: bool = false,
     // Keep the process alive after the last window closes, instead of quitting.
     // Null means craft decides from the shape of the app: a tray or
     // menubar-only app stays, an ordinary windowed app goes. See
@@ -86,6 +95,8 @@ pub fn freeOptionStrings(allocator: std.mem.Allocator, options: *WindowOptions) 
     if (options.icon) |s| allocator.free(s);
     if (options.app_name) |s| allocator.free(s);
     if (options.frame_autosave) |s| allocator.free(s);
+    if (options.log_file) |s| allocator.free(s);
+    if (options.log_level) |s| allocator.free(s);
     if (options.eval_source) |s| allocator.free(s);
     if (options.eval_file) |s| allocator.free(s);
     options.* = WindowOptions{};
@@ -171,6 +182,9 @@ const BundleConfig = struct {
     titlebarHidden: ?bool = null,
     headless: ?bool = null,
     keepRunning: ?bool = null,
+    logFile: ?[]const u8 = null,
+    logJson: ?bool = null,
+    logLevel: ?[]const u8 = null,
 };
 
 /// Absolute path of the running executable's directory.
@@ -245,6 +259,8 @@ fn loadBundleConfig(allocator: std.mem.Allocator) ?WindowOptions {
     if (cfg.title) |v| options.title = allocator.dupe(u8, v) catch options.title;
     if (cfg.appName) |v| options.app_name = allocator.dupe(u8, v) catch null;
     if (cfg.frameAutosave) |v| options.frame_autosave = allocator.dupe(u8, v) catch null;
+    if (cfg.logFile) |v| options.log_file = allocator.dupe(u8, v) catch null;
+    if (cfg.logLevel) |v| options.log_level = allocator.dupe(u8, v) catch null;
     if (cfg.icon) |v| options.icon = allocator.dupe(u8, v) catch null;
     applyScalarConfig(cfg, &options);
 
@@ -271,6 +287,7 @@ fn applyScalarConfig(cfg: BundleConfig, options: *WindowOptions) void {
     if (cfg.titlebarHidden) |v| options.titlebar_hidden = v;
     if (cfg.headless) |v| options.headless = v;
     if (cfg.keepRunning) |v| options.keep_running = v;
+    if (cfg.logJson) |v| options.log_json = v;
     // A menubar app with a dock icon and no tray is not a menubar app, so the
     // one flag sets all three rather than making every manifest repeat them.
     if (cfg.menubarOnly) |v| {
@@ -497,6 +514,18 @@ pub fn parseArgs(allocator: std.mem.Allocator, args: []const [:0]const u8) !Wind
             options.hide_dock_icon = true;
         } else if (std.mem.eql(u8, arg, "--headless")) {
             options.headless = true;
+        } else if (std.mem.eql(u8, arg, "--log-file")) {
+            i += 1;
+            if (i >= args.len) return CliError.MissingValue;
+            options.log_file = try allocator.dupe(u8, args[i]);
+        } else if (std.mem.eql(u8, arg, "--log-json")) {
+            options.log_json = true;
+        } else if (std.mem.eql(u8, arg, "--log-quiet")) {
+            options.log_quiet = true;
+        } else if (std.mem.eql(u8, arg, "--log-level")) {
+            i += 1;
+            if (i >= args.len) return CliError.MissingValue;
+            options.log_level = try allocator.dupe(u8, args[i]);
         } else if (std.mem.eql(u8, arg, "--keep-running")) {
             options.keep_running = true;
         } else if (std.mem.eql(u8, arg, "--quit-on-close")) {
@@ -606,6 +635,13 @@ fn printHelp() void {
         \\      --system-tray        Show system tray icon
         \\      --hide-dock-icon     Hide dock icon (menubar-only mode, macOS)
         \\      --menubar-only       Menubar-only mode (no window, system tray only)
+        \\      --log-file <PATH>    Append craft's own log to this file as well as
+        \\                           stderr. Captures everything craft logs through
+        \\                           std.log; debug-mode std.debug.print tracing is
+        \\                           not included.
+        \\      --log-json           One JSON object per record instead of a line.
+        \\      --log-level <LEVEL>  debug, info, warn, error or fatal (default info).
+        \\      --log-quiet          Write only to --log-file, leaving stderr alone.
         \\      --keep-running       Stay running after the last window closes.
         \\                           The default for tray and menubar-only apps;
         \\                           an ordinary windowed app quits.
@@ -768,4 +804,52 @@ test "the last of the two flags wins" {
     var args = [_][:0]const u8{ "craft", "--keep-running", "--quit-on-close" };
     const options = try parseArgs(std.testing.allocator, &args);
     try std.testing.expectEqual(@as(?bool, false), options.keep_running);
+}
+
+test "the logging flags are parsed" {
+    var args = [_][:0]const u8{ "craft", "--log-file", "/tmp/craft.log", "--log-json", "--log-level", "debug", "--log-quiet" };
+    const options = try parseArgs(std.testing.allocator, &args);
+    defer {
+        var o = options;
+        freeOptionStrings(std.testing.allocator, &o);
+    }
+    try std.testing.expectEqualStrings("/tmp/craft.log", options.log_file.?);
+    try std.testing.expect(options.log_json);
+    try std.testing.expectEqualStrings("debug", options.log_level.?);
+    try std.testing.expect(options.log_quiet);
+}
+
+test "logging is off unless asked for" {
+    var args = [_][:0]const u8{"craft"};
+    const options = try parseArgs(std.testing.allocator, &args);
+    try std.testing.expectEqual(@as(?[]const u8, null), options.log_file);
+    try std.testing.expectEqual(@as(?[]const u8, null), options.log_level);
+    try std.testing.expect(!options.log_json);
+    try std.testing.expect(!options.log_quiet);
+}
+
+test "--log-file without a value is an error, not a silent default" {
+    var args = [_][:0]const u8{ "craft", "--log-file" };
+    try std.testing.expectError(CliError.MissingValue, parseArgs(std.testing.allocator, &args));
+}
+
+test "a manifest can ask for a log file" {
+    const source =
+        \\{"title":"Probe","logFile":"/var/log/app.log","logLevel":"warn","logJson":true}
+    ;
+    const parsed = try std.json.parseFromSlice(BundleConfig, std.testing.allocator, source, .{
+        .ignore_unknown_fields = true,
+        .allocate = .alloc_always,
+    });
+    defer parsed.deinit();
+
+    // The path and level are applied inside `loadBundleConfig`, which reads the
+    // filesystem; what is checkable here is that the manifest keys decode and
+    // that the scalar reaches the options.
+    try std.testing.expectEqualStrings("/var/log/app.log", parsed.value.logFile.?);
+    try std.testing.expectEqualStrings("warn", parsed.value.logLevel.?);
+
+    var options = WindowOptions{};
+    applyScalarConfig(parsed.value, &options);
+    try std.testing.expect(options.log_json);
 }

--- a/packages/zig/src/log.zig
+++ b/packages/zig/src/log.zig
@@ -37,16 +37,64 @@ pub const LogConfig = struct {
     enable_timestamps: bool = true,
     output_file: ?[]const u8 = null,
     json_output: bool = false,
+    /// Also write every record to stderr.
+    ///
+    /// On by default, which is what this logger has always done. A caller that
+    /// wants a file and a quiet terminal — a packaged app, a headless run —
+    /// had no way to ask, because the stderr write was unconditional.
+    mirror_to_stderr: bool = true,
     filter_pattern: ?[]const u8 = null,
 };
 
 var current_config: LogConfig = .{};
 var log_file: ?std.Io.File = null;
+
+/// Where the next record goes.
+///
+/// `Io.Dir.CreateFileOptions` has no append flag in this Zig, and
+/// `writeStreamingAll` starts at position zero — so an existing log was
+/// overwritten from the beginning on every run, leaving whatever was longer
+/// than the new content stranded past the end as garbage. Seeded from the
+/// file's size at open and advanced by every write, with `writePositionalAll`,
+/// which is how appending is spelled here.
+var log_file_offset: u64 = 0;
+
+/// Storage for the configuration's strings.
+///
+/// `LogConfig` carries `output_file` and `filter_pattern` as slices, and
+/// `init` used to keep the caller's. The path arrives from the command line
+/// and `minimal.zig` frees those strings during startup, so retaining them
+/// would leave this module reading freed memory on the first log call after
+/// argument parsing finished — a use-after-free that arrives only once
+/// something actually configures the logger, which nothing did until now.
+var output_file_storage: [std.fs.max_path_bytes]u8 = undefined;
+var filter_storage: [256]u8 = undefined;
 /// Guards `current_config`, `log_file`, and the final write to stderr+file
 /// so concurrent loggers don't interleave bytes or race on config updates.
 /// The previous module-level `var`s were read/written from every call site
 /// without any synchronization.
 var log_mutex: compat_mutex.Mutex = .{};
+
+/// True while this thread is inside `log`.
+///
+/// `compat_mutex` falls back to a spinlock when `std.Thread.Mutex` is absent,
+/// and it is absent in this Zig — so the lock is non-recursive and never
+/// yields. A `std.log` call made from inside `log` would spin against a lock
+/// this thread already holds, forever: a hard hang with no panic and no
+/// stack. That was unreachable while nothing configured the logger, and
+/// routing every `std.log` site through it is exactly what makes it reachable.
+///
+/// Dropping the inner record is the right trade. The alternative is a process
+/// that stops responding because something logged while logging.
+threadlocal var in_log: bool = false;
+
+/// The `Io` to write through, captured at `init`.
+///
+/// `io_context.get()` takes `global_state`'s own non-recursive spinlock, and
+/// `log` used to call it while holding `log_mutex` — two spinlocks nested in a
+/// fixed order, and a lazy `std.Io.Threaded` construction on the C allocator
+/// reachable from inside a log call. Captured once instead.
+var log_io: ?std.Io = null;
 
 pub fn init(config: LogConfig) !void {
     log_mutex.lock();
@@ -60,12 +108,35 @@ pub fn init(config: LogConfig) !void {
     }
 
     current_config = config;
+    log_file_offset = 0;
+    log_io = io_context.get();
 
+    // Take copies before anything else can free the originals.
     if (config.output_file) |path| {
-        log_file = try std.Io.Dir.cwd().createFile(io_context.get(), path, .{
+        if (path.len > output_file_storage.len) return error.NameTooLong;
+        @memcpy(output_file_storage[0..path.len], path);
+        current_config.output_file = output_file_storage[0..path.len];
+    }
+    if (config.filter_pattern) |pattern| {
+        if (pattern.len > filter_storage.len) return error.NameTooLong;
+        @memcpy(filter_storage[0..pattern.len], pattern);
+        current_config.filter_pattern = filter_storage[0..pattern.len];
+    }
+
+    if (current_config.output_file) |path| {
+        const io = io_context.get();
+        const file = try std.Io.Dir.cwd().createFile(io, path, .{
             .truncate = false,
             .read = true,
         });
+        // Append rather than overwrite: a log that starts again from byte zero
+        // on every launch loses the run that diagnosed the problem.
+        const existing = file.stat(io) catch |stat_err| {
+            file.close(io);
+            return stat_err;
+        };
+        log_file_offset = existing.size;
+        log_file = file;
     }
 }
 
@@ -103,6 +174,32 @@ fn shouldLogLocked(level: LogLevel) bool {
     return @backingInt(level) >= @backingInt(current_config.min_level);
 }
 
+/// `std.fmt.bufPrint` that clips instead of failing.
+///
+/// Returns as much of the formatted text as fits, ending with a marker so a
+/// reader can tell the difference between a short message and a clipped one.
+/// The alternative — what this code did before — was to return nothing at all
+/// and log no record, silently.
+fn formatTruncating(buf: []u8, comptime format: []const u8, args: anytype) []const u8 {
+    if (std.fmt.bufPrint(buf, format, args)) |written| {
+        return written;
+    } else |_| {}
+
+    const marker = "…[truncated]";
+    if (buf.len <= marker.len) return buf[0..0];
+
+    // Re-format into the space that is left, then stamp the marker on the end.
+    // A second failure means even the clipped form does not fit, so keep
+    // whatever was written and mark it.
+    const room = buf.len - marker.len;
+    var written_len: usize = room;
+    if (std.fmt.bufPrint(buf[0..room], format, args)) |written| {
+        written_len = written.len;
+    } else |_| {}
+    @memcpy(buf[written_len..][0..marker.len], marker);
+    return buf[0 .. written_len + marker.len];
+}
+
 pub fn log(
     comptime level: LogLevel,
     comptime format: []const u8,
@@ -113,14 +210,26 @@ pub fn log(
     // prevents stderr interleaving between threads and makes config
     // updates atomic with emission. Previously every call touched
     // `current_config` and `log_file` unsynchronized.
+    // Before the lock, not after: the point is to never reach a lock this
+    // thread already holds.
+    if (in_log) return;
+    in_log = true;
+    defer in_log = false;
+
     log_mutex.lock();
     defer log_mutex.unlock();
 
     if (!shouldLogLocked(level)) return;
 
-    // Format message
+    // Format the message, truncating rather than dropping it.
+    //
+    // This was `bufPrint(...) catch return`, which discarded the whole record
+    // when it did not fit — so the longest messages, which are usually the
+    // ones worth reading, were the only ones guaranteed to be missing. A log
+    // that silently omits its biggest entries is worse than one that clips
+    // them, because nothing indicates anything was lost.
     var msg_buf: [2048]u8 = undefined;
-    const message = std.fmt.bufPrint(&msg_buf, format, args) catch return;
+    const message = formatTruncating(&msg_buf, format, args);
 
     // Apply filter if configured
     if (current_config.filter_pattern) |pattern| {
@@ -133,7 +242,7 @@ pub fn log(
     var output_len: usize = 0;
 
     // Each call owns its own timestamp buffer — safe for concurrent logging.
-    var ts_buf: [8]u8 = undefined;
+    var ts_buf: [timestamp_len]u8 = undefined;
     const timestamp = formatTimestamp(&ts_buf);
 
     if (current_config.json_output) {
@@ -142,7 +251,29 @@ pub fn log(
         // `foo "bar"\nbaz` would corrupt every log consumer parsing the stream.
         var esc_buf: [4096]u8 = undefined;
         var esc_len: usize = 0;
-        for (message) |c| {
+        var i: usize = 0;
+        while (i < message.len) {
+            const c = message[i];
+
+            // Anything outside ASCII is walked as a UTF-8 sequence rather than
+            // byte by byte. Passing high bytes through individually is what
+            // the previous loop did, and a message carrying invalid UTF-8 — a
+            // filename, a truncated IPC frame — then produced a line that
+            // `JSON.parse` rejects. A log format that a bad byte can make
+            // unreadable is not a structured log format.
+            if (c >= 0x80) {
+                const seq_len = std.unicode.utf8ByteSequenceLength(c) catch 0;
+                const valid = seq_len > 0 and i + seq_len <= message.len and
+                    std.unicode.utf8ValidateSlice(message[i..][0..seq_len]);
+                const chunk: []const u8 = if (valid) message[i..][0..seq_len] else "\\ufffd";
+                if (esc_len + chunk.len > esc_buf.len) break;
+                @memcpy(esc_buf[esc_len..][0..chunk.len], chunk);
+                esc_len += chunk.len;
+                i += if (valid) seq_len else 1;
+                continue;
+            }
+
+            i += 1;
             const esc: []const u8 = switch (c) {
                 '"' => "\\\"",
                 '\\' => "\\\\",
@@ -165,36 +296,36 @@ pub fn log(
             esc_len += esc.len;
         }
 
-        const result = std.fmt.bufPrint(&output_buf, "{{\"timestamp\":\"{s}\",\"level\":\"{s}\",\"message\":\"{s}\"}}\n", .{ timestamp, level.toString(), esc_buf[0..esc_len] }) catch return;
-        output_len = result.len;
+        output_len = formatTruncating(&output_buf, "{{\"timestamp\":\"{s}\",\"level\":\"{s}\",\"message\":\"{s}\"}}\n", .{ timestamp, level.toString(), esc_buf[0..esc_len] }).len;
     } else {
         // Standard output
         const reset = "\x1B[0m";
         const dim = "\x1B[2m";
 
         if (current_config.enable_timestamps and current_config.enable_colors) {
-            const result = std.fmt.bufPrint(&output_buf, "{s}[{s}]{s} {s}{s}{s} {s}\n", .{ dim, timestamp, reset, level.color(), level.toString(), reset, message }) catch return;
-            output_len = result.len;
+            output_len = formatTruncating(&output_buf, "{s}[{s}]{s} {s}{s}{s} {s}\n", .{ dim, timestamp, reset, level.color(), level.toString(), reset, message }).len;
         } else if (current_config.enable_timestamps) {
-            const result = std.fmt.bufPrint(&output_buf, "[{s}] {s} {s}\n", .{ timestamp, level.toString(), message }) catch return;
-            output_len = result.len;
+            output_len = formatTruncating(&output_buf, "[{s}] {s} {s}\n", .{ timestamp, level.toString(), message }).len;
         } else if (current_config.enable_colors) {
-            const result = std.fmt.bufPrint(&output_buf, "{s}{s}{s} {s}\n", .{ level.color(), level.toString(), reset, message }) catch return;
-            output_len = result.len;
+            output_len = formatTruncating(&output_buf, "{s}{s}{s} {s}\n", .{ level.color(), level.toString(), reset, message }).len;
         } else {
-            const result = std.fmt.bufPrint(&output_buf, "{s} {s}\n", .{ level.toString(), message }) catch return;
-            output_len = result.len;
+            output_len = formatTruncating(&output_buf, "{s} {s}\n", .{ level.toString(), message }).len;
         }
     }
 
     const output = output_buf[0..output_len];
 
-    // Write to stderr
-    _ = std.Io.File.stderr().writeStreamingAll(io_context.get(), output) catch return;
+    const io = log_io orelse io_context.get();
 
-    // Write to file if configured
+    if (current_config.mirror_to_stderr) {
+        _ = std.Io.File.stderr().writeStreamingAll(io, output) catch {};
+    }
+
+    // Appended at the tracked offset. `writeStreamingAll` writes from position
+    // zero, which overwrote the previous run in place.
     if (log_file) |file| {
-        _ = file.writeStreamingAll(io_context.get(), output) catch return;
+        file.writePositionalAll(io, output, log_file_offset) catch return;
+        log_file_offset += output.len;
     }
 }
 
@@ -224,27 +355,309 @@ pub fn fatal(comptime format: []const u8, args: anytype) void {
 /// reading live logs see their own wall-clock time instead of raw UTC.
 /// `ts.sec` values below zero are clamped to 0 so pre-1970 clocks (e.g.
 /// a VM booting with no RTC) can't panic in `@intCast`.
-fn formatTimestamp(buf: *[8]u8) []const u8 {
-    var ts: std.c.timespec = undefined;
-    if (std.c.clock_gettime(.REALTIME, &ts) != 0) {
-        @memcpy(buf, "00:00:00");
+/// An ISO-8601 UTC timestamp: `YYYY-MM-DDTHH:MM:SSZ`.
+///
+/// This used to emit `HH:MM:SS` and nothing else, which is fine for watching a
+/// terminal and useless for the thing `--log-file` exists to produce: a trail
+/// you read afterwards, possibly days afterwards, to work out what a
+/// long-running app did. A time with no date cannot answer that.
+///
+/// UTC rather than local. The previous comment claimed it used `localtime_r`;
+/// the body did modular arithmetic on the epoch and left a dead `_ = t;`
+/// behind. `localtime_r` is not declared in `std.c` in this Zig, so honouring
+/// that comment would mean declaring the extern — and a log shared between a
+/// machine and whoever reads it later is better off unambiguous anyway.
+fn formatTimestamp(buf: *[timestamp_len]u8) []const u8 {
+    const fallback = "0000-00-00T00:00:00Z";
+
+    // `compat.timestamp` rather than `std.c.clock_gettime`: the latter does not
+    // compile for Windows in this Zig, and this file only ever built because
+    // nothing instantiated `log` — wiring every std.log site through it is
+    // what made the Windows path get analysed for the first time.
+    const secs = @import("compat.zig").timestamp();
+    const epoch_seconds: std.time.epoch.EpochSeconds = .{ .secs = @intCast(@max(secs, 0)) };
+    const day = epoch_seconds.getEpochDay().calculateYearDay();
+    const month_day = day.calculateMonthDay();
+    const time = epoch_seconds.getDaySeconds();
+
+    const written = std.fmt.bufPrint(buf, "{d:0>4}-{d:0>2}-{d:0>2}T{d:0>2}:{d:0>2}:{d:0>2}Z", .{
+        day.year,
+        month_day.month.numeric(),
+        month_day.day_index + 1,
+        time.getHoursIntoDay(),
+        time.getMinutesIntoHour(),
+        time.getSecondsIntoMinute(),
+    }) catch {
+        @memcpy(buf, fallback);
         return buf[0..];
+    };
+    return written;
+}
+
+/// Width of `YYYY-MM-DDTHH:MM:SSZ`.
+const timestamp_len = 20;
+
+// =============================================================================
+// Tests
+// =============================================================================
+//
+// This module had none. It was written complete — levels, JSON, a filter, a
+// mutex, file output — and then never configured by anything, so every path
+// below the default was unexercised. Wiring `--log-file` in front of it
+// without first running it would have been the same mistake the rest of this
+// codebase keeps making: shipping code that looks right and has never run.
+
+const testing = std.testing;
+
+fn resetInLogForTesting() void {
+    in_log = false;
+}
+
+test "a message longer than the buffer is clipped, not discarded" {
+    // The defect: `bufPrint(...) catch return` dropped the entire record when
+    // it did not fit, so the longest messages — usually the interesting ones —
+    // were the only ones certain to be missing, with nothing to say so.
+    var buf: [64]u8 = undefined;
+    var long: [500]u8 = undefined;
+    @memset(&long, 'x');
+
+    const out = formatTruncating(&buf, "{s}", .{long});
+    try testing.expect(out.len > 0);
+    try testing.expect(out.len <= buf.len);
+    try testing.expect(std.mem.endsWith(u8, out, "…[truncated]"));
+}
+
+test "a message that fits is untouched" {
+    var buf: [64]u8 = undefined;
+    const out = formatTruncating(&buf, "hello {s}", .{"world"});
+    try testing.expectEqualStrings("hello world", out);
+}
+
+test "a buffer too small even for the marker yields nothing rather than corrupting it" {
+    var buf: [4]u8 = undefined;
+    const out = formatTruncating(&buf, "{s}", .{"much longer than four"});
+    try testing.expectEqual(@as(usize, 0), out.len);
+}
+
+test "the configuration's strings are copied, not borrowed" {
+    // `init` stored the caller's slices, and `minimal.zig` frees the
+    // command-line strings during startup — so the first log call after
+    // argument parsing would have read freed memory. Nothing had configured
+    // the logger before, which is the only reason it never happened.
+    var path_buf: [64]u8 = undefined;
+    const scratch = try std.fmt.bufPrint(&path_buf, "{s}", .{"craft-log-borrow-test.txt"});
+
+    try init(.{ .output_file = scratch, .filter_pattern = "keepme", .mirror_to_stderr = false });
+    defer {
+        deinit();
+        std.Io.Dir.cwd().deleteFile(io_context.get(), "craft-log-borrow-test.txt") catch {};
     }
 
-    const safe_sec = @max(ts.sec, 0);
-    const t: std.c.time_t = @intCast(safe_sec);
+    // Scribble over the caller's buffer. A borrowed slice would now be garbage.
+    @memset(&path_buf, '!');
 
-    _ = t;
-    const slice = blk: {
-        const total_seconds: u64 = @intCast(safe_sec);
-        const seconds = @mod(total_seconds, 60);
-        const minutes = @mod(@divFloor(total_seconds, 60), 60);
-        const hours = @mod(@divFloor(total_seconds, 3600), 24);
-        break :blk std.fmt.bufPrint(buf, "{d:0>2}:{d:0>2}:{d:0>2}", .{ hours, minutes, seconds }) catch null;
-    };
+    try testing.expectEqualStrings("craft-log-borrow-test.txt", current_config.output_file.?);
+    try testing.expectEqualStrings("keepme", current_config.filter_pattern.?);
+}
 
-    return slice orelse retry: {
-        @memcpy(buf, "00:00:00");
-        break :retry buf[0..];
-    };
+test "a second run appends instead of overwriting the first" {
+    // `Io.Dir.CreateFileOptions` has no append flag and `writeStreamingAll`
+    // starts at position zero, so every run rewrote the file from the
+    // beginning — losing the run that diagnosed the problem and leaving any
+    // longer previous content stranded past the end.
+    const io = io_context.get();
+    const path = "craft-log-append-test.txt";
+    std.Io.Dir.cwd().deleteFile(io, path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(io, path) catch {};
+
+    try init(.{
+        .output_file = path,
+        .min_level = .Debug,
+        .enable_colors = false,
+        .enable_timestamps = false,
+        .mirror_to_stderr = false,
+    });
+    log(.Info, "first run {d}", .{1});
+    deinit();
+
+    try init(.{
+        .output_file = path,
+        .min_level = .Debug,
+        .enable_colors = false,
+        .enable_timestamps = false,
+        .mirror_to_stderr = false,
+    });
+    log(.Info, "second run {d}", .{2});
+    deinit();
+
+    var read_buf: [4096]u8 = undefined;
+    const file = try std.Io.Dir.cwd().openFile(io, path, .{});
+    defer file.close(io);
+    const n = try file.readPositionalAll(io, &read_buf, 0);
+    const contents = read_buf[0..n];
+
+    // Both runs are present, and in order.
+    const first = std.mem.indexOf(u8, contents, "first run 1") orelse return error.FirstRunLost;
+    const second = std.mem.indexOf(u8, contents, "second run 2") orelse return error.SecondRunLost;
+    try testing.expect(first < second);
+}
+
+test "the level filter keeps quiet records out of the file" {
+    const io = io_context.get();
+    const path = "craft-log-level-test.txt";
+    std.Io.Dir.cwd().deleteFile(io, path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(io, path) catch {};
+
+    try init(.{
+        .output_file = path,
+        .min_level = .Warning,
+        .enable_colors = false,
+        .enable_timestamps = false,
+        .mirror_to_stderr = false,
+    });
+    log(.Debug, "quiet", .{});
+    log(.Info, "also quiet", .{});
+    log(.Warning, "loud", .{});
+    deinit();
+
+    var read_buf: [4096]u8 = undefined;
+    const file = try std.Io.Dir.cwd().openFile(io, path, .{});
+    defer file.close(io);
+    const n = try file.readPositionalAll(io, &read_buf, 0);
+    const contents = read_buf[0..n];
+
+    try testing.expect(std.mem.indexOf(u8, contents, "loud") != null);
+    try testing.expect(std.mem.indexOf(u8, contents, "quiet") == null);
+}
+
+test "json output stays parseable when the message fights back" {
+    const io = io_context.get();
+    const path = "craft-log-json-test.txt";
+    std.Io.Dir.cwd().deleteFile(io, path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(io, path) catch {};
+
+    try init(.{
+        .output_file = path,
+        .min_level = .Debug,
+        .json_output = true,
+        .mirror_to_stderr = false,
+    });
+    log(.Error, "he said {s} then a newline{s}and a tab{s}", .{ "\"hi\"", "\n", "\t" });
+    deinit();
+
+    var read_buf: [4096]u8 = undefined;
+    const file = try std.Io.Dir.cwd().openFile(io, path, .{});
+    defer file.close(io);
+    const n = try file.readPositionalAll(io, &read_buf, 0);
+    const line = std.mem.trimEnd(u8, read_buf[0..n], "\n");
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, line, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("ERROR", parsed.value.object.get("level").?.string);
+    const msg = parsed.value.object.get("message").?.string;
+    try testing.expect(std.mem.indexOf(u8, msg, "\"hi\"") != null);
+}
+
+test "mirroring to stderr can be turned off without losing the file" {
+    // The stderr write was unconditional, so a packaged or headless app could
+    // not ask for a file and a quiet terminal.
+    const io = io_context.get();
+    const path = "craft-log-quiet-test.txt";
+    std.Io.Dir.cwd().deleteFile(io, path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(io, path) catch {};
+
+    try init(.{
+        .output_file = path,
+        .min_level = .Debug,
+        .enable_colors = false,
+        .enable_timestamps = false,
+        .mirror_to_stderr = false,
+    });
+    log(.Info, "written to the file only", .{});
+    deinit();
+
+    var read_buf: [1024]u8 = undefined;
+    const file = try std.Io.Dir.cwd().openFile(io, path, .{});
+    defer file.close(io);
+    const n = try file.readPositionalAll(io, &read_buf, 0);
+    try testing.expect(std.mem.indexOf(u8, read_buf[0..n], "written to the file only") != null);
+}
+
+test "re-initialising closes the previous file rather than leaking it" {
+    const io = io_context.get();
+    const a = "craft-log-reinit-a.txt";
+    const b = "craft-log-reinit-b.txt";
+    defer std.Io.Dir.cwd().deleteFile(io, a) catch {};
+    defer std.Io.Dir.cwd().deleteFile(io, b) catch {};
+
+    try init(.{ .output_file = a, .mirror_to_stderr = false });
+    try init(.{ .output_file = b, .mirror_to_stderr = false });
+    try testing.expectEqualStrings(b, current_config.output_file.?);
+    deinit();
+    try testing.expect(log_file == null);
+}
+
+test "json survives a message that is not valid UTF-8" {
+    // A filename, a truncated IPC frame, any raw byte over 0x7f: these used to
+    // be copied into the JSON string verbatim, producing a line that
+    // `JSON.parse` rejects. A structured log a single bad byte can make
+    // unreadable is not structured.
+    const io = io_context.get();
+    const path = "craft-log-utf8-test.txt";
+    std.Io.Dir.cwd().deleteFile(io, path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(io, path) catch {};
+
+    try init(.{
+        .output_file = path,
+        .min_level = .Debug,
+        .json_output = true,
+        .mirror_to_stderr = false,
+    });
+    // 0xFF is never valid UTF-8; the é is, and must survive intact.
+    log(.Warning, "bad byte {s} and caf\xc3\xa9", .{"\xff\xfe"});
+    deinit();
+
+    var read_buf: [4096]u8 = undefined;
+    const file = try std.Io.Dir.cwd().openFile(io, path, .{});
+    defer file.close(io);
+    const n = try file.readPositionalAll(io, &read_buf, 0);
+    const line = std.mem.trimEnd(u8, read_buf[0..n], "\n");
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, line, .{});
+    defer parsed.deinit();
+    const msg = parsed.value.object.get("message").?.string;
+    try testing.expect(std.mem.indexOf(u8, msg, "café") != null);
+    try testing.expect(std.mem.indexOf(u8, msg, "\u{fffd}") != null);
+}
+
+test "a timestamp carries the date, not just the time" {
+    // `--log-file` produces a trail read afterwards, sometimes days
+    // afterwards. `HH:MM:SS` alone cannot say which day.
+    var buf: [timestamp_len]u8 = undefined;
+    const ts = formatTimestamp(&buf);
+    try testing.expectEqual(timestamp_len, ts.len);
+    try testing.expectEqual(@as(u8, '-'), ts[4]);
+    try testing.expectEqual(@as(u8, '-'), ts[7]);
+    try testing.expectEqual(@as(u8, 'T'), ts[10]);
+    try testing.expectEqual(@as(u8, 'Z'), ts[timestamp_len - 1]);
+    // A plausible year rather than the epoch fallback.
+    const year = try std.fmt.parseInt(u16, ts[0..4], 10);
+    try testing.expect(year >= 2020);
+}
+
+test "logging from inside logging drops the inner record instead of hanging" {
+    // `compat_mutex` is a non-recursive spinlock here — `std.Thread.Mutex`
+    // does not exist in this Zig — so a reentrant call would spin against a
+    // lock this thread already holds, forever. Routing every std.log site
+    // through this module is what made that reachable.
+    resetInLogForTesting();
+    try testing.expect(!in_log);
+
+    in_log = true;
+    // Would deadlock without the guard; returns immediately with it.
+    log(.Error, "reentrant", .{});
+    try testing.expect(in_log);
+
+    resetInLogForTesting();
+    try testing.expect(!in_log);
 }

--- a/packages/zig/src/main.zig
+++ b/packages/zig/src/main.zig
@@ -8,6 +8,15 @@ pub const macos = if (builtin.os.tag == .macos) @import("macos.zig") else struct
 const BridgeAPI = @import("bridge_api.zig").BridgeAPI;
 
 // Re-export io_context so root modules can access it without dual-module conflicts
+/// The host-side logger, and the sink `--log-file` configures.
+///
+/// Exported here because `minimal.zig` — the executable's root — cannot
+/// `@import("log.zig")` directly: a file may belong to only one module per
+/// compilation and this one belongs to `craft`. `src/craft.zig` appears to
+/// export it as `craft.app.Log`, but that file is not a module root and
+/// nothing imports it, so it was never a reachable surface.
+pub const Log = @import("log.zig");
+pub const Logging = @import("logging.zig");
 pub const io_context = @import("io_context.zig");
 pub const startup_timing = @import("startup_timing.zig");
 pub const js_runtime = @import("js_runtime.zig");

--- a/packages/zig/src/minimal.zig
+++ b/packages/zig/src/minimal.zig
@@ -8,6 +8,47 @@ const io_context = craft.io_context;
 // `craft`, and macos.zig already owns it there.
 const timing = craft.startup_timing;
 
+/// Craft's log handler.
+///
+/// One declaration in the executable's root, and every `std.log` call in the
+/// program routes through it — across module boundaries, because `std.log`
+/// resolves its handler from the compilation root rather than from the calling
+/// module. That is what makes `--log-file` worth having: without it the flag
+/// opens a file that only `devmode.zig` and `hotreload.zig` ever write to,
+/// which is to say an empty one.
+///
+/// `log_level = .debug` was already here and is load-bearing. `std.log.debug`
+/// is compiled out at comptime below the threshold, and most of craft's
+/// `std.log` calls are debug level; releases build ReleaseSafe, so without it
+/// `--log-level debug` would be a flag that could not do anything.
+///
+/// Not captured: `std.debug.print`, which craft uses in far more places than
+/// `std.log`. Those go through `std.Options.debug_io` rather than the log
+/// handler, and most sit behind `if (builtin.mode == .debug)`. Said plainly in
+/// `--help`, rather than left for someone to work out from a log file that is
+/// quieter than they expected.
+pub const std_options: std.Options = .{
+    .log_level = .debug,
+    .logFn = craftLogFn,
+};
+
+fn craftLogFn(
+    comptime message_level: std.log.Level,
+    comptime scope: @EnumLiteral(),
+    comptime format: []const u8,
+    args: anytype,
+) void {
+    // The scope is prefixed rather than dropped: `std.log.scoped(...)` is used
+    // throughout craft, and the scope is most of what makes a line findable.
+    const prefix = if (scope == .default) "" else "[" ++ @tagName(scope) ++ "] ";
+    craft.Log.log(switch (message_level) {
+        .debug => .Debug,
+        .info => .Info,
+        .warn => .Warning,
+        .err => .Error,
+    }, prefix ++ format, args);
+}
+
 pub fn main(init: std.process.Init) !void {
     io_context.init(init.io);
     const allocator = init.gpa;
@@ -56,6 +97,18 @@ pub fn main(init: std.process.Init) !void {
         std.debug.print("Error: --headless and --menubar-only are contradictory — a menubar app has no window to hide\n", .{});
         std.process.exit(1);
     }
+
+    // Configure logging before anything else that might have something to
+    // say. Both startup paths flow through here, and `--log-file` is only
+    // useful if it is open before the interesting part of startup runs.
+    //
+    // Safe to do with strings the caller will free: `log.init` copies them.
+    // It did not until now, and nothing had ever configured it, which is the
+    // only reason that was not already a use-after-free.
+    configureLogging(options) catch |err| {
+        std.debug.print("Error: could not open --log-file '{s}': {s}\n", .{ options.log_file orelse "", @errorName(err) });
+        std.process.exit(1);
+    };
 
     // Whether closing the last window ends the process. Decided here, before
     // either startup path, because both need the same answer and only this
@@ -388,6 +441,86 @@ pub fn main(init: std.process.Init) !void {
 
 /// Run with system tray using a modified App flow
 /// Key difference: we create the system tray BEFORE calling initPlatform
+/// Turn the logging flags into a configured sink.
+///
+/// A bad path is fatal rather than ignored. Someone who passed `--log-file`
+/// is going to go looking in that file, and a run that silently logged
+/// nowhere is worse than one that refused to start — the whole point of the
+/// flag is to be able to find out what happened afterwards.
+fn configureLogging(options: cli.WindowOptions) !void {
+    const wants_file = options.log_file != null;
+    const wants_level = options.log_level != null;
+    if (!wants_file and !wants_level and !options.log_json and !options.log_quiet) return;
+
+    const level: craft.Log.LogLevel = if (options.log_level) |name| blk: {
+        break :blk parseLogLevel(name) orelse {
+            std.debug.print(
+                "Error: unknown --log-level '{s}' (expected debug, info, warn, error or fatal)\n",
+                .{name},
+            );
+            std.process.exit(1);
+        };
+    } else .Info;
+
+    try craft.Log.init(.{
+        .min_level = level,
+        .output_file = options.log_file,
+        .json_output = options.log_json,
+        // Colour codes in a file are noise; on a terminal they are not.
+        .enable_colors = !options.log_json and !wants_file,
+        // --log-quiet only makes sense with somewhere else for records to go.
+        .mirror_to_stderr = !(options.log_quiet and wants_file),
+    });
+
+    // The scoped front end (`logging.notification`, `logging.menu`, ...) feeds
+    // the same sink through the callback it already had, so its call sites
+    // reach the log file without any of them being touched.
+    craft.Logging.init(.{
+        .target = .callback,
+        .callback = forwardScopedLog,
+        .level = switch (level) {
+            .Debug => .debug,
+            .Info => .info,
+            .Warning => .warn,
+            .Error => .err,
+            .Fatal => .fatal,
+        },
+        // Timestamp and colour are the outer sink's job now; doubling them
+        // would put two of each on every line.
+        .colored = false,
+        .show_timestamp = false,
+    });
+}
+
+fn forwardScopedLog(level: craft.Logging.LogLevel, module: []const u8, message: []const u8) void {
+    _ = module; // already present in the formatted message
+    switch (level) {
+        .trace, .debug => craft.Log.log(.Debug, "{s}", .{message}),
+        .info => craft.Log.log(.Info, "{s}", .{message}),
+        .warn => craft.Log.log(.Warning, "{s}", .{message}),
+        .err => craft.Log.log(.Error, "{s}", .{message}),
+        .fatal => craft.Log.log(.Fatal, "{s}", .{message}),
+        .off => {},
+    }
+}
+
+/// Spellings accepted by `--log-level`.
+fn parseLogLevel(name: []const u8) ?craft.Log.LogLevel {
+    const table = .{
+        .{ "debug", craft.Log.LogLevel.Debug },
+        .{ "info", craft.Log.LogLevel.Info },
+        .{ "warn", craft.Log.LogLevel.Warning },
+        .{ "warning", craft.Log.LogLevel.Warning },
+        .{ "error", craft.Log.LogLevel.Error },
+        .{ "err", craft.Log.LogLevel.Error },
+        .{ "fatal", craft.Log.LogLevel.Fatal },
+    };
+    inline for (table) |entry| {
+        if (std.ascii.eqlIgnoreCase(name, entry[0])) return entry[1];
+    }
+    return null;
+}
+
 fn runWithSystemTray(allocator: std.mem.Allocator, options: cli.WindowOptions) !void {
     std.debug.print("\n⚡ Creating system tray application\n", .{});
     std.debug.print("   Title: {s}\n", .{options.title});


### PR DESCRIPTION
Closes #70.

`src/log.zig` was written complete — levels, JSON, a filter, a mutex, file output — and then **never configured by anything**. The issue asks to put a flag in front of it.

**Doing only that would have produced an empty file.** The module has two callers (`devmode.zig`, `hotreload.zig`); craft's actual diagnostics go through `std.log` and `logging.zig`, neither of which it has ever seen.

## What lands in the file, and how

| source | mechanism | in the file? |
|---|---|---|
| `std.log.*` (~200 sites, 50 files) | `pub const std_options` → `craftLogFn` in the exe root | **yes** — across module boundaries |
| `logging.zig` scoped loggers | its existing `.target = .callback` hook | **yes** — zero call sites touched |
| `log.zig` direct callers | already direct | yes |
| `std.debug.print` | none — goes through `std.Options.debug_io` | **no**, and `--help` says so |

The `log_level = .debug` already declared in `minimal.zig` turns out to be load-bearing: `std.log.debug` is compiled out at comptime below the threshold, and most of craft's logging is debug level. Without it `--log-level debug` would be a flag that could not do anything.

## Wiring it up is what made its defects reachable

Seven, all on the `--log-file` path, none previously reachable because nothing configured the module:

1. **Messages over 2048 bytes were dropped whole**, not truncated — `bufPrint(...) catch return`. The longest records are usually the ones worth reading, and nothing said anything was missing.
2. **The file was written from offset zero every run.** `CreateFileOptions` has no append flag in this Zig and `writeStreamingAll` starts at position 0, so each launch overwrote the previous one and left anything longer stranded past the end. Now seeded from `stat().size` and advanced with `writePositionalAll`.
3. **`init` kept the caller's slices** for `output_file` and `filter_pattern`, and `minimal.zig` frees the command-line strings during startup — a use-after-free that had simply never been reachable.
4. **A reentrancy hang.** `compat_mutex` falls back to a non-recursive spinlock that never yields (`std.Thread.Mutex` doesn't exist in this Zig), and `log` holds it across the write. A `std.log` call from inside `log` would spin against a lock the same thread holds, **forever** — no panic, no stack. Inert while nothing logged through it; live the moment 200 call sites do.
5. **The timestamp had no date.** `--log-file` exists to leave a trail read afterwards; a time alone can't say which day. Now ISO-8601 UTC — and the comment claiming `localtime_r` (which isn't in `std.c` here, and whose result the code discarded via a dead `_ = t;`) no longer claims it.
6. **Bytes over 0x7f went into JSON verbatim**, so one bad byte from a filename or truncated frame made the line unparseable.
7. **`std.c.clock_gettime` doesn't compile for Windows here.** The file only ever built because nothing instantiated `log()`.

That's the third time this session that wiring something up is what exposed it. It is the argument for the flag and the fixes landing together rather than the flag landing alone.

## Tests

The module *did* have tests — `test/log_test.zig` — which reach it across a module boundary and therefore cannot touch the config storage or the formatter, **the three places it was wrong**. Twelve more now run against the source directly, covering truncation, append across runs, string ownership, level filtering, JSON under hostile input, invalid UTF-8, stderr suppression, re-init, the date, and the reentrancy guard.

## Verified end to end, not just compiled

```
$ craft --html-file p.html --headless --log-file f.log
$ cat f.log
[2026-08-27T12:02:08Z] WARN refused to open a new window for a URL the page
cannot send to the browser: craft-probe://payload
```

That record originates from a `std.log.warn` in `macos.zig` — a **different module** from the root — which is what proves the cross-module routing works. Also confirmed by running the binary:

| behaviour | result |
|---|---|
| two runs append | 2 records (the old code left 1) |
| `--log-json` | parses as JSON |
| `--log-quiet` | in file: 1, on stderr: 0 |
| `--log-level error` | the warn is filtered out |

An earlier probe produced an **empty** file and I nearly reported success on "the flag works" — the file existed and the build was green. It was empty because the handler override hadn't actually landed. Forcing a known `std.log.warn` and finding it still absent is what caught it.

## Verified

`zig build` · `zig build test` · `zig build test-js` · `x86_64-windows` cross-build · `zig fmt --check` · `tsc --noEmit` · 511 bun tests · pickier 38 warnings, unchanged from main.