### PR TITLE
fix(bridge): stop discarding the fields the page actually sends

### DIFF
--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -807,6 +807,14 @@ pub fn build(b: *std.Build) void {
         "src/bridge_capabilities.zig",
         "src/bridge_capabilities_actions.zig",
         "src/js/craft-bridge.js",
+        // The bridges whose payload field names are checked against the page's
+        // — see `field_checked` in the test.
+        "src/bridge_fs.zig",
+        "src/bridge_window.zig",
+        "src/bridge_updater.zig",
+        "src/bridge_bluetooth.zig",
+        "src/bridge_serial.zig",
+        "src/bridge_local_server.zig",
     }) |source_path| {
         capability_conformance_tests.root_module.addAnonymousImport(source_path, .{
             .root_source_file = b.path(source_path),

--- a/packages/zig/src/bridge_app.zig
+++ b/packages/zig/src/bridge_app.zig
@@ -64,7 +64,7 @@ pub const AppBridge = struct {
         } else if (std.mem.eql(u8, action, A.set_badge)) {
             try self.setBadge(data);
         } else if (std.mem.eql(u8, action, A.bounce)) {
-            try self.bounce();
+            try self.bounce(data);
         } else {
             if (comptime builtin.mode == .debug)
                 std.debug.print("[AppBridge] Unknown action: {s}\n", .{action});
@@ -244,17 +244,32 @@ pub const AppBridge = struct {
         }
     }
 
-    fn bounce(self: *Self) !void {
+    /// `craft.app.bounce(type)` — 'critical' or 'informational'.
+    ///
+    /// This took no payload at all and always requested an informational
+    /// bounce, so `bounce('critical')` hopped the Dock icon once instead of
+    /// bouncing until the user activates the app — which is the entire
+    /// difference between the two, and the only reason to pass an argument.
+    fn bounce(self: *Self, data: ?[]const u8) !void {
         _ = self;
         if (builtin.os.tag == .macos) {
             const macos = @import("macos.zig");
             const NSApplication = macos.getClass("NSApplication");
             const app = macos.msgSend0(NSApplication, "sharedApplication");
 
-            // NSApplicationActivateIgnoringOtherApps + request user attention
-            // NSInformationalRequest = 10
+            // `NSRequestUserAttentionType`: critical bounces until the app is
+            // activated, informational bounces once.
+            const NSCriticalRequest: c_long = 0;
             const NSInformationalRequest: c_long = 10;
-            _ = macos.msgSend1(app, "requestUserAttention:", NSInformationalRequest);
+
+            const request = if (data) |json_data| blk: {
+                break :blk if (std.mem.indexOf(u8, json_data, "critical") != null)
+                    NSCriticalRequest
+                else
+                    NSInformationalRequest;
+            } else NSInformationalRequest;
+
+            _ = macos.msgSend1(app, "requestUserAttention:", request);
         }
     }
 

--- a/packages/zig/src/bridge_bluetooth.zig
+++ b/packages/zig/src/bridge_bluetooth.zig
@@ -463,16 +463,28 @@ pub const BluetoothBridge = struct {
 
     /// Connect to a Bluetooth device
     /// JSON: {"address": "XX:XX:XX:XX:XX:XX"}
-    fn connectDevice(self: *Self, data: []const u8) !void {
-        _ = self;
-        var address: []const u8 = "";
-
-        if (std.mem.indexOf(u8, data, "\"address\":\"")) |idx| {
-            const start = idx + 11;
-            if (std.mem.indexOfPos(u8, data, start, "\"")) |end| {
-                address = data[start..end];
+    /// The device a connect/disconnect names.
+    ///
+    /// `craft.bluetooth.connectDevice(id)` sends `{"id":"…"}`, and both
+    /// handlers scanned only for `"address":"`. The needle never matched, the
+    /// address stayed empty, and the call failed its own `MissingData` check —
+    /// so connecting to a device found by `craft.bluetooth.onDeviceFound` was
+    /// impossible. `address` stays accepted for anything posting raw messages.
+    fn deviceAddress(data: []const u8) []const u8 {
+        for ([_][]const u8{ "\"id\":\"", "\"address\":\"" }) |key| {
+            if (std.mem.indexOf(u8, data, key)) |idx| {
+                const start = idx + key.len;
+                if (std.mem.indexOfPos(u8, data, start, "\"")) |end| {
+                    return data[start..end];
+                }
             }
         }
+        return "";
+    }
+
+    fn connectDevice(self: *Self, data: []const u8) !void {
+        _ = self;
+        const address = deviceAddress(data);
 
         if (address.len == 0) return BridgeError.MissingData;
 
@@ -497,14 +509,7 @@ pub const BluetoothBridge = struct {
     /// JSON: {"address": "XX:XX:XX:XX:XX:XX"}
     fn disconnectDevice(self: *Self, data: []const u8) !void {
         _ = self;
-        var address: []const u8 = "";
-
-        if (std.mem.indexOf(u8, data, "\"address\":\"")) |idx| {
-            const start = idx + 11;
-            if (std.mem.indexOfPos(u8, data, start, "\"")) |end| {
-                address = data[start..end];
-            }
-        }
+        const address = deviceAddress(data);
 
         if (address.len == 0) return BridgeError.MissingData;
 

--- a/packages/zig/src/bridge_fs.zig
+++ b/packages/zig/src/bridge_fs.zig
@@ -152,7 +152,13 @@ pub const FSBridge = struct {
     /// JSON: {"path": "/path/to/file", "content": "data", "callbackId": "cb1"}
     fn writeFile(self: *Self, data: []const u8) !void {
         const path = json_utils.getString(data, "path") orelse "";
-        const content = json_utils.getString(data, "content") orelse "";
+        // `craft.fs.writeFile(path, data)` sends the bytes under `data`; this
+        // read `content`, which the page has never sent, so `orelse ""` fired
+        // on every call and the file was created empty. `content` stays
+        // accepted for anything posting raw bridge messages against the old
+        // spelling.
+        const content = json_utils.getString(data, "data") orelse
+            json_utils.getString(data, "content") orelse "";
         const callback_id = json_utils.getString(data, "callbackId") orelse "";
 
         if (path.len == 0) return BridgeError.MissingData;
@@ -179,7 +185,10 @@ pub const FSBridge = struct {
     /// JSON: {"path": "/path/to/file", "content": "data", "callbackId": "cb1"}
     fn appendFile(self: *Self, data: []const u8) !void {
         const path = json_utils.getString(data, "path") orelse "";
-        const content = json_utils.getString(data, "content") orelse "";
+        // Same mismatch as `writeFile`: the page sends `data`, this read
+        // `content`, and the append wrote nothing while reporting success.
+        const content = json_utils.getString(data, "data") orelse
+            json_utils.getString(data, "content") orelse "";
         const callback_id = json_utils.getString(data, "callbackId") orelse "";
 
         if (path.len == 0) return BridgeError.MissingData;
@@ -451,8 +460,13 @@ pub const FSBridge = struct {
     /// Copy file
     /// JSON: {"src": "/path/from", "dest": "/path/to", "callbackId": "cb1"}
     fn copy(self: *Self, data: []const u8) !void {
-        const src = json_utils.getString(data, "src") orelse "";
-        const dest = json_utils.getString(data, "dest") orelse "";
+        // `craft.fs.copy(from, to)` sends `from`/`to`; this read `src`/`dest`,
+        // so both were empty and the call failed its own path check while the
+        // caller's promise resolved.
+        const src = json_utils.getString(data, "from") orelse
+            json_utils.getString(data, "src") orelse "";
+        const dest = json_utils.getString(data, "to") orelse
+            json_utils.getString(data, "dest") orelse "";
         const callback_id = json_utils.getString(data, "callbackId") orelse "";
 
         if (src.len == 0 or dest.len == 0) return BridgeError.MissingData;
@@ -473,8 +487,13 @@ pub const FSBridge = struct {
     /// Move/rename file
     /// JSON: {"src": "/path/from", "dest": "/path/to", "callbackId": "cb1"}
     fn move(self: *Self, data: []const u8) !void {
-        const src = json_utils.getString(data, "src") orelse "";
-        const dest = json_utils.getString(data, "dest") orelse "";
+        // `craft.fs.move(from, to)` sends `from`/`to`; this read `src`/`dest`,
+        // so both were empty and the call failed its own path check while the
+        // caller's promise resolved.
+        const src = json_utils.getString(data, "from") orelse
+            json_utils.getString(data, "src") orelse "";
+        const dest = json_utils.getString(data, "to") orelse
+            json_utils.getString(data, "dest") orelse "";
         const callback_id = json_utils.getString(data, "callbackId") orelse "";
 
         if (src.len == 0 or dest.len == 0) return BridgeError.MissingData;

--- a/packages/zig/src/bridge_updater.zig
+++ b/packages/zig/src/bridge_updater.zig
@@ -213,7 +213,12 @@ pub const UpdaterBridge = struct {
 
         const macos = @import("macos.zig");
 
+        // `craft.updater.setAutomaticChecks(on)` sends `{"value":…}`; this
+        // declared only `enabled`, so `ignore_unknown_fields` dropped the
+        // boolean and every call read the `false` default — automatic checks
+        // could be turned off but never on. `enabled` stays accepted.
         const EnabledParams = struct {
+            value: ?bool = null,
             enabled: bool = false,
         };
 
@@ -222,7 +227,7 @@ pub const UpdaterBridge = struct {
             .allocate = .alloc_always,
         }) catch return BridgeError.InvalidJSON;
         defer parsed.deinit();
-        const enabled = parsed.value.enabled;
+        const enabled = parsed.value.value orelse parsed.value.enabled;
 
         self.automatic_checks = enabled;
 
@@ -242,7 +247,10 @@ pub const UpdaterBridge = struct {
 
         const macos = @import("macos.zig");
 
+        // Same mismatch: the page sends `{"seconds":…}` and this declared only
+        // `interval`, so every interval silently stayed at the 24-hour default.
         const IntervalParams = struct {
+            seconds: ?u32 = null,
             interval: u32 = 86400,
         };
 
@@ -251,7 +259,7 @@ pub const UpdaterBridge = struct {
             .allocate = .alloc_always,
         }) catch return BridgeError.InvalidJSON;
         defer parsed.deinit();
-        const interval = parsed.value.interval;
+        const interval = parsed.value.seconds orelse parsed.value.interval;
 
         self.check_interval = interval;
 

--- a/packages/zig/src/bridge_window.zig
+++ b/packages/zig/src/bridge_window.zig
@@ -216,7 +216,12 @@ pub const WindowBridge = struct {
         // a payload like `{"resize":false,"fullscreen":true}` was read as
         // `fullscreen=false` because the `:false` needle fired first.
         const should_be_fullscreen = if (data) |json_data|
-            json_utils.getBool(json_data, "fullscreen") orelse true
+            // `craft.window.setFullscreen(on)` sends `{"value":…}`; this read
+            // `fullscreen`, which the page has never sent, so `orelse true`
+            // fired on every call and `setFullscreen(false)` *entered*
+            // fullscreen. `fullscreen` stays accepted for raw callers.
+            json_utils.getBool(json_data, "value") orelse
+                json_utils.getBool(json_data, "fullscreen") orelse true
         else
             true;
 
@@ -325,8 +330,19 @@ pub const WindowBridge = struct {
             // Parse vibrancy type from {"vibrancy": "..."}
             var vibrancy_type: []const u8 = "none";
             if (data) |json_data| {
-                if (std.mem.indexOf(u8, json_data, "\"vibrancy\":\"")) |idx| {
-                    const start = idx + 12;
+                // `setVibrancy(material)` sends `{"material":"sidebar"}`;
+                // this scanned for `"vibrancy":"`, never matched, and left
+                // "none" — which takes the *removal* branch below, so the call
+                // stripped vibrancy instead of applying it.
+                const vkey = if (std.mem.indexOf(u8, json_data, "\"material\":\"") != null)
+                    "\"material\":\""
+                else
+                    "\"vibrancy\":\"";
+                if (std.mem.indexOf(u8, json_data, vkey)) |idx| {
+                    // `vkey.len`, not a literal: the two spellings happen to
+                    // be the same length, which is luck and not something the
+                    // next key added here would inherit.
+                    const start = idx + vkey.len;
                     if (std.mem.indexOfPos(u8, json_data, start, "\"")) |end| {
                         vibrancy_type = json_data[start..end];
                     }
@@ -423,8 +439,12 @@ pub const WindowBridge = struct {
         var opacity: f64 = 1.0;
         if (data) |json_data| {
             // Parse {"opacity": 0.8}
-            if (std.mem.indexOf(u8, json_data, "\"opacity\":")) |idx| {
-                var start = idx + 10;
+            // The page sends `{"value":0.4}`; this scanned for `"opacity":`,
+            // never matched, and left the default 1.0 — so every opacity was
+            // fully opaque and each value was indistinguishable from the next.
+            const key = if (std.mem.indexOf(u8, json_data, "\"value\":") != null) "\"value\":" else "\"opacity\":";
+            if (std.mem.indexOf(u8, json_data, key)) |idx| {
+                var start = idx + key.len;
                 while (start < json_data.len and (json_data[start] == ' ' or json_data[start] == '\t')) : (start += 1) {}
                 var end = start;
                 while (end < json_data.len and ((json_data[end] >= '0' and json_data[end] <= '9') or json_data[end] == '.')) : (end += 1) {}

--- a/packages/zig/test/capabilities_test.zig
+++ b/packages/zig/test/capabilities_test.zig
@@ -416,3 +416,269 @@ test "the manifest renders and parses" {
     try testing.expect(channels.count() > 0);
     try testing.expect(channels.get("craft:fs:change") != null);
 }
+
+test "every bridge type the page can send is routed by the dispatcher" {
+    // The direction nothing checked. `test "the registry covers exactly the
+    // namespaces the dispatcher routes"` pins the registry against the
+    // dispatcher, and the channel test pins the events — but what the page can
+    // *call* was never compared against what native will answer.
+    //
+    // A new `craft.foo.bar()` added to the facade with no arm in
+    // `handleBridgeMessageJSON` posts a message that is parsed, matched
+    // against every arm, and dropped. `_send` resolves the moment the message
+    // leaves, so the caller gets a fulfilled promise and nothing happens —
+    // silent, and exactly the shape of #27, #47 and #69.
+    const chain = blk: {
+        const start = std.mem.indexOf(u8, dispatcher_source, "pub fn handleBridgeMessageJSON") orelse
+            return error.DispatcherNotFound;
+        const end = std.mem.indexOfPos(u8, dispatcher_source, start, "\npub fn handleBridgeMessage(") orelse
+            dispatcher_source.len;
+        break :blk dispatcher_source[start..end];
+    };
+
+    var checked: usize = 0;
+    var unrouted: usize = 0;
+
+    // `_send('type', 'action'` / `_req(` / `_post(` — the three ways the
+    // facade posts a message.
+    for ([_][]const u8{ "_send('", "_req('", "_post('" }) |opener| {
+        var search: usize = 0;
+        while (std.mem.indexOfPos(u8, bridge_js, search, opener)) |hit| {
+            search = hit + opener.len;
+            const rest = bridge_js[search..];
+            const close = std.mem.indexOfScalar(u8, rest, '\'') orelse continue;
+            const msg_type = rest[0..close];
+            if (msg_type.len == 0 or msg_type.len > 64) continue;
+
+            checked += 1;
+
+            var needle_buf: [128]u8 = undefined;
+            const needle = try std.fmt.bufPrint(&needle_buf, "msg_type, \"{s}\"", .{msg_type});
+            if (std.mem.indexOf(u8, chain, needle) == null) {
+                unrouted += 1;
+                std.debug.print(
+                    "craft-bridge.js posts type '{s}' but handleBridgeMessageJSON does not route it\n",
+                    .{msg_type},
+                );
+            }
+        }
+    }
+
+    // Floor: the facade posts hundreds of messages. If a refactor changes how
+    // they are written this scan finds none and would otherwise pass having
+    // compared nothing at all.
+    try testing.expect(checked >= 200);
+    try testing.expectEqual(@as(usize, 0), unrouted);
+}
+
+/// Bridges whose payload field names are checked against what the page sends.
+///
+/// A ratchet like `max_undeclared`: this list may only grow. Adding a bridge
+/// here is what "the fields on both sides agree" costs, and it is cheap —
+/// every entry below was added after the audit that found nine bridges reading
+/// keys the page has never sent.
+const field_checked = [_]struct {
+    /// The bridge type as the page names it in `_send`/`_req`.
+    namespace: []const u8,
+    source: []const u8,
+}{
+    .{ .namespace = "fs", .source = @embedFile("src/bridge_fs.zig") },
+    .{ .namespace = "window", .source = @embedFile("src/bridge_window.zig") },
+    .{ .namespace = "updater", .source = @embedFile("src/bridge_updater.zig") },
+    .{ .namespace = "bluetooth", .source = @embedFile("src/bridge_bluetooth.zig") },
+    .{ .namespace = "serial", .source = @embedFile("src/bridge_serial.zig") },
+    .{ .namespace = "localServer", .source = @embedFile("src/bridge_local_server.zig") },
+};
+
+/// The body of `fn <action>(...)`, from its signature to the next `    fn `.
+///
+/// Narrowing the search to the handler is what makes this catch a name used in
+/// the *wrong* handler — `writeFile` reading a key only `readFile` sends. A
+/// file-wide search cannot: the first version of this test passed against the
+/// exact bug it was written for, because the name still appeared elsewhere in
+/// the same file.
+fn handlerBody(source: []const u8, action: []const u8) ?[]const u8 {
+    var needle_buf: [96]u8 = undefined;
+    const needle = std.fmt.bufPrint(&needle_buf, "\n    fn {s}(", .{action}) catch return null;
+    const start = std.mem.indexOf(u8, source, needle) orelse return null;
+    const after = start + needle.len;
+
+    // Ends at the next declaration *or* the next doc comment, whichever comes
+    // first. Stopping only at `fn ` swallows the following function's `///`
+    // block — and these bridges document their payloads in it, so
+    // `appendFile`'s `/// JSON: {"content": "data"}` leaked into `writeFile`'s
+    // span and made the check pass against the bug it was written for.
+    const next_fn = std.mem.indexOfPos(u8, source, after, "\n    fn ") orelse source.len;
+    const next_doc = std.mem.indexOfPos(u8, source, after, "\n    ///") orelse source.len;
+    return source[start..@min(next_fn, next_doc)];
+}
+
+/// Whether a bridge's source mentions `name` as a payload field.
+///
+/// Two spellings, because bridges read payloads two ways. Some scan for a
+/// literal needle — `json_utils.getString(data, "path")` — where the name
+/// appears quoted. Others parse into a struct, where it is an unquoted field
+/// declaration: `path: []const u8 = ""`. A check that knew only the first
+/// reports every struct-based bridge as broken, which is exactly what the
+/// first version of this test did.
+fn bridgeKnowsField(source: []const u8, name: []const u8) bool {
+    var quoted_buf: [96]u8 = undefined;
+    const quoted = std.fmt.bufPrint(&quoted_buf, "\"{s}\"", .{name}) catch return true;
+    if (std.mem.indexOf(u8, source, quoted) != null) return true;
+
+    // A struct field: the name at the start of an indented line, followed by a
+    // colon. Anchored on the newline so `path:` inside `filePath:` or a
+    // comment does not count.
+    var field_buf: [96]u8 = undefined;
+    const field = std.fmt.bufPrint(&field_buf, "\n    {s}: ", .{name}) catch return true;
+    if (std.mem.indexOf(u8, source, field) != null) return true;
+
+    // A struct field at any indentation, identified by its default: every
+    // payload struct in these bridges declares one (`baud: u32 = 9600`).
+    //
+    // The default is what tells a field from a *parameter*. `fn writeFile(self:
+    // *Self, data: []const u8)` contains `data: `, and accepting that made the
+    // check pass against the exact bug it was written for — the handler was
+    // reading the wrong key while its own parameter supplied the name.
+    var nested_buf: [96]u8 = undefined;
+    const nested = std.fmt.bufPrint(&nested_buf, "{s}: ", .{name}) catch return true;
+    var search: usize = 0;
+    while (std.mem.indexOfPos(u8, source, search, nested)) |hit| {
+        search = hit + nested.len;
+        if (hit != 0) {
+            const before = source[hit - 1];
+            if (before != ' ' and before != '\n' and before != '\t') continue;
+        }
+        const line_end = std.mem.indexOfScalarPos(u8, source, hit, '\n') orelse source.len;
+        if (std.mem.indexOfScalarPos(u8, source[0..line_end], hit, '=') != null) return true;
+    }
+    return false;
+}
+
+/// Fields a handler legitimately does not name.
+///
+/// Narrowing the search to the handler is what makes the check catch a name
+/// read in the wrong place — but it also flags two honest patterns: a handler
+/// that reads the payload without keying off the field name, and one that
+/// delegates the parsing to a helper. Each exemption costs a line and a
+/// reason, which is the point: the list is short and every entry is arguable,
+/// rather than the check being weakened for everyone.
+const field_exempt = [_]struct {
+    namespace: []const u8,
+    action: []const u8,
+    field: []const u8,
+    why: []const u8,
+}{
+    .{
+        .namespace = "window",
+        .action = "setAlwaysOnTop",
+        .field = "value",
+        .why = "scans the payload for the literal \"false\", so it reads the boolean without naming the key",
+    },
+    .{ .namespace = "window", .action = "setResizable", .field = "value", .why = "same key-agnostic boolean scan" },
+    .{ .namespace = "window", .action = "setMovable", .field = "value", .why = "same key-agnostic boolean scan" },
+    .{ .namespace = "window", .action = "setHasShadow", .field = "value", .why = "same key-agnostic boolean scan" },
+    .{
+        .namespace = "bluetooth",
+        .action = "connectDevice",
+        .field = "id",
+        .why = "delegates to `deviceAddress`, which accepts both \"id\" and \"address\"",
+    },
+    .{ .namespace = "bluetooth", .action = "disconnectDevice", .field = "id", .why = "same helper" },
+};
+
+fn isExempt(namespace: []const u8, action: []const u8, field: []const u8) bool {
+    for (field_exempt) |e| {
+        if (std.mem.eql(u8, e.namespace, namespace) and
+            std.mem.eql(u8, e.action, action) and
+            std.mem.eql(u8, e.field, field)) return true;
+    }
+    return false;
+}
+
+test "every field the page sends is a name the handler actually looks for" {
+    // The bug class this exists for, from issue #69 and the audit that
+    // followed it: the page posts `{"data": "..."}`, the handler reads
+    // `"content"`, and nothing objects. Every bridge parses with
+    // `ignore_unknown_fields = true` or scans for a literal needle, so a name
+    // that does not match is not an error — the value is simply gone and the
+    // caller's promise resolves.
+    //
+    // It cost `craft.fs.writeFile` writing empty files, `setFullscreen(false)`
+    // entering fullscreen, `setVibrancy` removing vibrancy, and Bluetooth
+    // connects that could never name a device.
+    //
+    // The check is deliberately loose: it asks only whether the field name
+    // appears *somewhere* in the handling bridge, quoted. That is enough to
+    // catch a name the native side has never heard of, which is the whole
+    // failure, without trying to model which handler owns which action.
+    var checked: usize = 0;
+    var missing: usize = 0;
+
+    for ([_][]const u8{ "_send('", "_req('" }) |opener| {
+        var search: usize = 0;
+        while (std.mem.indexOfPos(u8, bridge_js, search, opener)) |hit| {
+            search = hit + opener.len;
+            const rest = bridge_js[search..];
+
+            const type_end = std.mem.indexOfScalar(u8, rest, '\'') orelse continue;
+            const msg_type = rest[0..type_end];
+
+            // Only the bridges that have opted in.
+            var source: ?[]const u8 = null;
+            for (field_checked) |entry| {
+                if (std.mem.eql(u8, entry.namespace, msg_type)) source = entry.source;
+            }
+            if (source == null) continue;
+
+            // The action, so the search can be narrowed to its handler.
+            const after_type = rest[type_end + 1 ..];
+            const a_open = std.mem.indexOf(u8, after_type, "'") orelse continue;
+            const a_rest = after_type[a_open + 1 ..];
+            const a_end = std.mem.indexOfScalar(u8, a_rest, '\'') orelse continue;
+            const action_name = a_rest[0..a_end];
+
+            // `fn <action>(` when the handler is named after the action, which
+            // is the convention throughout. Falls back to the whole file when
+            // it is not — looser, but never a false alarm.
+            const scope = handlerBody(source.?, action_name) orelse source.?;
+
+            // The `_stringify({ ... })` literal for this call, if it has one.
+            const call_end = std.mem.indexOfScalarPos(u8, bridge_js, search, '\n') orelse bridge_js.len;
+            const call = bridge_js[search..call_end];
+            const brace = std.mem.indexOf(u8, call, "_stringify({") orelse continue;
+            const obj_start = brace + "_stringify({".len;
+            const obj_end = std.mem.indexOfScalarPos(u8, call, obj_start, '}') orelse continue;
+            const obj = call[obj_start..obj_end];
+
+            // Field names: an identifier followed by a colon.
+            var i: usize = 0;
+            while (i < obj.len) {
+                while (i < obj.len and !std.ascii.isAlphabetic(obj[i])) i += 1;
+                const name_start = i;
+                while (i < obj.len and (std.ascii.isAlphanumeric(obj[i]) or obj[i] == '_')) i += 1;
+                if (i >= obj.len or name_start == i) break;
+                const name = obj[name_start..i];
+                var j = i;
+                while (j < obj.len and obj[j] == ' ') j += 1;
+                if (j >= obj.len or obj[j] != ':') continue;
+
+                checked += 1;
+                if (isExempt(msg_type, action_name, name)) continue;
+                if (!bridgeKnowsField(scope, name)) {
+                    missing += 1;
+                    std.debug.print(
+                        "craft-bridge.js sends '{s}' to the {s} bridge, which never mentions that name —\n" ++
+                            "  the value is parsed and discarded, and the caller's promise still resolves.\n",
+                        .{ name, msg_type },
+                    );
+                }
+            }
+        }
+    }
+
+    // Floor: these six bridges carry dozens of fields between them. A scan
+    // that matched nothing would pass having compared nothing.
+    try testing.expect(checked >= 30);
+    try testing.expectEqual(@as(usize, 0), missing);
+}


### PR DESCRIPTION
#69 was one instance of a class. The page posts `{"data": …}`, the handler reads `"content"`, and **nothing objects** — every bridge parses with `ignore_unknown_fields = true` or scans for a literal needle, so a name that does not match is not an error. The value is gone and the caller's promise resolves.

I swept all 281 calls the page can make. Nine more, in five bridges:

| call | page sends | native read | what happened |
|---|---|---|---|
| `fs.writeFile(path, data)` | `data` | `content` | **wrote an empty file, every time** |
| `fs.appendFile(path, data)` | `data` | `content` | appended nothing |
| `fs.copy(from, to)` | `from`,`to` | `src`,`dest` | no-op |
| `fs.move(from, to)` | `from`,`to` | `src`,`dest` | no-op |
| `window.setFullscreen(on)` | `value` | `fullscreen` `orelse true` | **`setFullscreen(false)` *entered* fullscreen** |
| `window.setOpacity(v)` | `value` | `opacity` | every window stayed fully opaque |
| `window.setVibrancy(mat)` | `material` | `vibrancy` | **took the removal branch — stripped vibrancy instead of applying it** |
| `bluetooth.connectDevice(id)` | `id` | `address` | address empty, call failed its own `MissingData` check |
| `updater.setAutomaticChecks` / `setCheckInterval` | `value`,`seconds` | `enabled`,`interval` | both silently kept defaults |
| `app.bounce(type)` | `type` | *(no payload read)* | `'critical'` hopped once instead of bouncing until activated |

Each now reads the name the page sends; the old spelling stays accepted for anything posting raw bridge messages. **The page's names are the published API — the native side is what was wrong.**

Verified end to end by running the binary: `writeFile` then `appendFile` produces `hello from writeFile + appended`, and `copy` followed by `move` leaves exactly `moved.txt`. Before, all four were silent no-ops.

## This explains something I waved past

Two days ago, mid-way through unrelated work, I hit *"`appendFile` reports success and writes nothing"*, wrote it off as **"a separate `bridge_fs` bug, not this PR's"**, and moved on without filing it. That was the symptom of this. Noticing a defect and not recording it is how it survives.

## The durable half

A conformance check: every field name the page sends must appear in the handler that serves it.

- **Handler-scoped, not file-scoped.** A file-wide search cannot tell `writeFile` reading a key only `readFile` sends — and file-scope demonstrably misses the `fs` bugs, the most severe ones.
- **Stops at the next doc comment as well as the next `fn`.** These bridges document payloads in `///` blocks, and `appendFile`'s `/// JSON: {"content": "data"}` leaked into `writeFile`'s span, making the check pass against the exact bug it was written for.
- **Distinguishes struct fields from function parameters** by requiring a default (`baud: u32 = 9600`). Without that, `fn writeFile(self: *Self, data: []const u8)` supplied the very name it was failing to read.
- **Six bridges opt in, as a ratchet that may only grow**, plus a short exemption list — four window setters that scan for the literal `"false"` without keying on a name, and two bluetooth handlers that delegate to a shared helper. Each exemption carries its reason.

## A process note, because it cost me

Several of my controls were **silently not applying**. I used `.replace()` without asserting it matched, so the file was unchanged and the test "passed" on code I believed I had broken — and I spent an iteration fixing a test that was already correct.

A control that does not assert it applied is not a control. Every control here now asserts its own edit landed, and each fires:

| control | result |
|---|---|
| revert `writeFile` to `"content"` (name still elsewhere in file) | fails ✓ |
| revert `copy` to `src`/`dest` | fails ✓ |
| remove the key from every `fs` handler | fails ✓ |
| clean tree | passes ✓ |

## Not changed

Two of the sixteen candidates were **not real** — `serial.open` and `localServer.start` both declare their fields in the parse struct. Left alone.

## Verified

`zig build` · `zig build test` · `zig build test-js` · `x86_64-windows` cross-build · `zig fmt --check` · 511 bun tests · pickier 38 warnings, unchanged from main.


---

## A second conformance check, in the same commit

This PR also carries a test I wrote separately and then folded in when the two
turned out to be the same question asked at different depths. Flagging it
rather than leaving it unmentioned in the diff:

**`every bridge type the page can send is routed by the dispatcher`**

The existing conformance suite pins the capability registry against the
dispatcher, and the channel list against the events the page subscribes to. It
never compared what the page can **call** against what native will answer.

Add `craft.foo.bar()` to the facade with no arm in `handleBridgeMessageJSON`
and the message is parsed, matched against every arm, and dropped. `_send`
resolves the moment it is posted, so the caller gets a fulfilled promise and
nothing happens — the same silence as #27, #47 and #69.

The sweep found the current tree clean at this level: every one of the 50 types
the page sends is routed. The test is what keeps it that way. Two native types,
`debug` and `nativeUI`, are routed but unreachable from the page — noted, not
changed, since an unreachable handler is inert rather than wrong.

Controlled both ways: adding a page call with an unrouted type fails it
(`craft-bridge.js posts type 'telemetry' but handleBridgeMessageJSON does not
route it`), and so does removing a dispatcher arm. The first is uniquely this
test's — a brand-new JS type is invisible to the registry check, because the
registry would not know about it either.
