### PR TITLE
fix(log): send the page's own log somewhere it can be read

### DIFF
--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -757,6 +757,17 @@ pub fn build(b: *std.Build) void {
     });
     log_unit_tests.root_module.link_libc = true;
 
+    // The page-facing log bridge. It answered `{"ok":true}` and wrote nothing
+    // at all on Linux and Windows, which no test noticed because it had none.
+    const bridge_log_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/bridge_log.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    bridge_log_tests.root_module.link_libc = true;
+
     // The conformance test: what craft declares, against what it dispatches.
     const capability_conformance_tests = b.addTest(.{
         .root_module = b.createModule(.{
@@ -1128,6 +1139,7 @@ pub fn build(b: *std.Build) void {
     const run_local_tls_tests = b.addRunArtifact(local_tls_tests);
     const run_menu_roles_tests = b.addRunArtifact(menu_roles_tests);
     const run_capabilities_tests = b.addRunArtifact(capabilities_tests);
+    const run_bridge_log_tests = b.addRunArtifact(bridge_log_tests);
     const run_log_unit_tests = b.addRunArtifact(log_unit_tests);
     const run_bridge_shell_tests = b.addRunArtifact(bridge_shell_tests);
     const run_window_lifecycle_tests = b.addRunArtifact(window_lifecycle_tests);
@@ -1251,6 +1263,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_local_tls_tests.step);
     test_step.dependOn(&run_menu_roles_tests.step);
     test_step.dependOn(&run_capabilities_tests.step);
+    test_step.dependOn(&run_bridge_log_tests.step);
     test_step.dependOn(&run_log_unit_tests.step);
     test_step.dependOn(&run_bridge_shell_tests.step);
     test_step.dependOn(&run_window_lifecycle_tests.step);

--- a/packages/zig/src/bridge_log.zig
+++ b/packages/zig/src/bridge_log.zig
@@ -1,31 +1,63 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const bridge_error = @import("bridge_error.zig");
+const host_log = @import("log.zig");
 
 const BridgeError = bridge_error.BridgeError;
 
-extern "c" fn os_log_create(subsystem: [*:0]const u8, category: [*:0]const u8) ?*anyopaque;
-
-/// Unified system log integration. Apps call `craft.log.{debug,info,
-/// warn,error}(message)` and we route through `os_log` so messages
-/// land in Console.app, `log show`, and any aggregator the user has
-/// configured (e.g. Sentry's macOS log adapter).
+/// The page's own log, forwarded to the same sink as craft's.
 ///
-/// `os_log` itself is macro-driven and can't be invoked from C
-/// without going through libBlocksRuntime; for now we stamp messages
-/// with `std.debug.print` which routes to stderr and is captured by
-/// the unified log subsystem when run from a launched app. The
-/// `os_log_create` hook is in place so a future revision can swap to
-/// the proper macro path without touching the JS surface.
+/// `craft.log.{debug,info,warn,error}(message)` used to reach
+/// `std.debug.print` on macOS and *nothing at all* anywhere else — the write
+/// sat behind `if (builtin.os.tag == .macos)`, so on Linux and Windows the
+/// payload was parsed, discarded, and answered `{"ok":true}`. A page that
+/// logged into that got a resolved promise and no record.
+///
+/// It goes through `log.zig` now, which is what `--log-file` configures, so a
+/// page's diagnostics land in the same file and the same order as the host's
+/// rather than in a different place on one platform and nowhere on the others.
+///
+/// The `os_log_create` handle this file used to open on macOS is gone. It was
+/// created at init, never used, and the comment beside it called it a
+/// placeholder for a future revision that would reach `os_log` proper —
+/// which needs libBlocksRuntime and never happened. A file sink is the thing
+/// it was standing in for.
+/// The host level a page's `level` string means.
+///
+/// Anything unrecognised is info rather than dropped: a page that invents a
+/// level, or sends none, should still be heard. Silently discarding it would
+/// be the same failure this file already had on Linux and Windows.
+fn levelFor(name: []const u8) host_log.LogLevel {
+    const table = .{
+        .{ "debug", host_log.LogLevel.Debug },
+        .{ "trace", host_log.LogLevel.Debug },
+        .{ "info", host_log.LogLevel.Info },
+        .{ "log", host_log.LogLevel.Info },
+        .{ "warn", host_log.LogLevel.Warning },
+        .{ "warning", host_log.LogLevel.Warning },
+        .{ "error", host_log.LogLevel.Error },
+        .{ "err", host_log.LogLevel.Error },
+        .{ "fatal", host_log.LogLevel.Fatal },
+    };
+    inline for (table) |entry| {
+        if (std.ascii.eqlIgnoreCase(name, entry[0])) return entry[1];
+    }
+    return .Info;
+}
+
 pub const LogBridge = struct {
     allocator: std.mem.Allocator,
-    log_handle: ?*anyopaque = null,
 
     const Self = @This();
 
+    /// Longest page message recorded. The text comes from the page, and the
+    /// host sink formats into a fixed buffer — clamping here means a long
+    /// message is clipped at a boundary this file chose rather than one the
+    /// formatter happened to have.
+    const max_message = 1024;
+
     pub fn init(allocator: std.mem.Allocator) Self {
-        const handle = if (builtin.os.tag == .macos) os_log_create("com.craft.app", "default") else null;
-        return .{ .allocator = allocator, .log_handle = handle };
+        return .{ .allocator = allocator };
     }
 
     pub fn deinit(_: *Self) void {}
@@ -45,9 +77,72 @@ pub const LogBridge = struct {
         }) catch return BridgeError.InvalidJSON;
         defer parsed.deinit();
 
-        if (builtin.os.tag == .macos) {
-            std.debug.print("[craft.{s}] {s}\n", .{ parsed.value.level, parsed.value.message });
+        const message = if (parsed.value.message.len > max_message)
+            parsed.value.message[0..max_message]
+        else
+            parsed.value.message;
+
+        // Tagged `[page]` so a log file makes it obvious which side a line came
+        // from — the host's records and the page's now share one stream, and
+        // telling them apart is most of what makes that stream readable.
+        switch (levelFor(parsed.value.level)) {
+            .Debug => host_log.log(.Debug, "[page] {s}", .{message}),
+            .Info => host_log.log(.Info, "[page] {s}", .{message}),
+            .Warning => host_log.log(.Warning, "[page] {s}", .{message}),
+            .Error => host_log.log(.Error, "[page] {s}", .{message}),
+            .Fatal => host_log.log(.Fatal, "[page] {s}", .{message}),
         }
+
         bridge_error.sendResultToJS(self.allocator, "log", "{\"ok\":true}");
     }
 };
+
+const testing = std.testing;
+
+test "the levels the page facade sends all map to a host level" {
+    // These four are exactly what `craft.log.*` sends (craft-bridge.js).
+    try testing.expectEqual(host_log.LogLevel.Debug, levelFor("debug"));
+    try testing.expectEqual(host_log.LogLevel.Info, levelFor("info"));
+    try testing.expectEqual(host_log.LogLevel.Warning, levelFor("warn"));
+    try testing.expectEqual(host_log.LogLevel.Error, levelFor("error"));
+}
+
+test "level names are matched without regard to case" {
+    try testing.expectEqual(host_log.LogLevel.Warning, levelFor("WARN"));
+    try testing.expectEqual(host_log.LogLevel.Error, levelFor("Error"));
+}
+
+test "an unrecognised level is still heard" {
+    // Dropping it would repeat the failure this file already had, where a
+    // page's log was parsed, discarded, and answered ok.
+    try testing.expectEqual(host_log.LogLevel.Info, levelFor("verbose"));
+    try testing.expectEqual(host_log.LogLevel.Info, levelFor(""));
+    try testing.expectEqual(host_log.LogLevel.Info, levelFor("🙂"));
+}
+
+test "the payload the page sends decodes into a level and a message" {
+    const Shape = struct {
+        level: []const u8 = "info",
+        message: []const u8 = "",
+    };
+    const payload =
+        \\{"level":"warn","message":"something happened"}
+    ;
+    const parsed = try std.json.parseFromSlice(Shape, testing.allocator, payload, .{
+        .ignore_unknown_fields = true,
+        .allocate = .alloc_always,
+    });
+    defer parsed.deinit();
+
+    try testing.expectEqual(host_log.LogLevel.Warning, levelFor(parsed.value.level));
+    try testing.expectEqualStrings("something happened", parsed.value.message);
+}
+
+test "a page cannot log an unbounded message" {
+    // The text comes from the page. Clipping here means the boundary is one
+    // this file chose rather than whatever the host formatter happened to have.
+    var huge: [LogBridge.max_message * 2]u8 = undefined;
+    @memset(&huge, 'x');
+    const clipped = if (huge.len > LogBridge.max_message) huge[0..LogBridge.max_message] else huge[0..];
+    try testing.expectEqual(LogBridge.max_message, clipped.len);
+}


### PR DESCRIPTION
Follow-up to #70. That issue's *ask* was the `--log-file` flag, which #78 delivered — but it also noted, separately, that the page-facing `craft.log.*` namespace was macOS-only and discarded its payload elsewhere. I didn't do that half, so here it is.

## What it did

```zig
if (builtin.os.tag == .macos) {
    std.debug.print("[craft.{s}] {s}\n", .{ level, message });
}
bridge_error.sendResultToJS(self.allocator, "log", "{\"ok\":true}");
```

On **Linux and Windows** the payload was parsed, discarded, and answered `{"ok":true}`. A page that logged into that got a resolved promise and no record anywhere.

On **macOS** it went to stderr rather than through the host logger — so `--log-file`, which now exists, did not contain it either.

## What it does now

Page records go through `log.zig`, the same sink `--log-file` configures, on every platform:

```
[2026-08-27T13:31:14Z] INFO [page] hello from the page
[2026-08-27T13:31:14Z] WARN [page] a warning from the page
[2026-08-27T13:31:14Z] ERROR [page] and an error
```

Verified by running the binary with `--log-file --log-quiet` and a page calling all four methods. The `debug` call is correctly absent — default level is info — and appears when `--log-level debug` is passed.

- Tagged **`[page]`**, because the host's records and the page's now share one stream and telling them apart is most of what makes that stream readable.
- An **unrecognised level is recorded as info, not dropped** — silently discarding it would be the same failure this file already had.
- The message is **clamped**, because it comes from the page.

## The dead `os_log` handle

`os_log_create("com.craft.app", "default")` was called at init, stored, and never used. The comment beside it described a future revision reaching `os_log` properly through libBlocksRuntime — which never happened, and which a file sink is a better answer to. Removed rather than left as a placeholder for something that now has a better implementation.

## Tests

The file had **none**, which is why nobody noticed two of three platforms recorded nothing. The level mapping is now a pure function with 5 tests, wired into `zig build test` — including that an invented level is still heard, and that the four levels the JS facade actually sends all map somewhere.

## Verified

`zig build` · `zig build test` · `zig build test-js` · `x86_64-windows` cross-build · `zig fmt --check` · 511 bun tests · pickier 38 warnings, unchanged from main.