### PR TITLE
fix(sync): stop craft's locks busy-waiting

### DIFF
--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -768,6 +768,18 @@ pub fn build(b: *std.Build) void {
     });
     bridge_log_tests.root_module.link_libc = true;
 
+    // The blocking primitives every other lock in craft is built on. They
+    // spun without yielding until now, so this is the first time they have
+    // been exercised at all.
+    const compat_mutex_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/compat_mutex.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    compat_mutex_tests.root_module.link_libc = true;
+
     // The conformance test: what craft declares, against what it dispatches.
     const capability_conformance_tests = b.addTest(.{
         .root_module = b.createModule(.{
@@ -1139,6 +1151,7 @@ pub fn build(b: *std.Build) void {
     const run_local_tls_tests = b.addRunArtifact(local_tls_tests);
     const run_menu_roles_tests = b.addRunArtifact(menu_roles_tests);
     const run_capabilities_tests = b.addRunArtifact(capabilities_tests);
+    const run_compat_mutex_tests = b.addRunArtifact(compat_mutex_tests);
     const run_bridge_log_tests = b.addRunArtifact(bridge_log_tests);
     const run_log_unit_tests = b.addRunArtifact(log_unit_tests);
     const run_bridge_shell_tests = b.addRunArtifact(bridge_shell_tests);
@@ -1263,6 +1276,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_local_tls_tests.step);
     test_step.dependOn(&run_menu_roles_tests.step);
     test_step.dependOn(&run_capabilities_tests.step);
+    test_step.dependOn(&run_compat_mutex_tests.step);
     test_step.dependOn(&run_bridge_log_tests.step);
     test_step.dependOn(&run_log_unit_tests.step);
     test_step.dependOn(&run_bridge_shell_tests.step);

--- a/packages/zig/src/compat_mutex.zig
+++ b/packages/zig/src/compat_mutex.zig
@@ -1,28 +1,102 @@
+//! Craft's mutex and condition variable.
+//!
+//! `std.Thread.Mutex` and `std.Thread.Condition` do not exist in this Zig — the
+//! Io rework moved blocking primitives to `std.Io.Mutex` and
+//! `std.Io.Condition`, which take an `Io` because that is what knows how to
+//! wait. This file existed to paper over that, and papered over it by spinning:
+//! `Mutex.lock` looped on `tryLock` with `spinLoopHint`, `Condition.wait` spun
+//! on a `u32` flag, and neither ever yielded.
+//!
+//! What that costs, measured: three threads waiting 300ms on a spun flag burn
+//! **896ms of CPU** — three cores held against whatever they are waiting for.
+//! A futex wait costs approximately nothing. On a machine with cores to spare
+//! it is waste; on a busy one the waiters are competing with the thread they
+//! need to finish.
+//!
+//! The flag-based `Condition` also had a narrower hazard — `broadcast` set one
+//! flag and the first waiter to observe it cleared it, which can lose a
+//! wakeup. It is a race rather than a certainty, and spinning waiters poll
+//! often enough that they usually all see it; a test written to catch it
+//! passed against the old code, so it is recorded here as a reason and not
+//! claimed as a demonstrated bug. The CPU measurement above is the one that
+//! reproduces.
+//!
+//! Both real primitives are used now. The `Io` they need is handed to this
+//! module once at startup rather than threaded through all 88 lock sites,
+//! which would have been a signature change across ten files for something
+//! that is a property of the process, not of any call.
+//!
+//! ## Why the fallback is still here
+//!
+//! `io_context.init` is not the first thing that runs, and tests, the
+//! `--eval` path and anything that locks before startup finishes have no `Io`.
+//! Those take the spin path — but a spin that yields, so it cannot starve the
+//! holder.
+//!
+//! The two paths are safe to mix in the only direction that occurs. `install`
+//! is called once and never undone, so:
+//!
+//!   - before it, the only way to acquire is `tryLock`, which moves the state
+//!     `unlocked -> locked_once` and never to `contended`; an unlock with no
+//!     `Io` therefore has no waiter to wake, and none can exist.
+//!   - after it, every acquire and release has an `Io`.
+//!
+//! A lock taken before and released after is fine: the state is `locked_once`,
+//! and `unlock` wakes nobody either way.
+
 const std = @import("std");
 
-/// Blocking mutex that works across Zig versions.
-/// Uses std.Thread.Mutex if available, otherwise falls back to std.atomic.Mutex.
+/// The `Io` used for blocking. Null until `install`.
+var runtime_io: ?std.Io = null;
+
+/// Hand this module the process `Io`. Called once, from `io_context.init`,
+/// before anything else has had a chance to contend for a lock.
+///
+/// Deliberately not read from `io_context` on demand: `global_state.zig` locks
+/// one of these mutexes to answer `io_context.get()`, so asking it here would
+/// recurse into the lock being taken.
+pub fn install(io: std.Io) void {
+    runtime_io = io;
+}
+
+/// For tests that need to exercise the pre-startup path.
+pub fn uninstallForTesting() void {
+    runtime_io = null;
+}
+
+/// How many times to spin before offering the core to someone else.
+///
+/// Long enough that an uncontended hand-off does not pay for a syscall, short
+/// enough that a waiter cannot hold a core against the lock's owner — which is
+/// the failure the old unbounded spin had.
+const spins_before_yield = 128;
+
 pub const Mutex = struct {
-    inner: InnerMutex = inner_init,
-
-    const has_thread_mutex = @hasDecl(std.Thread, "Mutex");
-
-    const InnerMutex = if (has_thread_mutex) std.Thread.Mutex else std.atomic.Mutex;
-
-    const inner_init: InnerMutex = if (has_thread_mutex) .{} else .unlocked;
+    inner: std.Io.Mutex = .init,
 
     pub fn lock(self: *Mutex) void {
-        if (has_thread_mutex) {
-            self.inner.lock();
-        } else {
-            while (!self.inner.tryLock()) {
-                std.atomic.spinLoopHint();
-            }
+        if (runtime_io) |io| {
+            // Uncancelable: a lock acquisition is not a cancelation point, and
+            // craft has no caller prepared to handle one here.
+            self.inner.lockUncancelable(io);
+            return;
+        }
+        var spins: usize = 0;
+        while (!self.inner.tryLock()) {
+            spins +%= 1;
+            if (spins % spins_before_yield == 0) std.Thread.yield() catch {};
+            std.atomic.spinLoopHint();
         }
     }
 
     pub fn unlock(self: *Mutex) void {
-        self.inner.unlock();
+        if (runtime_io) |io| {
+            self.inner.unlock(io);
+            return;
+        }
+        // No `Io` means nothing can be waiting on the futex: the only way to
+        // have acquired this lock is `tryLock`, which never sets `contended`.
+        self.inner.state.store(.unlocked, .release);
     }
 
     pub fn tryLock(self: *Mutex) bool {
@@ -30,25 +104,138 @@ pub const Mutex = struct {
     }
 };
 
-/// Condition variable replacement for std.Thread.Condition (removed in Zig 0.16).
-/// Uses atomic flag + spin wait since std.Io.Condition requires an Io instance.
 pub const Condition = struct {
-    flag: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+    inner: std.Io.Condition = .init,
 
     pub fn wait(self: *Condition, mutex: *Mutex) void {
-        mutex.unlock();
-        while (self.flag.load(.acquire) == 0) {
-            std.atomic.spinLoopHint();
+        if (runtime_io) |io| {
+            self.inner.waitUncancelable(io, &mutex.inner);
+            return;
         }
-        self.flag.store(0, .release);
+        // No `Io`, so no futex to wait on. Release the lock, yield, retake it —
+        // the caller is required to re-check its predicate in a loop, which is
+        // the same contract a real condition variable imposes for spurious
+        // wakeups.
+        mutex.unlock();
+        std.Thread.yield() catch {};
         mutex.lock();
     }
 
     pub fn signal(self: *Condition) void {
-        self.flag.store(1, .release);
+        if (runtime_io) |io| self.inner.signal(io);
     }
 
     pub fn broadcast(self: *Condition) void {
-        self.flag.store(1, .release);
+        if (runtime_io) |io| self.inner.broadcast(io);
     }
 };
+
+const testing = std.testing;
+
+test "a mutex excludes" {
+    var m: Mutex = .{};
+    m.lock();
+    try testing.expect(!m.tryLock());
+    m.unlock();
+    try testing.expect(m.tryLock());
+    m.unlock();
+}
+
+test "lock and unlock work before an Io is installed" {
+    // Startup, `--eval`, and every test take this path.
+    uninstallForTesting();
+    var m: Mutex = .{};
+    var i: usize = 0;
+    while (i < 1000) : (i += 1) {
+        m.lock();
+        m.unlock();
+    }
+    try testing.expect(m.tryLock());
+    m.unlock();
+}
+
+test "a lock taken before an Io arrives can be released after" {
+    // The only mixing that can occur, since `install` happens once and is
+    // never undone. The state is `locked_once` either way, so `unlock` has
+    // nobody to wake.
+    uninstallForTesting();
+    var m: Mutex = .{};
+    m.lock();
+    install(std.testing.io);
+    defer uninstallForTesting();
+    m.unlock();
+    try testing.expect(m.tryLock());
+    m.unlock();
+}
+
+test "several threads hand the lock around without losing a count" {
+    // The spin path used to be able to starve the holder on a single core.
+    // This does not detect starvation directly, but it does detect the thing
+    // starvation eventually causes: a count that does not add up.
+    uninstallForTesting();
+
+    const Shared = struct {
+        mutex: Mutex = .{},
+        counter: usize = 0,
+
+        fn bump(self: *@This(), times: usize) void {
+            var i: usize = 0;
+            while (i < times) : (i += 1) {
+                self.mutex.lock();
+                defer self.mutex.unlock();
+                self.counter += 1;
+            }
+        }
+    };
+
+    var shared: Shared = .{};
+    const per_thread = 2000;
+    const thread_count = 4;
+
+    var threads: [thread_count]std.Thread = undefined;
+    for (&threads) |*t| {
+        t.* = try std.Thread.spawn(.{}, Shared.bump, .{ &shared, per_thread });
+    }
+    for (threads) |t| t.join();
+
+    try testing.expectEqual(thread_count * per_thread, shared.counter);
+}
+
+test "broadcast reaches every waiter" {
+    // Not a regression test: the old flag-based Condition passes this too,
+    // because spinning waiters poll often enough that they all observe the
+    // flag before any of them clears it. Kept because it is the property the
+    // replacement has to hold, and because it is the shape of test that would
+    // catch a future `broadcast` that only signals one waiter.
+    if (!@hasDecl(std.testing, "io")) return error.SkipZigTest;
+    install(std.testing.io);
+    defer uninstallForTesting();
+
+    const Shared = struct {
+        mutex: Mutex = .{},
+        cond: Condition = .{},
+        ready: bool = false,
+        woken: std.atomic.Value(usize) = .init(0),
+
+        fn waiter(self: *@This()) void {
+            self.mutex.lock();
+            // Looped, because a condition variable may wake spuriously — the
+            // contract both the real primitive and the fallback rely on.
+            while (!self.ready) self.cond.wait(&self.mutex);
+            self.mutex.unlock();
+            _ = self.woken.fetchAdd(1, .release);
+        }
+    };
+
+    var shared: Shared = .{};
+    var threads: [3]std.Thread = undefined;
+    for (&threads) |*t| t.* = try std.Thread.spawn(.{}, Shared.waiter, .{&shared});
+
+    shared.mutex.lock();
+    shared.ready = true;
+    shared.mutex.unlock();
+    shared.cond.broadcast();
+
+    for (threads) |t| t.join();
+    try testing.expectEqual(@as(usize, 3), shared.woken.load(.acquire));
+}

--- a/packages/zig/src/io_context.zig
+++ b/packages/zig/src/io_context.zig
@@ -6,6 +6,11 @@ const global_state = @import("global_state.zig");
 /// Thread-safe access is provided through global_state.
 /// Initialize the global Io context. Must be called once at startup from main().
 pub fn init(io: std.Io) void {
+    // First, and before `global_state` — which locks one of these mutexes to
+    // answer `get()`. Handing the `Io` to the primitives here rather than
+    // having them ask for it is what keeps a lock acquisition from recursing
+    // into the lock it is acquiring.
+    @import("compat_mutex.zig").install(io);
     global_state.instance.setIo(io);
 }
 


### PR DESCRIPTION
The deferred item from #78. `compat_mutex` is what every lock in craft is built on — **10 files, 88 lock sites** — and it spins.

## What it costs

`std.Thread.Mutex` and `std.Thread.Condition` were removed; the Io rework moved blocking primitives to `std.Io.Mutex` / `std.Io.Condition`, which take an `Io` because that is what knows how to wait. This file papered over that by spinning: `Mutex.lock` looped on `tryLock` with `spinLoopHint`, `Condition.wait` spun on a `u32` flag, and **neither ever yielded**.

Measured, not asserted:

```
3 waiters, 300ms wall: 896 ms of CPU burned spinning
```

Three cores held against whatever they are waiting to finish. And #78 made this hotter, by routing ~200 `std.log` sites through a module that takes one of these locks across a write.

## The fix

Both real primitives, with the `Io` handed to the module once from `io_context.init` rather than threaded through 88 call sites — that would be a signature change across ten files for something that is a property of the process, not of any call.

**Installed before `global_state`, deliberately.** `global_state` locks one of these mutexes to answer `io_context.get()`, so having the lock ask for the `Io` itself would recurse into the lock being taken.

The spin path stays for anything running before startup finishes — tests, `--eval`, anything locking before `io_context.init` — **but it yields now**, so a waiter cannot hold a core against the holder.

Mixing the two paths is safe in the only direction that occurs. `install` happens once and is never undone, so:

- before it, the only way to acquire is `tryLock`, which moves `unlocked → locked_once` and never to `contended` — an unlock with no `Io` therefore has no waiter to wake, and none can exist
- after it, every acquire and release has an `Io`

A lock taken before and released after is fine: the state is `locked_once` either way, and `unlock` wakes nobody.

## What I could not demonstrate, and am not claiming

The flag-based `Condition` also had a lost-wakeup race — `broadcast` set one flag and the first waiter to observe it cleared it. **I wrote a test to catch that and it passed against the old code**, because spinning waiters poll often enough that they all see the flag before any clears it. It is a race, not a certainty.

So it is recorded in the file as a reason, not as a fixed bug, and the test is kept for the property it asserts with a comment saying explicitly that it is *not* a regression test. The CPU measurement is the part that reproduces.

## Tests

These primitives had **none** — which is how they stayed spin-only across the Zig version change that made them so. Five now: mutual exclusion, the pre-`Io` path, the before/after mixing case, a 4-thread × 2000-iteration counter that would not add up under a lost update, and broadcast reaching every waiter.

Also verified the binary still runs correctly under the new locks — `--log-file` output is byte-identical to before the change.

## Verified

`zig build` · `zig build test` · `zig build test-js` · `x86_64-windows` cross-build · `zig fmt --check` · 511 bun tests · pickier 38 warnings, unchanged from main.