### PR TITLE
iOS Phase 3: Tier-0 actions in Zig — 19 migrated, ratchet 105 → 86

### DIFF
--- a/packages/ios/fixtures/zig-slice/build-and-run.sh
+++ b/packages/ios/fixtures/zig-slice/build-and-run.sh
@@ -66,7 +66,7 @@ LAUNCH_PID=$!
 # The round trip is fast, but a cold simulator is not. Poll rather than sleep a
 # fixed amount, so a slow boot does not read as a failure.
 for _ in $(seq 1 60); do
-    if grep -q 'i=5' "$LOG" 2>/dev/null && grep -q 'i=3' "$LOG" 2>/dev/null; then sleep 1; break; fi
+    if grep -q 'i=7' "$LOG" 2>/dev/null && grep -q 'i=5' "$LOG" 2>/dev/null; then sleep 1; break; fi
     sleep 1
 done
 kill "$LAUNCH_PID" 2>/dev/null || true
@@ -110,5 +110,16 @@ echo "ok: unserved action reached the dispatcher (i=4 seen ${C4}x)"
 # reply path. Neither side could have produced this alone.
 [ "$C5" -ge 1 ] || { echo "FAIL: the host shim never answered, or its answer never reached the page"; exit 1; }
 echo "ok: hand-off to host shim closed (i=5 seen ${C5}x)"
+
+C6="$(count 6)"; C7="$(count 7)"
+
+[ "$C6" -ge 1 ] || { echo "FAIL: the rejecting action never reached the dispatcher"; exit 1; }
+echo "ok: rejecting action reached the dispatcher (i=6 seen ${C6}x)"
+
+# i=7 requires the page's __craftBridgeError handler to have seen error:true,
+# the HOST_DECLINED code, id 6, and a message whose backslash, quote and
+# newline survived Zig's escaping. Any of those wrong and this never fires.
+[ "$C7" -ge 1 ] || { echo "FAIL: the shim's rejection never reached the page intact"; exit 1; }
+echo "ok: error route closed with escaping intact (i=7 seen ${C7}x)"
 
 echo "PASS"

--- a/packages/ios/fixtures/zig-slice/build-and-run.sh
+++ b/packages/ios/fixtures/zig-slice/build-and-run.sh
@@ -44,7 +44,7 @@ swiftc -target "$TRIPLE" -sdk "$SDK" \
     "$FIXTURE/shim.swift" \
     "$OUT/main.o" "$OUT/page.o" \
     "$ROOT/packages/zig/zig-out/lib/$LIB" \
-    -framework UIKit -framework WebKit -framework Foundation \
+    -framework UIKit -framework WebKit -framework Foundation -framework Security \
     -o "$APP/CraftSlice"
 
 cp "$FIXTURE/Info.plist" "$APP/Info.plist"
@@ -66,7 +66,7 @@ LAUNCH_PID=$!
 # The round trip is fast, but a cold simulator is not. Poll rather than sleep a
 # fixed amount, so a slow boot does not read as a failure.
 for _ in $(seq 1 60); do
-    if grep -q 'i=7' "$LOG" 2>/dev/null && grep -q 'i=5' "$LOG" 2>/dev/null; then sleep 1; break; fi
+    if grep -q 'i=7' "$LOG" 2>/dev/null && grep -q 'i=8' "$LOG" 2>/dev/null; then sleep 1; break; fi
     sleep 1
 done
 kill "$LAUNCH_PID" 2>/dev/null || true
@@ -121,5 +121,9 @@ echo "ok: rejecting action reached the dispatcher (i=6 seen ${C6}x)"
 # newline survived Zig's escaping. Any of those wrong and this never fires.
 [ "$C7" -ge 1 ] || { echo "FAIL: the shim's rejection never reached the page intact"; exit 1; }
 echo "ok: error route closed with escaping intact (i=7 seen ${C7}x)"
+
+C8="$(count 8)"
+[ "$C8" -ge 1 ] || { echo "FAIL: the Tier-0 action's reply never carried a real app state"; exit 1; }
+echo "ok: Tier-0 action served by Zig with a live UIKit value (i=8 seen ${C8}x)"
 
 echo "PASS"

--- a/packages/ios/fixtures/zig-slice/page.m
+++ b/packages/ios/fixtures/zig-slice/page.m
@@ -11,6 +11,9 @@
 //   i=3  the user script had already run when the page's own script executed
 //   i=4  the page called an action Zig does *not* serve
 //   i=5  that reply came back, having been answered by the host shim
+//   i=6  the page called an action the shim answers by *rejecting*
+//   i=7  the rejection arrived via __craftBridgeError with its id, code, and
+//        an unmangled message — proving the error route and Zig-side escaping
 //
 // i=2 and i=5 are the load-bearing ones, and they prove different things.
 // i=2 cannot be produced by a stub: only a real UIKit process reports
@@ -33,6 +36,18 @@ const char craft_slice_page[] =
     "  bridge.postMessage({t:'mobile', a:'getDeviceInfo', i:3});\n"
     "}\n"
     "\n"
+    "var sentErrorAck = false;\n"
+    "window.__craftBridgeError = function (ctx) {\n"
+    "  // The message crossed Zig's escaping with a backslash, quote, and\n"
+    "  // newline intact; anything mangled and this equality fails, i=7 never\n"
+    "  // fires, and the harness reports the error route broken.\n"
+    "  var messageIntact = ctx && ctx.message === 'declined \\\\ \"on purpose\"\\nsecond line';\n"
+    "  if (!sentErrorAck && ctx && ctx.error === true && ctx.code === 'HOST_DECLINED'\n"
+    "      && ctx.id === 6 && messageIntact) {\n"
+    "    sentErrorAck = true;\n"
+    "    bridge.postMessage({t:'mobile', a:'getDeviceInfo', i:7});\n"
+    "  }\n"
+    "};\n"
     "window.__craftBridgeResult = function (action, payload, id) {\n"
     "  window.__craftSliceAck = JSON.stringify({action: action, id: id, payload: payload});\n"
     "  document.getElementById('s').textContent = window.__craftSliceAck;\n"
@@ -58,6 +73,8 @@ const char craft_slice_page[] =
     "  bridge.postMessage({t:'mobile', a:'getDeviceInfo', i:1});\n"
     "  // An action Zig does not serve, so it must reach the host shim.\n"
     "  bridge.postMessage({t:'mobile', a:'hostOnlyPing', i:4});\n"
+    "  // And one the shim answers by rejecting, to prove the error route.\n"
+    "  bridge.postMessage({t:'mobile', a:'hostOnlyFail', i:6});\n"
     "} else {\n"
     "  document.getElementById('s').textContent = 'NO BRIDGE';\n"
     "}\n"

--- a/packages/ios/fixtures/zig-slice/page.m
+++ b/packages/ios/fixtures/zig-slice/page.m
@@ -11,6 +11,8 @@
 //   i=3  the user script had already run when the page's own script executed
 //   i=4  the page called an action Zig does *not* serve
 //   i=5  that reply came back, having been answered by the host shim
+//   i=8  the page called a Tier-0 action Zig newly serves (getAppState) and
+//        its reply named a real UIKit application state
 //   i=6  the page called an action the shim answers by *rejecting*
 //   i=7  the rejection arrived via __craftBridgeError with its id, code, and
 //        an unmangled message — proving the error route and Zig-side escaping
@@ -25,7 +27,7 @@ const char craft_slice_page[] =
     "<!DOCTYPE html><html><head><meta charset=\"utf-8\">"
     "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">"
     "</head><body><h1 id=\"s\">craft slice</h1><script>\n"
-    "var sentRoundTrip = false, sentHandOff = false;\n"
+    "var sentRoundTrip = false, sentHandOff = false, sentTierZero = false;\n"
     "var bridge = window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.craft;\n"
     "\n"
     "// Read before anything else touches it: the user script is installed at\n"
@@ -62,6 +64,12 @@ const char craft_slice_page[] =
     "  // Zig routed the call out, Swift answered through\n"
     "  // craft_ios_deliver_result, and Zig delivered it here over the same\n"
     "  // protocol it uses for its own actions.\n"
+    "  // A Tier-0 action served by Zig itself: the reply carries the UIKit\n"
+    "  // application state, which only a live foregrounded process reports.\n"
+    "  if (!sentTierZero && (payload === 'active' || payload === 'inactive')) {\n"
+    "    sentTierZero = true;\n"
+    "    bridge.postMessage({t:'mobile', a:'getDeviceInfo', i:8});\n"
+    "  }\n"
     "  if (!sentHandOff && payload && payload.servedBy === 'host-shim'\n"
     "      && payload.language === 'swift') {\n"
     "    sentHandOff = true;\n"
@@ -73,6 +81,8 @@ const char craft_slice_page[] =
     "  bridge.postMessage({t:'mobile', a:'getDeviceInfo', i:1});\n"
     "  // An action Zig does not serve, so it must reach the host shim.\n"
     "  bridge.postMessage({t:'mobile', a:'hostOnlyPing', i:4});\n"
+    "  // A Tier-0 action migrated in this phase, served by Zig directly.\n"
+    "  bridge.postMessage({t:'mobile', a:'getAppState', i:88});\n"
     "  // And one the shim answers by rejecting, to prove the error route.\n"
     "  bridge.postMessage({t:'mobile', a:'hostOnlyFail', i:6});\n"
     "} else {\n"

--- a/packages/ios/fixtures/zig-slice/shim.swift
+++ b/packages/ios/fixtures/zig-slice/shim.swift
@@ -1,57 +1,78 @@
-// The host shim, in Swift, presenting the contract `CraftApp.swift` will.
+// The host shim, mirroring the design `CraftApp.swift`'s CraftSwiftShim uses —
+// including the part most likely to fail silently in production: discovering
+// Zig's delivery exports with `dlsym` rather than linking them.
 //
-// This replaces an Objective-C stand-in. The stand-in proved the runtime
-// mechanism — `objc_getClass` plus a message send — but not that *Swift*
-// presents that mechanism the way Zig expects: that `@objc(CraftSwiftShim)`
-// really does register under that name, that a `static func` becomes a class
-// method reachable by selector, that `String` parameters bridge from NSString,
-// and that `Bool` comes back as the ObjC BOOL Zig reads.
+// That discovery is the template's load-bearing assumption. A pure-Swift app
+// has no Zig runtime, so the template cannot use `@_silgen_name` (a hard link
+// dependency); it resolves the symbols at runtime and declines when absent.
+// Whether `dlsym(dlopen(nil, RTLD_NOW), ...)` finds a symbol that was
+// *statically linked* into the executable is exactly the kind of fact that
+// must be proven on a simulator, because if a build setting strips it from the
+// dynamic symbol table the seam degrades to "shim declines everything" with no
+// error anywhere.
 //
-// Those are exactly the assumptions the real wiring will rest on, so they are
-// worth testing against the real compiler rather than assumed from a language
-// that shares an ABI with it.
+// Two actions, proving the two reply routes:
+//   hostOnlyPing  -> craft_ios_deliver_result  (the page's promise resolves)
+//   hostOnlyFail  -> craft_ios_deliver_error   (the page's promise rejects)
+// The error route matters independently: delivering a rejection as a result
+// would run the app's then-branch with an error-shaped object.
 import Foundation
 
-// Zig owns the reply path. The shim decides *what* the answer is and hands it
-// back; the wire format, the request id and the escaping stay on the other
-// side. `@_silgen_name` reaches the exported symbol without needing a bridging
-// header, which keeps the harness to one swiftc invocation.
-@_silgen_name("craft_ios_deliver_result")
-func craft_ios_deliver_result(
-    _ action: UnsafePointer<CChar>, _ actionLen: UInt,
-    _ json: UnsafePointer<CChar>, _ jsonLen: UInt,
-    _ requestId: Int64
-)
+private typealias DeliverResultFn = @convention(c) (
+    UnsafePointer<CChar>, UInt, UnsafePointer<CChar>, UInt, Int64
+) -> Void
+private typealias DeliverErrorFn = @convention(c) (
+    UnsafePointer<CChar>, UInt, UnsafePointer<CChar>, UInt,
+    UnsafePointer<CChar>, UInt, Int64
+) -> Void
+
+private let deliverResult: DeliverResultFn? = {
+    guard let sym = dlsym(dlopen(nil, RTLD_NOW), "craft_ios_deliver_result") else { return nil }
+    return unsafeBitCast(sym, to: DeliverResultFn.self)
+}()
+
+private let deliverError: DeliverErrorFn? = {
+    guard let sym = dlsym(dlopen(nil, RTLD_NOW), "craft_ios_deliver_error") else { return nil }
+    return unsafeBitCast(sym, to: DeliverErrorFn.self)
+}()
 
 @objc(CraftSwiftShim)
 public class CraftSwiftShim: NSObject {
-    // Selector: handleAction:payload:requestId:  — which is what
-    // `ios_dispatch.handOffToHost` sends. A mismatch here is not a compile
-    // error on either side, so the simulator assertion is what catches it.
     @objc public static func handleAction(
         _ action: String,
         payload: String,
         requestId: Int64
     ) -> Bool {
-        // Exactly one action, to prove the seam. A real shim dispatches the
-        // ~105 the Swift template still owns.
-        guard action == "hostOnlyPing" else {
-            // Not ours. Zig answers UnknownAction, which is the same path a
-            // fully-migrated app with no shim at all takes.
+        switch action {
+        case "hostOnlyPing":
+            guard let deliverResult else { return false }
+            let json = "{\"servedBy\":\"host-shim\",\"language\":\"swift\",\"payloadBytes\":\(payload.utf8.count)}"
+            action.withCString { a in
+                json.withCString { j in
+                    deliverResult(a, UInt(strlen(a)), j, UInt(strlen(j)), requestId)
+                }
+            }
+            return true
+
+        case "hostOnlyFail":
+            guard let deliverError else { return false }
+            // The message deliberately contains the characters Swift's old
+            // hand-escaping mangled: a backslash, a quote, and a newline. If
+            // they reach the page intact, escaping lives on the Zig side where
+            // it belongs.
+            let message = "declined \\ \"on purpose\"\nsecond line"
+            action.withCString { a in
+                message.withCString { m in
+                    "HOST_DECLINED".withCString { c in
+                        deliverError(a, UInt(strlen(a)), m, UInt(strlen(m)),
+                                     c, UInt(strlen(c)), requestId)
+                    }
+                }
+            }
+            return true
+
+        default:
             return false
         }
-
-        let json = "{\"servedBy\":\"host-shim\",\"language\":\"swift\",\"payloadBytes\":\(payload.utf8.count)}"
-
-        action.withCString { a in
-            json.withCString { j in
-                craft_ios_deliver_result(
-                    a, UInt(strlen(a)),
-                    j, UInt(strlen(j)),
-                    requestId
-                )
-            }
-        }
-        return true
     }
 }

--- a/packages/ios/scripts/typecheck-template.sh
+++ b/packages/ios/scripts/typecheck-template.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Type-check CraftApp.swift without generating a project.
+#
+# The template cannot be compiled as-is: it carries {{BUNDLE_ID}} placeholders
+# and top-level code, and it references CraftActivityAttributes from a sibling
+# template. This substitutes a dummy id, adds -parse-as-library, and includes
+# the sibling — which is exactly what the generated app does, minus xcodegen.
+#
+# Detecting failure by exit code, not by grepping for "error:": the file is
+# full of `rejectCallback(callbackId, error: ...)` argument labels, and a grep
+# happily counts those as compiler errors. That mistake already cost a cycle.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TPL="$ROOT/packages/ios/templates"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+sed 's/{{BUNDLE_ID}}/app.craft.typecheck/g' "$TPL/CraftApp.swift" > "$TMP/CraftApp.swift"
+
+SDK="$(xcrun --sdk iphonesimulator --show-sdk-path)"
+swiftc -typecheck -parse-as-library \
+    -sdk "$SDK" -target arm64-apple-ios18.0-simulator \
+    "$TMP/CraftApp.swift" "$TPL/CraftActivityAttributes.swift"
+
+echo "CraftApp.swift typechecks"

--- a/packages/ios/templates/CraftApp.swift
+++ b/packages/ios/templates/CraftApp.swift
@@ -364,7 +364,12 @@ struct CraftWebView: UIViewRepresentable {
     func updateUIView(_ webView: WKWebView, context: Context) {}
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(config: config)
+        let coordinator = Coordinator(config: config)
+        // The Zig dispatcher finds CraftSwiftShim by class name; the shim finds
+        // its way back to the live coordinator through this. Weak, because
+        // SwiftUI owns the coordinator's lifetime.
+        CraftSwiftShim.coordinator = coordinator
+        return coordinator
     }
 
     // MARK: - Coordinator (Native Bridge)
@@ -511,8 +516,19 @@ struct CraftWebView: UIViewRepresentable {
             guard let body = message.body as? [String: Any],
                   let action = body["action"] as? String else { return }
 
-            let callbackId = body["callbackId"] as? String
+            dispatch(action: action, body: body, callbackId: body["callbackId"] as? String)
+        }
 
+        /// The action switch, reachable from two directions: the
+        /// WKScriptMessageHandler above, and `CraftSwiftShim.handleAction` when
+        /// the Zig dispatcher hands over an action it has not migrated yet.
+        ///
+        /// A hand-off call arrives with a synthetic callbackId of the form
+        /// "zig:<requestId>". The reply helpers recognise that prefix and route
+        /// the answer back through the Zig runtime's exported
+        /// `craft_ios_deliver_result` instead of evaluating JavaScript here —
+        /// one reply path, owned by whichever side received the page's message.
+        func dispatch(action: String, body: [String: Any], callbackId: String?) {
             switch action {
             case "startListening":
                 if config.enableSpeechRecognition { startSpeechRecognition() }
@@ -2426,6 +2442,10 @@ struct CraftWebView: UIViewRepresentable {
                 rejectCallback(callbackId, error: "Native result could not be serialized", code: "SERIALIZATION_ERROR")
                 return
             }
+            // A hand-off from the Zig dispatcher replies through Zig, which
+            // owns the wire format, the request id, and the escaping. Replying
+            // by JavaScript here as well would give the page two answers.
+            if CraftSwiftShim.deliverResultIfHandOff(id, json: resultStr) { return }
             let script = "window.craft._resolveCallback('\(id)', \(resultStr));"
             DispatchQueue.main.async { self.webView?.evaluateJavaScript(script, completionHandler: nil) }
         }
@@ -2436,7 +2456,17 @@ struct CraftWebView: UIViewRepresentable {
 
         private func rejectCallback(_ callbackId: String?, error: String, code: String = "CRAFT_ERROR") {
             guard let id = callbackId else { return }
-            let escapedError = error.replacingOccurrences(of: "'", with: "\\'").replacingOccurrences(of: "\n", with: "\\n")
+            // A hand-off rejection goes back through Zig's error route, so the
+            // page's promise *rejects*. Delivering it as a result would run the
+            // app's then-branch with an error-shaped object — fabricated
+            // success wearing a different hat.
+            if CraftSwiftShim.deliverErrorIfHandOff(id, message: error, code: code) { return }
+            // Backslashes first: escaping ' and \n but not \ let an error
+            // message containing a backslash break out of the string literal.
+            let escapedError = error
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "'", with: "\\'")
+                .replacingOccurrences(of: "\n", with: "\\n")
             let script = "window.craft._rejectCallback('\(id)', '\(escapedError)', '\(code)');"
             DispatchQueue.main.async { self.webView?.evaluateJavaScript(script, completionHandler: nil) }
         }
@@ -5157,5 +5187,100 @@ extension CraftWebView.Coordinator: WCSessionDelegate {
             self?.sendToWeb("craftWatchUserInfo", data: userInfo)
             self?.sendToWeb("craftWatchMessage", data: userInfo)
         }
+    }
+}
+
+
+// MARK: - Zig hand-off shim
+
+/// The seam the Zig dispatcher hands unmigrated actions through.
+///
+/// Discovery is symmetric and both directions are runtime-only. Zig finds this
+/// class with `objc_getClass("CraftSwiftShim")`; this class finds Zig's
+/// delivery exports with `dlsym`. Neither side links the other, so a
+/// pure-Swift app (no Zig runtime) and a fully-migrated Zig app (no shim work
+/// left) both build and run without dead dependencies.
+///
+/// The shim decides *what* the answer is, never *how* it reaches the page.
+/// Replies go back through Zig's `craft_ios_deliver_result` /
+/// `craft_ios_deliver_error`, which own the wire format, the request id, and
+/// the escaping. Two components replying to one page by different routes is
+/// how this codebase accumulated five envelopes.
+@objc(CraftSwiftShim)
+final class CraftSwiftShim: NSObject {
+    /// The coordinator serving hand-offs. Set by `makeCoordinator`.
+    static weak var coordinator: CraftWebView.Coordinator?
+
+    private typealias DeliverResultFn = @convention(c) (
+        UnsafePointer<CChar>, UInt, UnsafePointer<CChar>, UInt, Int64
+    ) -> Void
+    private typealias DeliverErrorFn = @convention(c) (
+        UnsafePointer<CChar>, UInt, UnsafePointer<CChar>, UInt,
+        UnsafePointer<CChar>, UInt, Int64
+    ) -> Void
+
+    private static let deliverResult: DeliverResultFn? = {
+        guard let sym = dlsym(dlopen(nil, RTLD_NOW), "craft_ios_deliver_result") else { return nil }
+        return unsafeBitCast(sym, to: DeliverResultFn.self)
+    }()
+
+    private static let deliverError: DeliverErrorFn? = {
+        guard let sym = dlsym(dlopen(nil, RTLD_NOW), "craft_ios_deliver_error") else { return nil }
+        return unsafeBitCast(sym, to: DeliverErrorFn.self)
+    }()
+
+    /// Entry point for the Zig dispatcher. Selector: handleAction:payload:requestId:
+    ///
+    /// Returns false when this shim cannot serve the call — no live
+    /// coordinator, or no Zig runtime to reply through — so Zig answers the
+    /// page with UnknownAction instead of the call vanishing.
+    @objc static func handleAction(_ action: String, payload: String, requestId: Int64) -> Bool {
+        guard let coordinator, deliverResult != nil else { return false }
+
+        let body = ((try? JSONSerialization.jsonObject(with: Data(payload.utf8))) as? [String: Any]) ?? [:]
+
+        // The synthetic callbackId routes this call's reply back through Zig.
+        // It carries the action too, because the reply helpers do not otherwise
+        // know it, and Zig's reply names the action for the page's
+        // action-matching fallback.
+        coordinator.dispatch(action: action, body: body, callbackId: "zig:\(requestId):\(action)")
+        return true
+    }
+
+    /// Route a resolve through Zig when the callbackId marks a hand-off.
+    /// Returns true when the reply has been (or could only be) handled here.
+    static func deliverResultIfHandOff(_ callbackId: String, json: String) -> Bool {
+        guard let (requestId, action) = parseHandOffId(callbackId) else { return false }
+        guard let deliverResult else { return true } // hand-off id but no runtime: drop, never eval JS
+        action.withCString { a in
+            json.withCString { j in
+                deliverResult(a, UInt(strlen(a)), j, UInt(strlen(j)), requestId)
+            }
+        }
+        return true
+    }
+
+    /// Route a rejection through Zig's error path, so the page's promise
+    /// rejects rather than resolving with an error-shaped object.
+    static func deliverErrorIfHandOff(_ callbackId: String, message: String, code: String) -> Bool {
+        guard let (requestId, action) = parseHandOffId(callbackId) else { return false }
+        guard let deliverError else { return true }
+        action.withCString { a in
+            message.withCString { m in
+                code.withCString { c in
+                    deliverError(a, UInt(strlen(a)), m, UInt(strlen(m)), c, UInt(strlen(c)), requestId)
+                }
+            }
+        }
+        return true
+    }
+
+    /// "zig:<requestId>:<action>" -> (requestId, action). Nil for ordinary
+    /// page-issued callback ids, which keep their JavaScript reply path.
+    private static func parseHandOffId(_ callbackId: String) -> (Int64, String)? {
+        guard callbackId.hasPrefix("zig:") else { return nil }
+        let rest = callbackId.dropFirst(4)
+        guard let sep = rest.firstIndex(of: ":"), let id = Int64(rest[..<sep]) else { return nil }
+        return (id, String(rest[rest.index(after: sep)...]))
     }
 }

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -339,6 +339,40 @@ pub fn build(b: *std.Build) void {
         ios_surface_tests.root_module.linkFramework("CoreFoundation", .{});
         ios_surface_tests.root_module.linkFramework("CoreGraphics", .{});
         ios_surface_tests.root_module.linkFramework("CoreMIDI", .{});
+        // The storage module is Keychain: SecItemAdd and the kSec* constants
+        // live in Security.framework.
+        ios_surface_tests.root_module.linkFramework("Security", .{});
+    }
+
+    // Tests are collected from the ROOT module only — a named-module import is
+    // a different module, so `test { _ = ios; }` in the surface gate enrolls
+    // nothing. This artifact makes src/ios.zig itself the root, which is the
+    // only arrangement that runs the tests inside ios_dispatch.zig and the
+    // mobile modules. Proven with a canary: a deliberately failing module test
+    // stayed green under every other wiring.
+    // A fresh module object rather than reusing `ios_module`: an artifact root
+    // needs a resolved target, and the one-module-per-file rule only applies
+    // within a single compilation — this artifact is its own.
+    const ios_module_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/ios.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    if (target.result.os.tag.isDarwin()) {
+        ios_module_tests.root_module.link_libc = true;
+        ios_module_tests.root_module.linkSystemLibrary("objc", .{});
+        ios_module_tests.root_module.linkFramework("Cocoa", .{});
+        ios_module_tests.root_module.linkFramework("WebKit", .{});
+        ios_module_tests.root_module.linkFramework("CoreFoundation", .{});
+        ios_module_tests.root_module.linkFramework("CoreGraphics", .{});
+        ios_module_tests.root_module.linkFramework("CoreMIDI", .{});
+        ios_module_tests.root_module.linkFramework("Security", .{});
+        // Rooting at ios.zig compiles its exports, whose reply path reaches the
+        // desktop bridge — including the Carbon hotkey machinery. Same linkage
+        // macos_hotkey_tests already carries.
+        ios_module_tests.root_module.linkFramework("Carbon", .{});
     }
 
     // The iOS conformance gate. It embeds the Swift template as the migration
@@ -356,6 +390,24 @@ pub fn build(b: *std.Build) void {
     });
     ios_conformance_tests.root_module.addAnonymousImport("src/bridge_mobile.zig", .{
         .root_source_file = b.path("src/bridge_mobile.zig"),
+    });
+    ios_conformance_tests.root_module.addAnonymousImport("src/bridge_mobile_clipboard.zig", .{
+        .root_source_file = b.path("src/bridge_mobile_clipboard.zig"),
+    });
+    ios_conformance_tests.root_module.addAnonymousImport("src/bridge_mobile_haptics.zig", .{
+        .root_source_file = b.path("src/bridge_mobile_haptics.zig"),
+    });
+    ios_conformance_tests.root_module.addAnonymousImport("src/bridge_mobile_device.zig", .{
+        .root_source_file = b.path("src/bridge_mobile_device.zig"),
+    });
+    ios_conformance_tests.root_module.addAnonymousImport("src/bridge_mobile_system.zig", .{
+        .root_source_file = b.path("src/bridge_mobile_system.zig"),
+    });
+    ios_conformance_tests.root_module.addAnonymousImport("src/bridge_mobile_display.zig", .{
+        .root_source_file = b.path("src/bridge_mobile_display.zig"),
+    });
+    ios_conformance_tests.root_module.addAnonymousImport("src/bridge_mobile_storage.zig", .{
+        .root_source_file = b.path("src/bridge_mobile_storage.zig"),
     });
 
     const menubar_tests = b.addTest(.{
@@ -1204,6 +1256,7 @@ pub fn build(b: *std.Build) void {
     const run_mobile_tests = b.addRunArtifact(mobile_tests);
     const run_ios_surface_tests = b.addRunArtifact(ios_surface_tests);
     const run_ios_conformance_tests = b.addRunArtifact(ios_conformance_tests);
+    const run_ios_module_tests = b.addRunArtifact(ios_module_tests);
     const run_menubar_tests = b.addRunArtifact(menubar_tests);
     const run_components_tests = b.addRunArtifact(components_tests);
     const run_gpu_tests = b.addRunArtifact(gpu_tests);
@@ -1339,6 +1392,7 @@ pub fn build(b: *std.Build) void {
     // touches no platform types, so it runs everywhere.
     if (target.result.os.tag.isDarwin()) {
         test_step.dependOn(&run_ios_surface_tests.step);
+        test_step.dependOn(&run_ios_module_tests.step);
     }
     test_step.dependOn(&run_ios_conformance_tests.step);
     test_step.dependOn(&run_menubar_tests.step);
@@ -1422,6 +1476,7 @@ pub fn build(b: *std.Build) void {
     const test_ios_step = b.step("test:ios", "Run the iOS surface gate");
     if (target.result.os.tag.isDarwin()) {
         test_ios_step.dependOn(&run_ios_surface_tests.step);
+        test_ios_step.dependOn(&run_ios_module_tests.step);
     }
     test_ios_step.dependOn(&run_ios_conformance_tests.step);
 
@@ -1681,6 +1736,11 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
+    // Linked by clang/swiftc, not by Zig, so the compiler-rt intrinsics Zig
+    // code needs (f128 soft-float from std.json's number parsing, among
+    // others) must travel inside the archive — no later link step provides
+    // them, and the failure is undefined symbols in whoever consumes the lib.
+    ios_device_lib.bundle_compiler_rt = true;
     // Frameworks are linked at the app level in Xcode, not in the static library
     const ios_device_install = b.addInstallArtifact(ios_device_lib, .{});
     build_ios.dependOn(&ios_device_install.step);
@@ -1705,6 +1765,11 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
+    // Linked by clang/swiftc, not by Zig, so the compiler-rt intrinsics Zig
+    // code needs (f128 soft-float from std.json's number parsing, among
+    // others) must travel inside the archive — no later link step provides
+    // them, and the failure is undefined symbols in whoever consumes the lib.
+    ios_sim_arm64_lib.bundle_compiler_rt = true;
     const ios_sim_arm64_install = b.addInstallArtifact(ios_sim_arm64_lib, .{});
     build_ios_simulator.dependOn(&ios_sim_arm64_install.step);
     build_ios_all.dependOn(&ios_sim_arm64_install.step);
@@ -1728,6 +1793,11 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
+    // Linked by clang/swiftc, not by Zig, so the compiler-rt intrinsics Zig
+    // code needs (f128 soft-float from std.json's number parsing, among
+    // others) must travel inside the archive — no later link step provides
+    // them, and the failure is undefined symbols in whoever consumes the lib.
+    ios_sim_x64_lib.bundle_compiler_rt = true;
     const ios_sim_x64_install = b.addInstallArtifact(ios_sim_x64_lib, .{});
     build_ios_simulator.dependOn(&ios_sim_x64_install.step);
     build_ios_all.dependOn(&ios_sim_x64_install.step);

--- a/packages/zig/src/bridge_mobile_clipboard.zig
+++ b/packages/zig/src/bridge_mobile_clipboard.zig
@@ -1,0 +1,541 @@
+//! The clipboard actions of the `mobile` namespace: `clipboardRead`,
+//! `clipboardWrite`.
+//!
+//! Ported from the two inline arms in `CraftApp.swift`'s dispatcher. The Swift
+//! is eleven lines, and three of its behaviours are deliberately not carried
+//! across:
+//!
+//! 1. **It can leave the caller waiting forever.** Both arms are an `if` with
+//!    no `else`, and clipboard is one of the few actions whose promise is built
+//!    inline instead of through `_createCallback` — which is the only thing
+//!    that installs the 30-second rejection. So a false `enableClipboard`, or a
+//!    `text` that is not a string, replies with nothing at all: not resolved,
+//!    not rejected, ever. Every path in this file ends in a reply or an error.
+//! 2. **`UIPasteboard.string ?? ""` conflates three different facts.** See
+//!    `readClipboard`.
+//! 3. **It reports success for a write it never checked.** See `putString`.
+//!
+//! ## The payload moved, and defaulting it would erase the clipboard
+//!
+//! The Swift-injected `window.craft` posts `text` at the *top level*, a sibling
+//! of `action`. `ios_dispatch` never looks there — it hands a namespace only
+//! the stringified `d`. A page still posting the flat legacy shape therefore
+//! arrives here with `d` absent, which `payloadOf` turns into `{}`. That is why
+//! an absent `text` is `MissingData` rather than a defaulted `""`: defaulting is
+//! precisely how `craft.fs.writeFile` came to write empty files for months, and
+//! here the same mistake would silently *wipe* the user's clipboard and report
+//! success. The page-side call must be
+//! `{t:'mobile', a:'clipboardWrite', d:'{"text":"…"}', i:N}`.
+//!
+//! ## `enableClipboard` is a deliberate behaviour change, recorded here
+//!
+//! The Swift gate reads `config.enableClipboard`, which originates in
+//! TypeScript (`packages/ios/src/index.ts`, defaulting to `false`), is
+//! templated into the Swift `CraftConfig`, and never reaches Zig. Rather than
+//! guess at it or drop it, it is left plumbable: a host can call
+//! `craft_ios_set_clipboard_enabled(false)` at startup. It defaults to
+//! *enabled*, because a default of off would answer every app with
+//! PERMISSION_DENIED until a host that does not exist yet is written. This is a
+//! real change: an app that left `enableClipboard: false` now gets a working
+//! clipboard while the capability object the page reads still says
+//! `clipboard: false`.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const capabilities = @import("capabilities.zig");
+const bridge_error = @import("bridge_error.zig");
+const objc_runtime = @import("objc_runtime.zig");
+
+const objc = objc_runtime.objc;
+
+/// The action names, spelled exactly as the Swift `case` labels spell them.
+///
+/// `test/ios_conformance_test.zig` matches the two lists by string, so a
+/// tidier spelling here does not read as "migrated" — it reads as "Zig serves
+/// an action the spec does not have", and the Swift arm stays live forever.
+pub const A = struct {
+    pub const clipboard_read = "clipboardRead";
+    pub const clipboard_write = "clipboardWrite";
+};
+
+/// Both `.result`. `clipboardWrite` hands nothing back but is not
+/// fire-and-forget: Swift resolves it with `true`, and `craft.clipboard.write()`
+/// returns a promise the page awaits. Declaring it `.none` would strand that
+/// caller for the whole request timeout. Desktop's `clipboard/writeText` is
+/// `.none` for a reason that does not apply here — `craft-bridge.js` posts it
+/// through `_send`, which resolves on post rather than on an answer.
+pub const capability_actions = [_]capabilities.ActionDecl{
+    .{ .name = A.clipboard_read, .reply = .result },
+    .{ .name = A.clipboard_write, .reply = .result },
+};
+
+/// The two literal replies. `clipboardRead` answers a *bare* JSON string and
+/// `clipboardWrite` a bare `true`; `formatResultJS` interpolates whatever it is
+/// given straight into `__craftBridgeResult(...)`, so neither needs wrapping.
+const reply_true = "true";
+const reply_no_text = "\"\"";
+
+/// NSUTF8StringEncoding, for `-lengthOfBytesUsingEncoding:`.
+const ns_utf8_string_encoding: usize = 4;
+
+/// Whether the app permits clipboard access — the `enableClipboard` gate the
+/// module comment describes.
+///
+/// A plain `bool`, not an atomic: WebKit delivers
+/// `userContentController:didReceiveScriptMessage:` on the main thread and
+/// `ios_dispatch.handleMessage` runs synchronously from there, so every reader
+/// is the main thread, and the only writer is a host doing this once at startup.
+var clipboard_enabled: bool = true;
+
+pub fn setEnabled(value: bool) void {
+    clipboard_enabled = value;
+}
+
+/// Startup hook for a host that wants the Swift gate back, alongside
+/// `craft_ios_deliver_result`. Turning the capability off makes the handlers
+/// *reject* with `PermissionDenied`; it must never reproduce the Swift gate's
+/// actual failure mode, which was silence.
+export fn craft_ios_set_clipboard_enabled(value: bool) callconv(.c) void {
+    clipboard_enabled = value;
+}
+
+pub const ClipboardBridge = struct {
+    allocator: std.mem.Allocator,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator) Self {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(_: *Self) void {}
+
+    pub fn handleMessage(self: *Self, action: []const u8, data: []const u8) !void {
+        if (std.mem.eql(u8, action, A.clipboard_read)) {
+            try self.readClipboard();
+        } else if (std.mem.eql(u8, action, A.clipboard_write)) {
+            try self.writeClipboard(data);
+        } else {
+            return bridge_error.BridgeError.UnknownAction;
+        }
+    }
+
+    /// Read the pasteboard, and say *which* of the "no text" cases happened.
+    ///
+    /// The reply is a bare JSON string — `"hello"`, not `{"text":"hello"}`.
+    /// That is what the page consumes: `test-bridges.html` does
+    /// `'Clipboard: ' + await craft.clipboard.read()`, and an object reply
+    /// renders as `[object Object]`. It diverges from desktop
+    /// `clipboard/readText`, which answers `{"text":…}`; unifying the two is a
+    /// contract change the page has to be rewritten for, so it is not made here
+    /// by accident.
+    ///
+    /// `-hasStrings` is asked first because `-string` on its own cannot tell an
+    /// empty pasteboard from a refusal. On iOS 16+ reading contents another app
+    /// wrote presents a system confirmation, and a denial yields nil with no
+    /// API that reports why. So: no strings at all is answered `""`, which is
+    /// true; strings present but `-string` nil is `PermissionDenied`, because
+    /// something was there and we were not given it. Swift answered `""` to
+    /// both, and to a pasteboard holding an image.
+    ///
+    /// **This action can put an alert on the screen.** A page that calls it on
+    /// load shows the user an unexplained paste prompt. Two things I could not
+    /// verify and that want confirming on a device (the simulator never prompts,
+    /// because a same-app write never does): that `-hasStrings` is itself
+    /// prompt-free, and whether `-string` blocks until the user answers — if it
+    /// does, it blocks this whole synchronous dispatch, and the page's
+    /// 30-second request timeout can fire before the tap.
+    fn readClipboard(self: *Self) !void {
+        if (!clipboard_enabled) return bridge_error.BridgeError.PermissionDenied;
+
+        const pasteboard = try generalPasteboard();
+        if (!try hasStrings(pasteboard)) {
+            bridge_error.sendResultToJS(self.allocator, A.clipboard_read, reply_no_text);
+            return;
+        }
+
+        const text = try pasteboardString(pasteboard) orelse
+            return bridge_error.BridgeError.PermissionDenied;
+
+        const json = try quoteAsJsonString(self.allocator, text);
+        defer self.allocator.free(json);
+        bridge_error.sendResultToJS(self.allocator, A.clipboard_read, json);
+    }
+
+    /// Write `text` to the pasteboard. Requires the field; does not invent it.
+    ///
+    /// An explicitly-sent empty `text` is written and acknowledged. Clearing the
+    /// clipboard is a legitimate request, and `bridge_clipboard.zig`'s
+    /// `if (text.len == 0) return;` is a silent drop the caller cannot tell from
+    /// a success. Only an *absent* `text` is an error.
+    ///
+    /// A non-string `text` is `InvalidParameter`, not coerced. The legacy JS
+    /// posts whatever the caller passed without a `String(...)` — unlike
+    /// `craft-bridge.js:565` — so a page handing in a number reaches here, and
+    /// guessing what it meant would put a stringified guess on the user's
+    /// clipboard.
+    fn writeClipboard(self: *Self, data: []const u8) !void {
+        if (!clipboard_enabled) return bridge_error.BridgeError.PermissionDenied;
+
+        var parsed = std.json.parseFromSlice(std.json.Value, self.allocator, data, .{}) catch |err| switch (err) {
+            // An allocation failure is not a malformed payload, and telling the
+            // page INVALID_JSON about its own perfectly good JSON sends whoever
+            // debugs it to the wrong side of the bridge.
+            error.OutOfMemory => return err,
+            else => return bridge_error.BridgeError.InvalidJSON,
+        };
+        defer parsed.deinit();
+
+        const text = try requiredText(parsed.value);
+        try putString(self.allocator, text);
+        bridge_error.sendResultToJS(self.allocator, A.clipboard_write, reply_true);
+    }
+};
+
+/// The `text` field, or the reason it cannot be used. Pure, so the host tests
+/// can pin the three outcomes that the Swift `as? String` collapsed into one
+/// silent fall-through.
+fn requiredText(payload: std.json.Value) ![]const u8 {
+    const object = switch (payload) {
+        .object => |o| o,
+        else => return bridge_error.BridgeError.InvalidJSON,
+    };
+    const field = object.get("text") orelse return bridge_error.BridgeError.MissingData;
+    return switch (field) {
+        .string => |s| s,
+        else => bridge_error.BridgeError.InvalidParameter,
+    };
+}
+
+/// Render `s` as a complete JSON string literal, quotes included.
+///
+/// `bridge_error.appendJsonEscaped` rather than the hand-rolled loop in
+/// `bridge_clipboard.zig:200`, which misses every control byte below 0x20.
+/// Clipboard contents are arbitrary user bytes and this string is interpolated
+/// into JavaScript that `evaluateJavaScript:` then parses as source.
+///
+/// Allocated rather than built in a stack buffer: unlike a device description,
+/// clipboard text has no ceiling, and a fixed buffer would truncate the paste
+/// into a syntax error in the page.
+fn quoteAsJsonString(allocator: std.mem.Allocator, s: []const u8) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.append(allocator, '"');
+    try bridge_error.appendJsonEscaped(allocator, &out, s);
+    try out.append(allocator, '"');
+
+    return out.toOwnedSlice(allocator);
+}
+
+/// `+[UIPasteboard generalPasteboard]`.
+///
+/// Both nulls are real conditions and neither is skipped: `objc_getClass`
+/// answers null when UIKit is not in the process, and `generalPasteboard`
+/// answers nil in an app extension, where `UIPasteboard` is unavailable
+/// outright.
+fn generalPasteboard() !objc.id {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const UIPasteboard = objc.objc_getClass("UIPasteboard") orelse return error.ClassNotFound;
+    const sel = objc.sel_registerName("generalPasteboard") orelse return error.SelectorNotFound;
+    const pasteboard = objc.msgSendId(UIPasteboard, sel);
+    if (pasteboard == null) return error.NoPasteboard;
+    return pasteboard;
+}
+
+/// `-[UIPasteboard hasStrings]` — whether there is any text to ask for.
+fn hasStrings(pasteboard: objc.id) !bool {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const sel = objc.sel_registerName("hasStrings") orelse return error.SelectorNotFound;
+    return objc.msgSendBool(pasteboard, sel);
+}
+
+/// `-[UIPasteboard changeCount]`.
+///
+/// No helper for this in `objc_runtime.zig`, which stops at id/bool/stret, so
+/// the cast is local. `NSInteger` is 64-bit on every supported iOS target,
+/// hence `isize`.
+fn changeCount(pasteboard: objc.id) !isize {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const sel = objc.sel_registerName("changeCount") orelse return error.SelectorNotFound;
+    const Fn = *const fn (objc.id, objc.SEL) callconv(.c) isize;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    return func(pasteboard, sel);
+}
+
+/// `-[UIPasteboard string]`, borrowed as UTF-8. Null means the pasteboard
+/// returned nil — which the caller, not this function, decides the meaning of.
+///
+/// The bytes belong to the autoreleased NSString and live until the pool drains
+/// at the end of this run-loop turn; every caller here copies or compares
+/// before returning.
+fn pasteboardString(pasteboard: objc.id) !?[]const u8 {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const sel = objc.sel_registerName("string") orelse return error.SelectorNotFound;
+    const ns = objc.msgSendId(pasteboard, sel);
+    if (ns == null) return null;
+    return try nsStringUTF8(ns);
+}
+
+/// The UTF-8 bytes of an NSString.
+///
+/// The length comes from `-lengthOfBytesUsingEncoding:` rather than from
+/// scanning for the terminator: an NSString may legitimately contain U+0000,
+/// and `std.mem.span` would truncate there without saying so — the same quiet
+/// data loss as a dropped payload field, on bytes the user chose. A zero length
+/// means empty or not representable as UTF-8, and both answer `""`.
+fn nsStringUTF8(ns: objc.id) ![]const u8 {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const utf8 = objc.getNSStringUTF8(ns) orelse return error.NilString;
+
+    const sel_len = objc.sel_registerName("lengthOfBytesUsingEncoding:") orelse
+        return error.SelectorNotFound;
+    const Fn = *const fn (objc.id, objc.SEL, usize) callconv(.c) usize;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    const len = func(ns, sel_len, ns_utf8_string_encoding);
+
+    return utf8[0..len];
+}
+
+/// `-[UIPasteboard setString:]`, then evidence that it landed.
+///
+/// `setString:` returns void, so "the call did not crash" is not evidence, and
+/// replying `true` on that alone is the fabricated success this migration
+/// exists to remove. `-changeCount` is the one real observation available: a
+/// bump means the pasteboard genuinely changed.
+///
+/// A stationary count is not immediately a failure, though. I could not confirm
+/// that writing text identical to the current contents still bumps the count,
+/// and rejecting a correct "copy pressed twice" would be its own false report —
+/// so no bump falls back to reading the contents back and comparing bytes. Only
+/// *unchanged count and contents that are not what we asked for* is reported as
+/// `NativeCallFailed`. A nil read-back counts as "there is no text on the
+/// pasteboard", which matches a request to write an empty string and nothing
+/// else.
+///
+/// The fallback read can itself raise the iOS 16+ paste prompt, in the one case
+/// where it runs: the write appears not to have landed, so another app may
+/// still own the contents. That is rare enough to be worth the certainty, and
+/// the alternative is answering with a guess.
+fn putString(allocator: std.mem.Allocator, text: []const u8) !void {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const pasteboard = try generalPasteboard();
+    const before = try changeCount(pasteboard);
+
+    // Autoreleased by `+stringWithUTF8String:`; releasing it here would
+    // over-release something the pasteboard has retained.
+    const ns_text = try objc.createNSString(text, allocator);
+    const sel_set = objc.sel_registerName("setString:") orelse return error.SelectorNotFound;
+    objc.msgSendVoid1(pasteboard, sel_set, ns_text);
+
+    if (try changeCount(pasteboard) != before) return;
+
+    const current = try pasteboardString(pasteboard);
+    const landed = if (current) |c| std.mem.eql(u8, c, text) else text.len == 0;
+    if (!landed) return bridge_error.BridgeError.NativeCallFailed;
+}
+
+const testing = std.testing;
+
+test "the declared actions are the ones the handler serves" {
+    try testing.expectEqual(@as(usize, 2), capability_actions.len);
+    try testing.expectEqualStrings(A.clipboard_read, capability_actions[0].name);
+    try testing.expectEqualStrings(A.clipboard_write, capability_actions[1].name);
+
+    // `.result` for both, including the write. A `.none` write would let a
+    // page's `await craft.clipboard.write(x)` sit until the request timeout.
+    for (capability_actions) |decl| {
+        try testing.expectEqual(capabilities.Reply.result, decl.reply);
+        try testing.expectEqual(capabilities.ActionStatus.live, decl.status);
+    }
+}
+
+test "the action names match the Swift case labels exactly" {
+    // The conformance ratchet compares these strings against the labels in
+    // `CraftApp.swift`. A prettier spelling here would leave the Swift arm live
+    // and register the migration as having served an action nobody asked for.
+    try testing.expectEqualStrings("clipboardRead", A.clipboard_read);
+    try testing.expectEqualStrings("clipboardWrite", A.clipboard_write);
+}
+
+test "every declared action dispatches to something" {
+    // It may well fail for want of UIKit on the host — that is fine and is not
+    // what this asserts. What it rules out is a name in the table that
+    // `handleMessage` does not compare against, which is the drift the
+    // capabilities mechanism exists to prevent.
+    var bridge = ClipboardBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    for (capability_actions) |decl| {
+        bridge.handleMessage(decl.name, "{}") catch |err| {
+            try testing.expect(err != bridge_error.BridgeError.UnknownAction);
+        };
+    }
+}
+
+test "an action the namespace does not serve is reported, not ignored" {
+    var bridge = ClipboardBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("clipboardClear", "{}"),
+    );
+    // Near-misses too: the desktop spelling is a different action on a
+    // different namespace and must not be quietly accepted here.
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("writeText", "{\"text\":\"x\"}"),
+    );
+}
+
+test "an absent text field is refused rather than defaulted to empty" {
+    // The single highest-risk case in this migration: a page still posting the
+    // flat legacy shape (`text` beside `action`, no `d`) arrives as `{}`. A
+    // default would wipe the user's clipboard and report success.
+    const allocator = testing.allocator;
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, "{}", .{});
+    defer parsed.deinit();
+
+    try testing.expectError(bridge_error.BridgeError.MissingData, requiredText(parsed.value));
+}
+
+test "a legacy top-level text field does not count as the payload" {
+    const allocator = testing.allocator;
+    var parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        allocator,
+        "{\"action\":\"clipboardWrite\",\"callbackId\":\"cb_1\"}",
+        .{},
+    );
+    defer parsed.deinit();
+
+    try testing.expectError(bridge_error.BridgeError.MissingData, requiredText(parsed.value));
+}
+
+test "text is read from the field the page actually sends" {
+    const allocator = testing.allocator;
+    var parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        allocator,
+        "{\"text\":\"hello \\\"world\\\"\"}",
+        .{},
+    );
+    defer parsed.deinit();
+
+    try testing.expectEqualStrings("hello \"world\"", try requiredText(parsed.value));
+}
+
+test "an explicitly empty text is a value, not a missing field" {
+    // Clearing the clipboard is a legitimate request. `bridge_clipboard.zig`
+    // returns early on a zero-length string and acknowledges nothing, which the
+    // caller cannot tell from success.
+    const allocator = testing.allocator;
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, "{\"text\":\"\"}", .{});
+    defer parsed.deinit();
+
+    try testing.expectEqualStrings("", try requiredText(parsed.value));
+}
+
+test "a non-string text is refused rather than coerced" {
+    // The legacy JS posts whatever the caller passed, with no `String(...)`.
+    const allocator = testing.allocator;
+    for ([_][]const u8{
+        "{\"text\":42}",
+        "{\"text\":null}",
+        "{\"text\":true}",
+        "{\"text\":{\"a\":1}}",
+        "{\"text\":[\"a\"]}",
+    }) |payload| {
+        var parsed = try std.json.parseFromSlice(std.json.Value, allocator, payload, .{});
+        defer parsed.deinit();
+        try testing.expectError(bridge_error.BridgeError.InvalidParameter, requiredText(parsed.value));
+    }
+}
+
+test "a payload that is not an object is refused" {
+    const allocator = testing.allocator;
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, "\"hello\"", .{});
+    defer parsed.deinit();
+
+    try testing.expectError(bridge_error.BridgeError.InvalidJSON, requiredText(parsed.value));
+}
+
+test "malformed payload JSON is reported as such, not as a missing field" {
+    var bridge = ClipboardBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidJSON,
+        bridge.handleMessage(A.clipboard_write, "{\"text\":"),
+    );
+}
+
+test "the read reply is a bare JSON string, not an object" {
+    // `test-bridges.html` concatenates the result: `'Clipboard: ' + result`.
+    // An object would render as `[object Object]`.
+    const allocator = testing.allocator;
+    const json = try quoteAsJsonString(allocator, "hello");
+    defer allocator.free(json);
+    try testing.expectEqualStrings("\"hello\"", json);
+}
+
+test "read replies survive quotes, backslashes, newlines, and control bytes" {
+    // Clipboard contents are arbitrary user bytes and this lands inside
+    // JavaScript source. The escape loop in `bridge_clipboard.zig` passes
+    // control bytes through untouched, which produces invalid JSON.
+    const allocator = testing.allocator;
+    const json = try quoteAsJsonString(allocator, "a\"b\\c\nd\te\x01f");
+    defer allocator.free(json);
+    try testing.expectEqualStrings("\"a\\\"b\\\\c\\nd\\te\\u0001f\"", json);
+
+    // And it is still parseable as the string it started as.
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("a\"b\\c\nd\te\x01f", parsed.value.string);
+}
+
+test "an empty clipboard is reported as an empty string, and it parses" {
+    const allocator = testing.allocator;
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, reply_no_text, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("", parsed.value.string);
+}
+
+test "the write reply is bare true, which is what the page resolves with" {
+    const allocator = testing.allocator;
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, reply_true, .{});
+    defer parsed.deinit();
+    try testing.expect(parsed.value.bool);
+}
+
+test "a disabled clipboard rejects both actions rather than falling silent" {
+    // The Swift gate's failure mode was a promise that never settled. Whatever
+    // is decided about `enableClipboard`, that must not come back.
+    var bridge = ClipboardBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    setEnabled(false);
+    defer setEnabled(true);
+
+    try testing.expectError(
+        bridge_error.BridgeError.PermissionDenied,
+        bridge.handleMessage(A.clipboard_read, "{}"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.PermissionDenied,
+        bridge.handleMessage(A.clipboard_write, "{\"text\":\"x\"}"),
+    );
+}
+
+test "UIKit work is refused explicitly off Darwin instead of being skipped" {
+    if (builtin.target.os.tag.isDarwin()) return error.SkipZigTest;
+    try testing.expectError(error.UnsupportedPlatform, generalPasteboard());
+    try testing.expectError(error.UnsupportedPlatform, putString(testing.allocator, "x"));
+}

--- a/packages/zig/src/bridge_mobile_clipboard.zig
+++ b/packages/zig/src/bridge_mobile_clipboard.zig
@@ -48,6 +48,16 @@ const objc_runtime = @import("objc_runtime.zig");
 
 const objc = objc_runtime.objc;
 
+/// The same type as `objc.id` — `?*anyopaque` — spelled locally.
+///
+/// `objc_runtime.objc` is an empty struct off Darwin, and a function
+/// *signature* is analysed even when a comptime platform guard makes its body
+/// unreachable. Naming `objc.id` in the signatures below would therefore break
+/// the host build, which is exactly what the guards exist to prevent. It stays
+/// a single optional pointer, never `?objc.id`, because a double optional is
+/// illegal in a `callconv(.c)` type.
+const Id = ?*anyopaque;
+
 /// The action names, spelled exactly as the Swift `case` labels spell them.
 ///
 /// `test/ios_conformance_test.zig` matches the two lists by string, so a
@@ -187,6 +197,21 @@ pub const ClipboardBridge = struct {
         defer parsed.deinit();
 
         const text = try requiredText(parsed.value);
+
+        // `putString` builds its NSString with `+stringWithUTF8String:`, which
+        // reads a NUL-terminated C string and stops at the first zero byte. A
+        // `text` carrying one — JSON spells it `\u0000` and std.json decodes
+        // it to a real byte — would reach the pasteboard truncated, bump the
+        // change count, pass the verification below, and be acknowledged
+        // `true`: a write reported as successful that stored something the
+        // caller never asked for. Refusing is the honest answer. Writing it
+        // properly is possible (`+stringWithBytes:length:encoding:` takes an
+        // explicit length) and is a deliberate non-goal here, because that is a
+        // new capability rather than the removal of a false report.
+        if (std.mem.indexOfScalar(u8, text, 0) != null) {
+            return bridge_error.BridgeError.InvalidParameter;
+        }
+
         try putString(self.allocator, text);
         bridge_error.sendResultToJS(self.allocator, A.clipboard_write, reply_true);
     }
@@ -234,7 +259,7 @@ fn quoteAsJsonString(allocator: std.mem.Allocator, s: []const u8) ![]u8 {
 /// answers null when UIKit is not in the process, and `generalPasteboard`
 /// answers nil in an app extension, where `UIPasteboard` is unavailable
 /// outright.
-fn generalPasteboard() !objc.id {
+fn generalPasteboard() !Id {
     if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
 
     const UIPasteboard = objc.objc_getClass("UIPasteboard") orelse return error.ClassNotFound;
@@ -245,7 +270,7 @@ fn generalPasteboard() !objc.id {
 }
 
 /// `-[UIPasteboard hasStrings]` — whether there is any text to ask for.
-fn hasStrings(pasteboard: objc.id) !bool {
+fn hasStrings(pasteboard: Id) !bool {
     if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
 
     const sel = objc.sel_registerName("hasStrings") orelse return error.SelectorNotFound;
@@ -257,7 +282,7 @@ fn hasStrings(pasteboard: objc.id) !bool {
 /// No helper for this in `objc_runtime.zig`, which stops at id/bool/stret, so
 /// the cast is local. `NSInteger` is 64-bit on every supported iOS target,
 /// hence `isize`.
-fn changeCount(pasteboard: objc.id) !isize {
+fn changeCount(pasteboard: Id) !isize {
     if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
 
     const sel = objc.sel_registerName("changeCount") orelse return error.SelectorNotFound;
@@ -272,7 +297,7 @@ fn changeCount(pasteboard: objc.id) !isize {
 /// The bytes belong to the autoreleased NSString and live until the pool drains
 /// at the end of this run-loop turn; every caller here copies or compares
 /// before returning.
-fn pasteboardString(pasteboard: objc.id) !?[]const u8 {
+fn pasteboardString(pasteboard: Id) !?[]const u8 {
     if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
 
     const sel = objc.sel_registerName("string") orelse return error.SelectorNotFound;
@@ -288,7 +313,7 @@ fn pasteboardString(pasteboard: objc.id) !?[]const u8 {
 /// and `std.mem.span` would truncate there without saying so — the same quiet
 /// data loss as a dropped payload field, on bytes the user chose. A zero length
 /// means empty or not representable as UTF-8, and both answer `""`.
-fn nsStringUTF8(ns: objc.id) ![]const u8 {
+fn nsStringUTF8(ns: Id) ![]const u8 {
     if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
 
     const utf8 = objc.getNSStringUTF8(ns) orelse return error.NilString;
@@ -330,7 +355,15 @@ fn putString(allocator: std.mem.Allocator, text: []const u8) !void {
 
     // Autoreleased by `+stringWithUTF8String:`; releasing it here would
     // over-release something the pasteboard has retained.
-    const ns_text = try objc.createNSString(text, allocator);
+    //
+    // Nil is a real answer, not a can't-happen: `+stringWithUTF8String:` returns
+    // nil for bytes that are not valid UTF-8, and `text` comes from a JSON
+    // string that may hold an unpaired surrogate. Passing that nil on would send
+    // `-[UIPasteboard setString:nil]`, which raises an Objective-C exception
+    // that Zig has no way to catch — the process dies with the page's promise
+    // still pending, which is a worse answer than any error code.
+    const ns_text = try objc.createNSString(text, allocator) orelse
+        return bridge_error.BridgeError.InvalidParameter;
     const sel_set = objc.sel_registerName("setString:") orelse return error.SelectorNotFound;
     objc.msgSendVoid1(pasteboard, sel_set, ns_text);
 
@@ -457,6 +490,34 @@ test "a non-string text is refused rather than coerced" {
         defer parsed.deinit();
         try testing.expectError(bridge_error.BridgeError.InvalidParameter, requiredText(parsed.value));
     }
+}
+
+test "a text carrying a NUL is refused rather than written truncated" {
+    // `objc.createNSString` goes through `+stringWithUTF8String:`, which stops
+    // at the first zero byte. Writing the prefix would still bump the change
+    // count and so would be acknowledged `true` — the caller told a write
+    // succeeded that stored something it never asked for. This runs on every
+    // host because the refusal happens before any UIKit call.
+    var bridge = ClipboardBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    // `\u0000` is what `JSON.stringify` emits for a NUL, and std.json decodes
+    // it back to one, so this is the exact payload a page can produce.
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        bridge.handleMessage(A.clipboard_write, "{\"text\":\"a\\u0000b\"}"),
+    );
+
+    // Guard against the check being written as `startsWith`/`endsWith` or as a
+    // length test: the byte is refused wherever it sits, including alone.
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        bridge.handleMessage(A.clipboard_write, "{\"text\":\"\\u0000\"}"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        bridge.handleMessage(A.clipboard_write, "{\"text\":\"trailing\\u0000\"}"),
+    );
 }
 
 test "a payload that is not an object is refused" {

--- a/packages/zig/src/bridge_mobile_device.zig
+++ b/packages/zig/src/bridge_mobile_device.zig
@@ -1,0 +1,642 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const capabilities = @import("capabilities.zig");
+const bridge_error = @import("bridge_error.zig");
+const bridge_log = @import("bridge_log.zig");
+const objc_runtime = @import("objc_runtime.zig");
+
+const objc = objc_runtime.objc;
+
+/// What a page can ask about the process it is running inside: how much memory
+/// it holds, whether it is foregrounded, whether it has a network, and a way to
+/// get a line into the host's log.
+///
+/// The four are grouped because they share a property the migration cares
+/// about: each one has an answer that can be *checked*. `usedMB` moves when the
+/// app allocates, `getAppState` flips when the home button is pressed, a log
+/// line appears in `simctl launch --console-pty` or it does not. None of them
+/// can be satisfied by a stub that resolves and means nothing — which is what
+/// the fallback path did before any of this existed, and what nine deleted
+/// Android handlers did after it.
+///
+/// `getNetworkStatus` is the one that cannot be answered honestly from Zig in
+/// this build, and it is declared `.unavailable` rather than guessed at. See
+/// `network_status_reason`.
+pub const A = struct {
+    pub const get_memory_usage = "getMemoryUsage";
+    pub const get_app_state = "getAppState";
+    pub const get_network_status = "getNetworkStatus";
+    pub const log = "log";
+};
+
+/// Why `getNetworkStatus` is reachable and does not work.
+///
+/// There is no synchronous, non-deprecated iOS API that answers "is there a
+/// network". `NWPathMonitor` is the one Swift uses and the one to port, but it
+/// needs `-framework Network` linked into every consuming app — the iOS Zig
+/// target is a static library, so an unlinked framework is an undefined symbol
+/// at *app* link time, not a Zig build failure — plus a hand-built Objective-C
+/// block and a mutex-guarded cache, because the path handler runs on a
+/// background queue where `evaluateJavaScript:` is illegal and
+/// `request_context` (thread-local) is empty.
+///
+/// `SCNetworkReachability` would avoid the block and is deprecated since 17.4,
+/// cannot see wired ethernet, and on the simulator reports the *host Mac's*
+/// reachability. `getifaddrs` can say which interfaces are up but not whether
+/// anything is reachable, so it cannot fill a field named `isConnected`.
+///
+/// The alternative to this declaration is not "a working handler", it is
+/// `{"isConnected":true,"type":"unknown"}` — which is both what Swift returns
+/// before its first path callback lands and what `bridge_network.zig:81`
+/// hardcodes. A caller cannot tell that apart from a real reading, which makes
+/// it strictly worse than an error.
+pub const network_status_reason =
+    "NWPathMonitor needs -framework Network linked into the app; no synchronous " ++
+    "iOS API can answer isConnected without fabricating it";
+
+pub const capability_actions = [_]capabilities.ActionDecl{
+    .{ .name = A.get_memory_usage, .reply = .result },
+    .{ .name = A.get_app_state, .reply = .result },
+    // `.reply` stays `.result` because that is the contract the page's promise
+    // is written against; `.status` is the field that carries the bad news. A
+    // `.none` here would tell an app this action is fire-and-forget, which is a
+    // different and equally wrong claim.
+    .{
+        .name = A.get_network_status,
+        .reply = .result,
+        .status = .unavailable,
+        .reason = network_status_reason,
+    },
+    .{ .name = A.log, .reply = .result },
+};
+
+/// Which handler an action selects, or null for one this namespace does not
+/// serve.
+///
+/// Split out from `handleMessage` so the table-versus-dispatch agreement can be
+/// asserted on a host, where `task_info` would answer about the test runner and
+/// `UIApplication` does not exist at all. A test that had to *call* the
+/// handlers to discover which names route could only run on a device, which is
+/// to say it would never run.
+const Route = enum { memory_usage, app_state, network_status, log };
+
+fn routeFor(action: []const u8) ?Route {
+    if (std.mem.eql(u8, action, A.get_memory_usage)) return .memory_usage;
+    if (std.mem.eql(u8, action, A.get_app_state)) return .app_state;
+    if (std.mem.eql(u8, action, A.get_network_status)) return .network_status;
+    if (std.mem.eql(u8, action, A.log)) return .log;
+    return null;
+}
+
+pub const DeviceBridge = struct {
+    allocator: std.mem.Allocator,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator) Self {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(_: *Self) void {}
+
+    pub fn handleMessage(self: *Self, action: []const u8, data: []const u8) !void {
+        const route = routeFor(action) orelse return bridge_error.BridgeError.UnknownAction;
+        // Switched exhaustively rather than with an `else`, so adding a `Route`
+        // without a handler is a compile error instead of a silently
+        // unreachable action.
+        return switch (route) {
+            .memory_usage => self.getMemoryUsage(),
+            .app_state => self.getAppState(),
+            .network_status => getNetworkStatus(),
+            .log => self.log(data),
+        };
+    }
+
+    fn getMemoryUsage(self: *Self) !void {
+        const info = try readTaskBasicInfo();
+        var buf: [160]u8 = undefined;
+        const json = try formatMemoryUsage(&buf, info);
+        bridge_error.sendResultToJS(self.allocator, A.get_memory_usage, json);
+    }
+
+    fn getAppState(self: *Self) !void {
+        const json = try appStateJson(try readApplicationState());
+        bridge_error.sendResultToJS(self.allocator, A.get_app_state, json);
+    }
+
+    /// Refuse, with the reason the capability table already carries.
+    ///
+    /// `PlatformNotSupported` rather than `NativeCallFailed`: no native call
+    /// was attempted, and saying one failed would send an app looking for a
+    /// device problem that is really a missing `-framework Network`.
+    ///
+    /// A dispatcher note, because this error is load-bearing on the way out:
+    /// `ios_dispatch.route` hands an action to the Swift shim only when a Zig
+    /// handler returns `UnknownAction`. `DeviceBridge` is in that router's
+    /// `mobile_bridges`, so this refusal takes `getNetworkStatus` away from the
+    /// shim, which does answer it — with `isConnected` hardcoded `true` and
+    /// `type` `"unknown"` (CraftApp.swift:399) until `NWPathMonitor`'s first
+    /// callback lands, and correctly after. That is the whole trade: an error
+    /// always, against a fabricated reading in the startup window and a real
+    /// one afterwards. `bridge_mobile_display.zig` makes the same call for
+    /// `lockOrientation`. Undoing it means linking Network and making this
+    /// live, or dropping the action from `A` so the shim keeps serving it.
+    fn getNetworkStatus() !void {
+        return bridge_error.BridgeError.PlatformNotSupported;
+    }
+
+    /// The page's own log line, forwarded to the host sink.
+    ///
+    /// Delegated to `bridge_log` rather than reimplemented: it already owns the
+    /// level table, the case-insensitive matching that keeps an unrecognised
+    /// level audible instead of dropped, the `[page]` tag, and the 1024-byte
+    /// clamp. A second copy here is the one that would drift.
+    ///
+    /// It also replies `{"ok":true}` under this same action name, which is why
+    /// the table says `.result`. Swift's `case "log"` replies with nothing and
+    /// `craft-bridge.js`'s `_send` registers no pending call, so the reply is
+    /// dropped at the page — but the declaration has to describe what the code
+    /// does, not what the page happens to do with it.
+    ///
+    /// There is exactly one payload shape to accept: `{level, message}` inside
+    /// the envelope's `d`. The Swift template's `craft.log(msg)` posts a flat
+    /// `{action:'log', message:msg}` with no `t` and no `d` at all, so it never
+    /// reaches a handler — `ios_dispatch.handleMessage` rejects it at
+    /// `MissingType`. Treating that as a second shape to support here would
+    /// mean reading `message` off the envelope, which this bridge never sees.
+    ///
+    /// `bridge_log` defaults a missing `message` to `""`, so a payload without
+    /// one records an empty `[page]` line and still acks. That is the desktop
+    /// contract, shared deliberately rather than forked; `craft-bridge.js`
+    /// always sends `String(m)`, so only a hand-rolled `_post` can hit it.
+    fn log(self: *Self, data: []const u8) !void {
+        var host = bridge_log.LogBridge.init(self.allocator);
+        defer host.deinit();
+        try host.handleMessage(A.log, data);
+    }
+};
+
+// =============================================================================
+// getMemoryUsage
+// =============================================================================
+
+/// `mach_task_basic_info`, from `<mach/task_info.h>`.
+///
+/// Written out rather than `@cImport`ed because the iOS static library builds
+/// without an SDK sysroot. The layout is load-bearing in a way that is easy to
+/// miss: `task_info` validates the caller's element count against the flavour's
+/// own *before* writing anything, so a struct that is one field short does not
+/// come back truncated — it comes back `KERN_INVALID_ARGUMENT` with the buffer
+/// untouched. `system_enhancements.zig:932` passes 10 for this 48-byte struct
+/// and has therefore reported zero bytes used on every call it has ever made.
+const MachTimeValue = extern struct {
+    seconds: i32,
+    microseconds: i32,
+};
+
+const MachTaskBasicInfo = extern struct {
+    virtual_size: u64,
+    resident_size: u64,
+    resident_size_max: u64,
+    user_time: MachTimeValue,
+    system_time: MachTimeValue,
+    policy: i32,
+    suspend_count: i32,
+};
+
+const MACH_TASK_BASIC_INFO: c_uint = 20;
+
+/// Counted in 4-byte `integer_t` units, derived from the struct rather than
+/// written as 12, so a field added or removed above cannot leave the count
+/// behind.
+const MACH_TASK_BASIC_INFO_COUNT: c_uint = @sizeOf(MachTaskBasicInfo) / @sizeOf(i32);
+
+const KERN_SUCCESS: c_int = 0;
+
+const mach = struct {
+    /// `mach_task_self()` is a macro over this variable in `<mach/mach_init.h>`.
+    /// Reading the variable rather than calling the function form keeps this
+    /// off a libSystem symbol that only exists because the macro predates it.
+    extern "c" var mach_task_self_: c_uint;
+
+    /// `kern_return_t task_info(task_name_t, task_flavor_t, task_info_t, mach_msg_type_number_t *)`.
+    /// `task_info_t` is `integer_t *`; the flavour decides what is actually
+    /// written there, which is why the count argument exists.
+    extern "c" fn task_info(
+        target_task: c_uint,
+        flavor: c_uint,
+        task_info_out: *anyopaque,
+        task_info_count: *c_uint,
+    ) c_int;
+};
+
+/// Ask the kernel how much memory this process holds.
+///
+/// This is mach, not UIKit — there is no Objective-C on this path and no main
+/// thread requirement.
+///
+/// Deliberately not `NSProcessInfo.processInfo.physicalMemory`: that is total
+/// device RAM, not process usage, and substituting it would put a number in
+/// `usedMB` that is right by units and wrong by three orders of magnitude.
+fn readTaskBasicInfo() !MachTaskBasicInfo {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    // Zeroed rather than `undefined`: if a future flavour revision fills fewer
+    // fields than this struct has, the tail reads as zero instead of as stack
+    // garbage that would look like a plausible byte count.
+    var info: MachTaskBasicInfo = std.mem.zeroes(MachTaskBasicInfo);
+    var count: c_uint = MACH_TASK_BASIC_INFO_COUNT;
+
+    const kr = mach.task_info(
+        mach.mach_task_self_,
+        MACH_TASK_BASIC_INFO,
+        @ptrCast(&info),
+        &count,
+    );
+    // Swift answers a failure with `["usedMB": 0, "error": ...]`, which
+    // *resolves* the page's promise carrying a fabricated zero. An error is the
+    // only answer that lets a caller tell "this app uses no memory" from "the
+    // reading could not be taken".
+    if (kr != KERN_SUCCESS) return bridge_error.BridgeError.NativeCallFailed;
+
+    return info;
+}
+
+/// `resident_size` in hundredths of a megabyte, rounded half up.
+///
+/// Integer arithmetic rather than `round(usedMB * 100) / 100` on a float, so
+/// the rounding is a property of this function — assertable in a host test —
+/// rather than of whatever the formatter does at the second decimal place.
+/// 1 MiB is 1048576 bytes and half of it is 524288, which is the bias added
+/// before the divide.
+fn residentHundredthsMB(resident_size: u64) u64 {
+    // A resident set would have to reach 1.8e17 bytes for this multiply to
+    // overflow u64, which is about six orders of magnitude past any device.
+    return (resident_size * 100 + 524288) / 1048576;
+}
+
+/// Render the reading as the JSON the page receives.
+///
+/// `usedMB` is the only field anything reads by name today
+/// (`test-bridges.html`); `startProfiling`/`stopProfiling` take the whole
+/// object opaquely and diff it. The raw byte counts are kept anyway because
+/// they are what was actually measured — `usedMB` is a rounded view of
+/// `residentSize`, and a caller that wants the exact number should not have to
+/// un-round it.
+fn formatMemoryUsage(buf: []u8, info: MachTaskBasicInfo) ![]const u8 {
+    const hundredths = residentHundredthsMB(info.resident_size);
+    return std.fmt.bufPrint(
+        buf,
+        "{{\"usedMB\":{d}.{d:0>2},\"residentSize\":{d},\"virtualSize\":{d}}}",
+        .{ hundredths / 100, hundredths % 100, info.resident_size, info.virtual_size },
+    );
+}
+
+// =============================================================================
+// getAppState
+// =============================================================================
+
+/// `UIApplicationState`, from `UIKit/UIApplication.h`.
+const UIApplicationStateActive: c_long = 0;
+const UIApplicationStateInactive: c_long = 1;
+const UIApplicationStateBackground: c_long = 2;
+
+/// The reply for a `UIApplicationState` raw value.
+///
+/// A bare JSON string, not an object: `craft.d.ts` declares
+/// `getAppState(): 'active' | 'inactive' | 'background'`, and Swift resolves
+/// the callback with the bare string too. Wrapping it in `{"state":...}` would
+/// be a nicer shape and would break every existing caller.
+///
+/// An unrecognised value is an error rather than a default. Swift's ternary
+/// (`active ? ... : (background ? ... : "inactive")`) folds anything new into
+/// `"inactive"`, so a fourth state added by a future iOS would be reported as a
+/// real, wrong reading instead of as something craft does not understand.
+fn appStateJson(state: c_long) ![]const u8 {
+    return switch (state) {
+        UIApplicationStateActive => "\"active\"",
+        UIApplicationStateInactive => "\"inactive\"",
+        UIApplicationStateBackground => "\"background\"",
+        else => error.UnknownApplicationState,
+    };
+}
+
+/// `[[UIApplication sharedApplication] applicationState]`.
+///
+/// Called straight from the dispatcher and not hopped onto a queue, which is
+/// the non-obvious part: `applicationState` is main-thread-only, and this is
+/// already on it. `ios.zig:craftDidReceiveScriptMessage` is a
+/// `WKScriptMessageHandler` callback, WebKit delivers those on the main thread,
+/// and `ios_dispatch.handleMessage` runs synchronously from there. A
+/// `dispatch_async` here would be the bug, not the fix: it would move the reply
+/// off the frame that holds this call's id, and `request_context` is
+/// thread-local.
+fn readApplicationState() !c_long {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const UIApplication = objc.objc_getClass("UIApplication") orelse return error.ClassNotFound;
+    const sel_shared = objc.sel_registerName("sharedApplication") orelse return error.SelectorNotFound;
+
+    // Nil here is a real condition, not a failure to check for form's sake: an
+    // app extension has no shared application, and neither does a process that
+    // has not reached `UIApplicationMain` yet (`ios.zig:683` records the same).
+    // Reporting "active" in either case would be a reading nobody took.
+    const app = objc.msgSendId(UIApplication, sel_shared) orelse return error.NoSharedApplication;
+
+    const sel_state = objc.sel_registerName("applicationState") orelse return error.SelectorNotFound;
+    // `UIApplicationState` is an `NSInteger`, so `c_long` on every 64-bit Apple
+    // target. A narrower return type here would not fail to compile; it would
+    // read the low half of the register and be right by luck for 0, 1 and 2.
+    const Fn = *const fn (objc.id, objc.SEL) callconv(.c) c_long;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    return func(app, sel_state);
+}
+
+// =============================================================================
+// Tests
+//
+// Host-only, and that is the constraint that shaped the code above: the two
+// readings that need a device are behind `readTaskBasicInfo` and
+// `readApplicationState`, and everything that decides what the page sees —
+// routing, rounding, formatting, state mapping — is a pure function beside
+// them.
+// =============================================================================
+
+const testing = std.testing;
+
+test "every declared action is one the dispatcher routes" {
+    // The failure this whole mechanism exists to prevent: a name in the table
+    // that `handleMessage` has never heard of, which the manifest then promises
+    // to an app.
+    for (capability_actions) |decl| {
+        if (routeFor(decl.name) == null) {
+            std.debug.print("declared action '{s}' does not route\n", .{decl.name});
+            return error.DeclaredActionDoesNotRoute;
+        }
+    }
+}
+
+test "every route the dispatcher has is a declared action" {
+    // The other direction. `handleMessage` switches exhaustively over `Route`,
+    // so a route with no handler is a compile error; this is what catches a
+    // route with a handler and no declaration, which would be an action the
+    // page can call and the manifest denies exists.
+    //
+    // Counting alone would not: two table rows naming the same action still
+    // total four while leaving one route undeclared. So each declaration has to
+    // claim a *distinct* route, and every route has to be claimed.
+    var claimed = std.mem.zeroes([std.enums.values(Route).len]bool);
+    for (capability_actions) |decl| {
+        const route = routeFor(decl.name) orelse return error.DeclaredActionDoesNotRoute;
+        const slot = @backingInt(route);
+        if (claimed[slot]) {
+            std.debug.print("two declarations route to {s}\n", .{@tagName(route)});
+            return error.TwoDeclarationsShareARoute;
+        }
+        claimed[slot] = true;
+    }
+    for (claimed, 0..) |taken, slot| {
+        if (!taken) {
+            std.debug.print(
+                "route {s} has a handler but no capability_actions row\n",
+                .{@tagName(@as(Route, @fromBackingInt(@intCast(slot))))},
+            );
+            return error.RouteNotDeclared;
+        }
+    }
+}
+
+test "an action the namespace does not serve is reported, not ignored" {
+    var bridge = DeviceBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("noSuchAction", "{}"),
+    );
+    // Near misses too — casing and namespacing are how a real typo arrives.
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("getmemoryusage", "{}"),
+    );
+}
+
+test "getNetworkStatus refuses rather than answering" {
+    // The whole point of declaring it. `{"isConnected":true}` would resolve the
+    // caller's promise with something nothing measured.
+    var bridge = DeviceBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.PlatformNotSupported,
+        bridge.handleMessage(A.get_network_status, "{}"),
+    );
+}
+
+test "an unavailable action carries the reason with it" {
+    // `capabilities.ActionDecl` requires it, and the reason is the entire value
+    // of the declaration: "getNetworkStatus is unavailable" sends an app
+    // hunting its own bug, the framework note does not.
+    for (capability_actions) |decl| {
+        if (decl.status == .unavailable) {
+            try testing.expect(decl.reason != null);
+            try testing.expect(decl.reason.?.len > 0);
+        }
+    }
+}
+
+test "the task_info struct is the size the flavour expects" {
+    // 48 bytes, so 12 `integer_t` elements. The count is what `task_info`
+    // validates before it writes anything, and getting it wrong is silent:
+    // `system_enhancements.zig` passes 10 and has returned zeros ever since.
+    try testing.expectEqual(@as(usize, 48), @sizeOf(MachTaskBasicInfo));
+    try testing.expectEqual(@as(c_uint, 12), MACH_TASK_BASIC_INFO_COUNT);
+}
+
+test "the kernel accepts the flavour and count, and answers with a real reading" {
+    // The size check above is a proxy, and `system_enhancements.zig` would pass
+    // it too — its struct is also 48 bytes; it is the *count* it gets wrong, so
+    // `task_info` rejects the call and leaves the buffer as it found it. Only
+    // making the call tells the two apart.
+    //
+    // It runs here because this path is mach, not UIKit: no shared application,
+    // no main thread, no device. The answer is about the test runner, and that
+    // is enough — what is under test is that the declarations link, the
+    // argument types are right, and the kernel does not refuse.
+    if (!builtin.target.os.tag.isDarwin()) return error.SkipZigTest;
+
+    const info = try readTaskBasicInfo();
+    // A process far enough along to run a test holds pages. Zero is the exact
+    // signature of a rejected count, which is the failure this exists to catch.
+    try testing.expect(info.resident_size > 0);
+    try testing.expect(info.virtual_size >= info.resident_size);
+}
+
+test "a missing UIApplication is reported rather than read past" {
+    // macOS has no `UIApplication`, which is the same shape as the two cases
+    // that matter on a device: an app extension, and a process that has not
+    // reached `UIApplicationMain`. Without this the null check is code nothing
+    // has ever taken, and the alternative to taking it is reporting a state
+    // nobody read.
+    //
+    // Pinned to macOS rather than Darwin: on iOS the class is present and the
+    // right answer is a state, not an error.
+    if (builtin.target.os.tag != .macos) return error.SkipZigTest;
+
+    try testing.expectError(error.ClassNotFound, readApplicationState());
+}
+
+test "megabytes are rounded to two places, half up" {
+    try testing.expectEqual(@as(u64, 0), residentHundredthsMB(0));
+    try testing.expectEqual(@as(u64, 100), residentHundredthsMB(1024 * 1024));
+    try testing.expectEqual(@as(u64, 150), residentHundredthsMB(1536 * 1024));
+    // 123456789 / 1048576 = 117.7376…, so 11773.76 hundredths, rounding up.
+    try testing.expectEqual(@as(u64, 11774), residentHundredthsMB(123456789));
+    // Half a hundredth, exactly at the boundary, goes up.
+    try testing.expectEqual(@as(u64, 1), residentHundredthsMB(5243));
+    // And a hair under it does not.
+    try testing.expectEqual(@as(u64, 0), residentHundredthsMB(5242));
+}
+
+test "the memory reply is shaped the way the page reads it" {
+    var buf: [160]u8 = undefined;
+    const json = try formatMemoryUsage(&buf, .{
+        .virtual_size = 400000000,
+        .resident_size = 123456789,
+        .resident_size_max = 123456789,
+        .user_time = .{ .seconds = 0, .microseconds = 0 },
+        .system_time = .{ .seconds = 0, .microseconds = 0 },
+        .policy = 0,
+        .suspend_count = 0,
+    });
+    try testing.expectEqualStrings(
+        "{\"usedMB\":117.74,\"residentSize\":123456789,\"virtualSize\":400000000}",
+        json,
+    );
+
+    // And it is JSON, not just the right characters — `usedMB` in particular
+    // has to survive as a number, which a zero-padded fraction can break.
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqual(@as(f64, 117.74), parsed.value.object.get("usedMB").?.float);
+    try testing.expectEqual(@as(i64, 123456789), parsed.value.object.get("residentSize").?.integer);
+}
+
+test "a fraction below ten keeps its leading zero" {
+    // `{d}.{d}` would render 4 hundredths as `1.4` — a tenfold error that no
+    // parser would reject.
+    var buf: [160]u8 = undefined;
+    const json = try formatMemoryUsage(&buf, .{
+        .virtual_size = 0,
+        .resident_size = 1024 * 1024 + 41943, // ~1.04 MiB
+        .resident_size_max = 0,
+        .user_time = .{ .seconds = 0, .microseconds = 0 },
+        .system_time = .{ .seconds = 0, .microseconds = 0 },
+        .policy = 0,
+        .suspend_count = 0,
+    });
+    try testing.expect(std.mem.startsWith(u8, json, "{\"usedMB\":1.04,"));
+}
+
+test "app states map to the three strings the SDK type declares" {
+    try testing.expectEqualStrings("\"active\"", try appStateJson(0));
+    try testing.expectEqualStrings("\"inactive\"", try appStateJson(1));
+    try testing.expectEqualStrings("\"background\"", try appStateJson(2));
+}
+
+test "an app state UIKit has not defined yet is not folded into inactive" {
+    // Swift's ternary reports any unknown value as "inactive", which is a real
+    // answer that happens to be wrong. This says it does not know.
+    try testing.expectError(error.UnknownApplicationState, appStateJson(3));
+    try testing.expectError(error.UnknownApplicationState, appStateJson(-1));
+}
+
+test "the app state reply is a bare JSON string, not an object" {
+    // `craft.d.ts` declares `getAppState(): 'active' | 'inactive' | 'background'`
+    // and `craft-bridge.js` resolves with `payload || {}`, so the reply has to
+    // parse as a string and be non-empty.
+    const parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        testing.allocator,
+        try appStateJson(2),
+        .{},
+    );
+    defer parsed.deinit();
+    try testing.expectEqualStrings("background", parsed.value.string);
+}
+
+test "a page's message and level survive the trip to the host sink" {
+    // The field-name trap, checked where it can actually fail.
+    //
+    // The version this replaces re-declared `bridge_log`'s parse shape locally
+    // and asserted that `std.json` filled it in — which is true of any two
+    // matching structs and says nothing about the code under test. Rename
+    // `message` inside `bridge_log` and that test stayed green while every page
+    // log became an empty line, which is the exact bug it claimed to guard.
+    //
+    // So: drive the real dispatcher, point the real sink at a file, and read
+    // the record back.
+    const host_log = @import("log.zig");
+    const io = @import("io_context.zig").get();
+    const path = "craft-device-log-test.txt";
+    std.Io.Dir.cwd().deleteFile(io, path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(io, path) catch {};
+    // Put the sink back for whatever runs next in this binary; the config is
+    // process-global, and leaving it muted would hide other tests' output.
+    defer host_log.init(.{}) catch {};
+
+    try host_log.init(.{
+        .output_file = path,
+        .min_level = .Debug,
+        .enable_colors = false,
+        .enable_timestamps = false,
+        .mirror_to_stderr = false,
+    });
+
+    var bridge = DeviceBridge.init(testing.allocator);
+    defer bridge.deinit();
+    try bridge.handleMessage(A.log,
+        \\{"level":"warn","message":"a page said this"}
+    );
+    // Closes the file, so the read below sees everything written.
+    host_log.deinit();
+
+    var read_buf: [4096]u8 = undefined;
+    const file = try std.Io.Dir.cwd().openFile(io, path, .{});
+    defer file.close(io);
+    const contents = read_buf[0..try file.readPositionalAll(io, &read_buf, 0)];
+
+    const at = std.mem.indexOf(u8, contents, "[page] a page said this") orelse {
+        std.debug.print("the page's message never reached the sink:\n{s}\n", .{contents});
+        return error.PageMessageNotRecorded;
+    };
+    // The level, on that same record rather than anywhere in the file — a
+    // stray WARN from an unrelated line would otherwise pass this for free.
+    const line_start = if (std.mem.lastIndexOfScalar(u8, contents[0..at], '\n')) |nl| nl + 1 else 0;
+    try testing.expect(std.mem.indexOf(u8, contents[line_start..at], "WARN") != null);
+}
+
+test "a log payload that will not parse is refused, not acknowledged" {
+    // Also proves the delegation is real: `InvalidJSON` is `bridge_log`'s
+    // answer, so seeing it here means `A.log` reached `LogBridge` rather than
+    // something local that shrugged and replied ok.
+    var bridge = DeviceBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidJSON,
+        bridge.handleMessage(A.log, "not json"),
+    );
+}
+
+test "the action names are the ones the Swift dispatcher answers" {
+    // Spelled out because these strings are the wire contract, and a rename
+    // here is invisible until a page stops being answered.
+    // `ios_conformance_test` scans this file's `A` block against
+    // `CraftApp.swift` and would catch a name the spec does not have; it would
+    // not catch all four being renamed in step, which is what this holds.
+    try testing.expectEqualStrings("getMemoryUsage", A.get_memory_usage);
+    try testing.expectEqualStrings("getAppState", A.get_app_state);
+    try testing.expectEqualStrings("getNetworkStatus", A.get_network_status);
+    try testing.expectEqualStrings("log", A.log);
+}

--- a/packages/zig/src/bridge_mobile_display.zig
+++ b/packages/zig/src/bridge_mobile_display.zig
@@ -1,0 +1,660 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const capabilities = @import("capabilities.zig");
+const bridge_error = @import("bridge_error.zig");
+const objc_runtime = @import("objc_runtime.zig");
+
+const objc = objc_runtime.objc;
+
+/// The `mobile` display group: the app icon's badge, the idle timer, and the
+/// two orientation actions.
+///
+/// These five arrived together because they are the ones whose Swift arms are
+/// *reachable but not reliable*, and the difference between them is worth
+/// stating up front.
+///
+/// `setBadge` / `clearBadge` / `setKeepAwake` are ported and live. Each ends by
+/// reading the value back out of UIKit and replying with what UIKit reports, so
+/// a reply here is an observation, not an assertion — the property
+/// `bridge_mobile.zig` chose `getDeviceInfo` for, applied to a setter.
+///
+/// `lockOrientation` / `unlockOrientation` are declared `.unavailable` and
+/// return an error. Swift does not lock anything: it writes `lockedOrientation`
+/// that nothing reads, and `supportedInterfaceOrientations` is overridden
+/// nowhere in the template, so `requestGeometryUpdate` is a one-shot nudge the
+/// system re-evaluates on the next rotation. A real lock needs a root view
+/// controller subclass overriding `supportedInterfaceOrientations`, and
+/// `ios.zig` instantiates a stock `UIViewController`. That is a startup-path
+/// change, not a bridge action, so this file says so instead of replying
+/// `true` to a request it did not carry out.
+///
+/// ## Three divergences from Swift, all deliberate
+///
+/// **No config gate.** Swift's dispatcher guards `setKeepAwake` and both
+/// orientation actions on `config.enableKeepAwake` / `enableOrientationLock`,
+/// which default to `false`, and there is no `else` — so in a default-built app
+/// today those calls reply *nothing at all* and the page's promise hangs to
+/// timeout. No config is plumbed into the Zig bridge, so these serve
+/// unconditionally. That is a behavior change; it is also the only one of the
+/// two options that answers the caller.
+///
+/// **No thread hop.** Every Swift helper here wraps its UIKit work in
+/// `DispatchQueue.main.async`. `ios_dispatch.handleMessage` is already called
+/// from `craftDidReceiveScriptMessage`, a `WKScriptMessageHandler` callback,
+/// which WebKit delivers on the main thread. The hop is redundant, and there is
+/// no dispatch-block machinery in this repo to reproduce it with.
+///
+/// **No badge authorization.** Swift calls
+/// `requestAuthorizationWithOptions:` and rejects with "Badge permission
+/// denied". Reporting that from Zig needs a *capturing* block — every block in
+/// this repo is static and non-capturing — so it is not attempted here. The
+/// consequence is stated rather than hidden: Zig sets the number and proves
+/// UIKit stored it, which is **not** proof that the springboard draws it. An
+/// unauthorized app gets `{"count":N}` and an invisible badge, and will never
+/// see "Badge permission denied" or the first-run prompt Swift triggers.
+pub const A = struct {
+    pub const set_badge = "setBadge";
+    pub const clear_badge = "clearBadge";
+    pub const set_keep_awake = "setKeepAwake";
+    pub const lock_orientation = "lockOrientation";
+    pub const unlock_orientation = "unlockOrientation";
+};
+
+pub const capability_actions = [_]capabilities.ActionDecl{
+    .{ .name = A.set_badge, .reply = .result },
+    .{ .name = A.clear_badge, .reply = .result },
+    .{ .name = A.set_keep_awake, .reply = .result },
+    .{
+        .name = A.lock_orientation,
+        .reply = .result,
+        .status = .unavailable,
+        .reason = "needs a root view controller overriding supportedInterfaceOrientations; craft's is a stock UIViewController",
+    },
+    .{
+        .name = A.unlock_orientation,
+        .reply = .result,
+        .status = .unavailable,
+        .reason = "nothing to unlock: no orientation lock is ever installed",
+    },
+};
+
+pub const DisplayBridge = struct {
+    allocator: std.mem.Allocator,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator) Self {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(_: *Self) void {}
+
+    pub fn handleMessage(self: *Self, action: []const u8, data: []const u8) !void {
+        if (std.mem.eql(u8, action, A.set_badge)) {
+            try self.setBadge(data);
+        } else if (std.mem.eql(u8, action, A.clear_badge)) {
+            try self.clearBadge();
+        } else if (std.mem.eql(u8, action, A.set_keep_awake)) {
+            try self.setKeepAwake(data);
+        } else if (std.mem.eql(u8, action, A.lock_orientation)) {
+            try self.lockOrientation(data);
+        } else if (std.mem.eql(u8, action, A.unlock_orientation)) {
+            try self.unlockOrientation();
+        } else {
+            return bridge_error.BridgeError.UnknownAction;
+        }
+    }
+
+    /// `{"count":N}` in, `{"count":<what UIKit now reports>}` out.
+    ///
+    /// The reply is an object, not the bare `true` Swift resolves:
+    /// `craft-bridge.js` settles with `payload || {}`, so any falsy scalar
+    /// arrives at the page as `{}` and carries nothing. An object also lets the
+    /// value be checked, which a `true` never could.
+    fn setBadge(self: *Self, data: []const u8) !void {
+        const requested = try badgeCountFrom(self.allocator, data);
+        try self.replyBadge(A.set_badge, try applyBadge(requested));
+    }
+
+    /// The same path as `setBadge` with a fixed 0, so the two cannot drift.
+    ///
+    /// `clearBadge` sends no payload at all, so there is nothing to parse:
+    /// `payloadOf` hands this `{}` and the count is not the caller's to choose.
+    fn clearBadge(self: *Self) !void {
+        try self.replyBadge(A.clear_badge, try applyBadge(0));
+    }
+
+    fn replyBadge(self: *Self, action: []const u8, observed: i64) !void {
+        var buf: [48]u8 = undefined;
+        bridge_error.sendResultToJS(self.allocator, action, try renderBadgeReply(&buf, observed));
+    }
+
+    /// `{"enabled":<bool>}` in, `{"enabled":<what UIKit now reports>}` out.
+    ///
+    /// Swift also stores `isKeepingAwake`, which nothing in the template ever
+    /// reads. It is not ported: a variable with no reader cannot be wrong, and
+    /// carrying it would suggest something restores it later. Nothing does —
+    /// `idleTimerDisabled` is per-application state UIKit drops when the app
+    /// backgrounds or relaunches, and neither implementation reinstates it.
+    fn setKeepAwake(self: *Self, data: []const u8) !void {
+        const requested = try keepAwakeFrom(self.allocator, data);
+        const observed = try applyKeepAwake(requested);
+
+        var buf: [32]u8 = undefined;
+        bridge_error.sendResultToJS(
+            self.allocator,
+            A.set_keep_awake,
+            try renderKeepAwakeReply(&buf, observed),
+        );
+    }
+
+    /// Validates the orientation, then refuses.
+    ///
+    /// The validation is not ceremony. Erroring on an unrecognized name gives
+    /// the caller `InvalidParameter` and erroring on a good one gives
+    /// `PlatformNotSupported`, which is the difference between "you asked for
+    /// something that does not exist" and "craft cannot do this at all". Swift
+    /// conflates them: its `default:` arm turns any unknown string into `.all`
+    /// and then reports success.
+    ///
+    /// `PlatformNotSupported` matters beyond the message. `ios_dispatch.route`
+    /// passes only `UnknownAction` to the host shim, so returning a real error
+    /// here stops the Swift arm from being asked to try the same thing — which
+    /// is right, because what it would do is either nothing observable or, when
+    /// `connectedScenes` is empty (the fixture has no scene manifest and uses
+    /// the legacy `UIApplicationMain` lifecycle), its `guard ... else { return }`
+    /// sits above `resolveCallback` and the promise hangs.
+    fn lockOrientation(self: *Self, data: []const u8) !void {
+        _ = try requestedOrientation(self.allocator, data);
+        return bridge_error.BridgeError.PlatformNotSupported;
+    }
+
+    /// Refuses, with nothing to validate: the page sends no payload.
+    fn unlockOrientation(self: *Self) !void {
+        _ = self;
+        return bridge_error.BridgeError.PlatformNotSupported;
+    }
+};
+
+// =============================================================================
+// Reply bodies
+// =============================================================================
+
+/// The reply shapes, in one place so the handlers and the tests cannot disagree.
+///
+/// Split out because a test that re-typed the format string would pass no
+/// matter what the handler sent — it would be asserting that `std.fmt` works.
+/// These are the strings the page actually receives.
+fn renderBadgeReply(buf: []u8, observed: i64) ![]const u8 {
+    return std.fmt.bufPrint(buf, "{{\"count\":{d}}}", .{observed});
+}
+
+fn renderKeepAwakeReply(buf: []u8, observed: bool) ![]const u8 {
+    return std.fmt.bufPrint(buf, "{{\"enabled\":{}}}", .{observed});
+}
+
+// =============================================================================
+// Payload parsing
+// =============================================================================
+
+/// The `count` the page sent, or an error naming why it could not be used.
+///
+/// Never defaults. A missing `count` is `MissingData`, not 0, because 0 is
+/// `clearBadge` — a dropped field would quietly perform a *different action*
+/// than the one asked for. That is the `bridge_app.zig` badge bug exactly: the
+/// desktop accepted only `{badge:"..."}` while every caller sent `{count:N}`,
+/// and the dock tile never updated while the call reported success.
+///
+/// Swift's `body["count"] as? Int` returns nil for a fractional number and its
+/// dispatcher has no `else`, so `setBadge(3.7)` today replies nothing and hangs
+/// the promise. Here a whole `3.0` is accepted — JSON has one number type and a
+/// page that computed its count with arithmetic legitimately produces it — and
+/// anything else is refused out loud.
+fn badgeCountFrom(allocator: std.mem.Allocator, data: []const u8) !i64 {
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch
+        return bridge_error.BridgeError.InvalidJSON;
+    defer parsed.deinit();
+
+    const root = switch (parsed.value) {
+        .object => |obj| obj,
+        else => return bridge_error.BridgeError.InvalidJSON,
+    };
+
+    const count: i64 = switch (root.get("count") orelse return bridge_error.BridgeError.MissingData) {
+        .integer => |n| n,
+        .float => |f| blk: {
+            // Beyond 2^53 an f64 no longer names one integer, so a value out
+            // there is not a count anyone can have meant.
+            if (f != @trunc(f) or f < 0 or f > 9007199254740991.0)
+                return bridge_error.BridgeError.InvalidParameter;
+            break :blk @intFromFloat(f);
+        },
+        // `std.json` emits `.number_string` for integers too large for i64.
+        else => return bridge_error.BridgeError.InvalidParameter,
+    };
+
+    // UIKit's behavior for a negative badge is undefined, and the page's own
+    // type says `number`, not "any number".
+    if (count < 0) return bridge_error.BridgeError.InvalidParameter;
+    return count;
+}
+
+/// The `enabled` the page sent.
+///
+/// Booleans only — no truthiness coercion. `setKeepAwake(1)` is a caller bug
+/// worth reporting, and guessing what a non-boolean meant is how a handler ends
+/// up doing the opposite of what was asked.
+fn keepAwakeFrom(allocator: std.mem.Allocator, data: []const u8) !bool {
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch
+        return bridge_error.BridgeError.InvalidJSON;
+    defer parsed.deinit();
+
+    const root = switch (parsed.value) {
+        .object => |obj| obj,
+        else => return bridge_error.BridgeError.InvalidJSON,
+    };
+
+    return switch (root.get("enabled") orelse return bridge_error.BridgeError.MissingData) {
+        .bool => |b| b,
+        else => return bridge_error.BridgeError.InvalidParameter,
+    };
+}
+
+/// The orientations Swift's switch recognizes.
+///
+/// Five, not the two `packages/typescript/types/craft.d.ts:528` publishes —
+/// the TS surface and the Swift switch already disagree, and the wire is what a
+/// page can actually reach.
+pub const Orientation = enum {
+    portrait,
+    portrait_upside_down,
+    landscape_left,
+    landscape_right,
+    landscape,
+
+    pub fn fromName(name: []const u8) ?Orientation {
+        const table = .{
+            .{ "portrait", Orientation.portrait },
+            .{ "portraitUpsideDown", Orientation.portrait_upside_down },
+            .{ "landscapeLeft", Orientation.landscape_left },
+            .{ "landscapeRight", Orientation.landscape_right },
+            .{ "landscape", Orientation.landscape },
+        };
+        inline for (table) |entry| {
+            if (std.mem.eql(u8, name, entry[0])) return entry[1];
+        }
+        return null;
+    }
+
+    /// `UIInterfaceOrientationMask`, which is `1 << UIInterfaceOrientation`.
+    ///
+    /// Spelled out because craft imports no UIKit headers, and kept even though
+    /// nothing sends it yet: it is the table the eventual implementation needs,
+    /// and the two easy ways to get it wrong — `landscapeLeft` is 4 and
+    /// `landscapeRight` is 3, so their masks are 16 and 8, the reverse of the
+    /// order they read in — are pinned by a test below rather than left to be
+    /// rediscovered.
+    pub fn mask(self: Orientation) c_ulong {
+        return switch (self) {
+            .portrait => 2,
+            .portrait_upside_down => 4,
+            .landscape_right => 8,
+            .landscape_left => 16,
+            .landscape => 24,
+        };
+    }
+};
+
+fn requestedOrientation(allocator: std.mem.Allocator, data: []const u8) !Orientation {
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch
+        return bridge_error.BridgeError.InvalidJSON;
+    defer parsed.deinit();
+
+    const root = switch (parsed.value) {
+        .object => |obj| obj,
+        else => return bridge_error.BridgeError.InvalidJSON,
+    };
+
+    const name = switch (root.get("orientation") orelse return bridge_error.BridgeError.MissingData) {
+        .string => |s| s,
+        else => return bridge_error.BridgeError.InvalidParameter,
+    };
+
+    return Orientation.fromName(name) orelse bridge_error.BridgeError.InvalidParameter;
+}
+
+// =============================================================================
+// UIKit
+// =============================================================================
+
+/// Set the icon badge, then report what UIKit says it is.
+///
+/// Two setters, on purpose. `setBadgeCount:withCompletionHandler:` (iOS 16+) is
+/// the supported route and is sent whenever `UNUserNotificationCenter` is in
+/// the process; `setApplicationIconBadgeNumber:` is deprecated as of iOS 17 but
+/// still present and, unlike the modern one, is synchronous — which is why it
+/// is the one whose effect can be read back on the next line. Both are handed
+/// the same number, so the asynchronous one landing later changes nothing.
+///
+/// The read-back is the point. Without it this function would be asserting that
+/// the badge is set; with it, the reply carries a number that came back out of
+/// UIKit. It still does not prove the badge is *visible* — that needs the
+/// authorization Swift requests and this does not (see the note on `A`).
+///
+/// If the deprecated pair ever disappears, this returns an error rather than an
+/// unverified success. Fixing that properly means a capturing block for the
+/// modern setter's completion handler, which is new machinery and should be a
+/// decision, not a side effect.
+fn applyBadge(count: i64) !i64 {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const wanted = std.math.cast(c_long, count) orelse return bridge_error.BridgeError.InvalidParameter;
+
+    const UIApplicationClass = objc.objc_getClass("UIApplication") orelse return error.ClassNotFound;
+    const sel_shared = objc.sel_registerName("sharedApplication") orelse return error.SelectorNotFound;
+    const app = objc.msgSendId(UIApplicationClass, sel_shared);
+    if (app == null) return error.NoSharedApplication;
+
+    const modern_sent = setBadgeThroughNotificationCenter(wanted);
+
+    const can_set = responds(app, "setApplicationIconBadgeNumber:");
+    if (!can_set and !modern_sent) return error.BadgeApiUnavailable;
+
+    if (can_set) {
+        const sel_set = objc.sel_registerName("setApplicationIconBadgeNumber:") orelse
+            return error.SelectorNotFound;
+        const SetFn = *const fn (objc.id, objc.SEL, c_long) callconv(.c) void;
+        const set: SetFn = @ptrCast(&objc.objc_msgSend);
+        set(app, sel_set, wanted);
+    }
+
+    if (!responds(app, "applicationIconBadgeNumber")) return error.BadgeNotVerifiable;
+
+    const sel_get = objc.sel_registerName("applicationIconBadgeNumber") orelse
+        return error.SelectorNotFound;
+    const GetFn = *const fn (objc.id, objc.SEL) callconv(.c) c_long;
+    const get: GetFn = @ptrCast(&objc.objc_msgSend);
+
+    const observed = get(app, sel_get);
+    if (observed != wanted) return error.BadgeNotApplied;
+    return @intCast(observed);
+}
+
+/// Send `setBadgeCount:withCompletionHandler:`. False means it was not sent.
+///
+/// `objc_getClass` returning null here is a real and expected condition, not a
+/// failure: `packages/ios/fixtures/zig-slice/build-and-run.sh` links only
+/// UIKit, WebKit and Foundation, so on that fixture UserNotifications is not in
+/// the process at all. The caller decides what to do about it — this returns
+/// what happened rather than swallowing it.
+///
+/// The completion handler is `nullable` in the header, so nil is legal and no
+/// block is needed. Note that `requestAuthorizationWithOptions:`, which Swift
+/// also calls, is *not* nullable there — passing nil to that one crashes, which
+/// is part of why authorization is not attempted here.
+fn setBadgeThroughNotificationCenter(count: c_long) bool {
+    const UNCenterClass = objc.objc_getClass("UNUserNotificationCenter") orelse return false;
+    const sel_current = objc.sel_registerName("currentNotificationCenter") orelse return false;
+    const center = objc.msgSendId(UNCenterClass, sel_current);
+    if (center == null) return false;
+
+    if (!responds(center, "setBadgeCount:withCompletionHandler:")) return false;
+
+    const sel_set = objc.sel_registerName("setBadgeCount:withCompletionHandler:") orelse return false;
+    const Fn = *const fn (objc.id, objc.SEL, c_long, ?*anyopaque) callconv(.c) void;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    func(center, sel_set, count, null);
+    return true;
+}
+
+/// Disable or re-enable the idle timer, then report what UIKit says it is.
+///
+/// The getter is `isIdleTimerDisabled`, not `idleTimerDisabled`: the property
+/// declares `getter=isIdleTimerDisabled`. A wrong selector is not a compile
+/// error — it reaches `doesNotRecognizeSelector:` at runtime — so it is worth
+/// the line to say why this one looks asymmetric with its setter.
+fn applyKeepAwake(enabled: bool) !bool {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const UIApplicationClass = objc.objc_getClass("UIApplication") orelse return error.ClassNotFound;
+    const sel_shared = objc.sel_registerName("sharedApplication") orelse return error.SelectorNotFound;
+    const app = objc.msgSendId(UIApplicationClass, sel_shared);
+    if (app == null) return error.NoSharedApplication;
+
+    const sel_set = objc.sel_registerName("setIdleTimerDisabled:") orelse return error.SelectorNotFound;
+    const SetFn = *const fn (objc.id, objc.SEL, bool) callconv(.c) void;
+    const set: SetFn = @ptrCast(&objc.objc_msgSend);
+    set(app, sel_set, enabled);
+
+    const sel_get = objc.sel_registerName("isIdleTimerDisabled") orelse return error.SelectorNotFound;
+    const GetFn = *const fn (objc.id, objc.SEL) callconv(.c) bool;
+    const get: GetFn = @ptrCast(&objc.objc_msgSend);
+
+    const observed = get(app, sel_get);
+    if (observed != enabled) return error.KeepAwakeNotApplied;
+    return observed;
+}
+
+/// `-[NSObject respondsToSelector:]`.
+///
+/// The version gate craft uses everywhere instead of parsing an OS version —
+/// `macos.zig:582` records why: the question is always whether *this* selector
+/// exists, and asking that directly cannot drift from what the SDK did.
+/// `objc_runtime.zig` has no one-argument BOOL sender, hence the local type.
+fn responds(target: objc.id, selector_name: [:0]const u8) bool {
+    const sel_responds = objc.sel_registerName("respondsToSelector:") orelse return false;
+    const selector = objc.sel_registerName(selector_name) orelse return false;
+    const Fn = *const fn (objc.id, objc.SEL, objc.SEL) callconv(.c) bool;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    return func(target, sel_responds, selector);
+}
+
+const testing = std.testing;
+
+test "the declared table and the dispatcher serve the same actions" {
+    // A table and a dispatch chain that disagree is the failure the whole
+    // capabilities mechanism exists to make impossible, and it is cheapest to
+    // catch here rather than from a page whose promise never settles.
+    try testing.expectEqual(@as(usize, 5), capability_actions.len);
+
+    const payloads = [_][]const u8{
+        "{\"count\":3}",
+        "{}",
+        "{\"enabled\":true}",
+        "{\"orientation\":\"portrait\"}",
+        "{}",
+    };
+    try testing.expectEqual(capability_actions.len, payloads.len);
+
+    var bridge = DisplayBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    for (capability_actions, payloads) |decl, data| {
+        // The host has no UIKit, so the live actions fail here. What matters is
+        // that they fail *having been dispatched*: `UnknownAction` is the one
+        // answer that means the arm is missing.
+        if (bridge.handleMessage(decl.name, data)) |_| {} else |err| {
+            try testing.expect(err != bridge_error.BridgeError.UnknownAction);
+        }
+        try testing.expectEqual(capabilities.Reply.result, decl.reply);
+    }
+}
+
+test "an action the namespace does not serve is reported, not ignored" {
+    var bridge = DisplayBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("noSuchAction", "{}"),
+    );
+    // Near-misses too: a page calling `setbadge` must be told, not served.
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("setbadge", "{\"count\":1}"),
+    );
+}
+
+test "every unavailable row explains itself" {
+    // `.unavailable` without a reason tells an app that something is broken and
+    // nothing about what, which is barely better than not declaring it.
+    for (capability_actions) |decl| {
+        if (decl.status != .unavailable) continue;
+        try testing.expect(decl.reason != null);
+        try testing.expect(decl.reason.?.len > 0);
+    }
+}
+
+test "a badge count is read from the field the page actually sends" {
+    try testing.expectEqual(@as(i64, 5), try badgeCountFrom(testing.allocator, "{\"count\":5}"));
+    try testing.expectEqual(@as(i64, 0), try badgeCountFrom(testing.allocator, "{\"count\":0}"));
+
+    // Whole floats are that integer. JSON has one number type, and a page that
+    // computed its count with arithmetic hands over `3.0`.
+    try testing.expectEqual(@as(i64, 3), try badgeCountFrom(testing.allocator, "{\"count\":3.0}"));
+}
+
+test "a missing count is refused rather than defaulted to zero" {
+    // The whole reason this is not `orelse 0`: zero is `clearBadge`. Defaulting
+    // would turn a dropped field into a different action, performed silently
+    // and reported as success.
+    try testing.expectError(
+        bridge_error.BridgeError.MissingData,
+        badgeCountFrom(testing.allocator, "{}"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.MissingData,
+        badgeCountFrom(testing.allocator, "{\"badge\":7}"),
+    );
+}
+
+test "a count that is not a count is refused, not rounded or dropped" {
+    // Swift's `as? Int` returns nil for each of these and its dispatcher has no
+    // `else`, so today they reply nothing at all and hang the caller.
+    for ([_][]const u8{
+        "{\"count\":3.7}",
+        "{\"count\":\"5\"}",
+        "{\"count\":true}",
+        "{\"count\":null}",
+        "{\"count\":-1}",
+        "{\"count\":[1]}",
+    }) |data| {
+        try testing.expectError(
+            bridge_error.BridgeError.InvalidParameter,
+            badgeCountFrom(testing.allocator, data),
+        );
+    }
+}
+
+test "a payload that is not an object is a JSON error, not a missing field" {
+    // Reporting `MissingData` for `[1,2]` would send the caller looking for a
+    // field in something that has no fields.
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidJSON,
+        badgeCountFrom(testing.allocator, "[1,2]"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidJSON,
+        badgeCountFrom(testing.allocator, "{\"count\":"),
+    );
+}
+
+test "keep-awake reads a boolean and only a boolean" {
+    try testing.expectEqual(true, try keepAwakeFrom(testing.allocator, "{\"enabled\":true}"));
+    try testing.expectEqual(false, try keepAwakeFrom(testing.allocator, "{\"enabled\":false}"));
+
+    try testing.expectError(
+        bridge_error.BridgeError.MissingData,
+        keepAwakeFrom(testing.allocator, "{}"),
+    );
+    // No truthiness. Guessing what `1` meant is how a handler ends up doing the
+    // opposite of what was asked.
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        keepAwakeFrom(testing.allocator, "{\"enabled\":1}"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        keepAwakeFrom(testing.allocator, "{\"enabled\":\"true\"}"),
+    );
+}
+
+test "the orientation names are the ones the Swift switch recognizes" {
+    try testing.expectEqual(Orientation.portrait, Orientation.fromName("portrait").?);
+    try testing.expectEqual(Orientation.portrait_upside_down, Orientation.fromName("portraitUpsideDown").?);
+    try testing.expectEqual(Orientation.landscape_left, Orientation.fromName("landscapeLeft").?);
+    try testing.expectEqual(Orientation.landscape_right, Orientation.fromName("landscapeRight").?);
+    try testing.expectEqual(Orientation.landscape, Orientation.fromName("landscape").?);
+
+    // Swift's `default:` turns anything else into `.all` and reports success.
+    try testing.expectEqual(@as(?Orientation, null), Orientation.fromName("sideways"));
+    try testing.expectEqual(@as(?Orientation, null), Orientation.fromName("Portrait"));
+}
+
+test "the orientation masks are shifts of UIInterfaceOrientation, not their reading order" {
+    // `landscapeLeft` is orientation 4 and `landscapeRight` is 3, so the masks
+    // are 16 and 8 — the reverse of the order the names suggest. This is the
+    // pair that gets transposed.
+    try testing.expectEqual(@as(c_ulong, 2), Orientation.portrait.mask());
+    try testing.expectEqual(@as(c_ulong, 4), Orientation.portrait_upside_down.mask());
+    try testing.expectEqual(@as(c_ulong, 8), Orientation.landscape_right.mask());
+    try testing.expectEqual(@as(c_ulong, 16), Orientation.landscape_left.mask());
+    try testing.expectEqual(
+        Orientation.landscape_left.mask() | Orientation.landscape_right.mask(),
+        Orientation.landscape.mask(),
+    );
+}
+
+test "the orientation actions refuse, and say which kind of refusal it is" {
+    var bridge = DisplayBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    // A well-formed request craft cannot carry out.
+    try testing.expectError(
+        bridge_error.BridgeError.PlatformNotSupported,
+        bridge.handleMessage(A.lock_orientation, "{\"orientation\":\"landscape\"}"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.PlatformNotSupported,
+        bridge.handleMessage(A.unlock_orientation, "{}"),
+    );
+
+    // A malformed one. Distinct on purpose: the caller can fix this one.
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        bridge.handleMessage(A.lock_orientation, "{\"orientation\":\"sideways\"}"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.MissingData,
+        bridge.handleMessage(A.lock_orientation, "{}"),
+    );
+}
+
+test "replies are objects carrying a value, not bare scalars" {
+    // `craft-bridge.js` settles with `payload || {}`. A bare `false` — which
+    // `setKeepAwake(false)` would resolve, following Swift — arrives at the
+    // page as `{}` and loses the answer entirely.
+    //
+    // These call the same renderers the handlers do, so changing a key name or
+    // dropping the object wrapper fails here instead of reading as coverage.
+    var buf: [48]u8 = undefined;
+
+    try testing.expectEqualStrings("{\"count\":7}", try renderBadgeReply(&buf, 7));
+    try testing.expectEqualStrings("{\"count\":0}", try renderBadgeReply(&buf, 0));
+    try testing.expectEqualStrings("{\"enabled\":false}", try renderKeepAwakeReply(&buf, false));
+    try testing.expectEqualStrings("{\"enabled\":true}", try renderKeepAwakeReply(&buf, true));
+
+    // The stack buffers the handlers hand these are 48 and 32 bytes; the widest
+    // reply either can produce has to fit, or a legitimate count turns into a
+    // `NoSpaceLeft` the page reads as a native failure.
+    var badge_buf: [48]u8 = undefined;
+    try testing.expect((try renderBadgeReply(&badge_buf, std.math.minInt(i64))).len <= badge_buf.len);
+    var keep_buf: [32]u8 = undefined;
+    try testing.expect((try renderKeepAwakeReply(&keep_buf, false)).len <= keep_buf.len);
+}
+
+test "UIKit work is refused off Darwin rather than attempted" {
+    if (builtin.target.os.tag.isDarwin()) return error.SkipZigTest;
+    try testing.expectError(error.UnsupportedPlatform, applyBadge(1));
+    try testing.expectError(error.UnsupportedPlatform, applyKeepAwake(true));
+}

--- a/packages/zig/src/bridge_mobile_haptics.zig
+++ b/packages/zig/src/bridge_mobile_haptics.zig
@@ -1,0 +1,669 @@
+//! The haptics half of the `mobile` namespace: `haptic` and `vibrate`.
+//!
+//! Split out of `bridge_mobile.zig` because the two actions have opposite
+//! contracts — `haptic` is fire-and-forget and gated on a config flag, while
+//! `vibrate` replies and is gated on nothing — and because one of them cannot
+//! be served honestly from Zig yet. Keeping that admission next to the working
+//! action, rather than folded into the namespace's main file, is the point.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const capabilities = @import("capabilities.zig");
+const bridge_error = @import("bridge_error.zig");
+const objc_runtime = @import("objc_runtime.zig");
+const mobile = @import("mobile.zig");
+
+const objc = objc_runtime.objc;
+
+/// Reused rather than redefined: `mobile.iOS.HapticType` is already the
+/// vocabulary the rest of the tree speaks, and a second spelling of the same
+/// seven cases is a second thing to keep in step.
+const HapticType = mobile.iOS.HapticType;
+
+pub const A = struct {
+    pub const haptic = "haptic";
+    pub const vibrate = "vibrate";
+};
+
+/// `haptic` is declared `unavailable`, and that is a decision, not an oversight.
+///
+/// The Swift it replaces does not run `triggerHaptic` unconditionally — it runs
+/// it `if config.enableHaptics` (`CraftApp.swift:537`), and that flag defaults
+/// to **false** in both the template (`CraftApp.swift:190`) and the SDK
+/// (`packages/ios/src/index.ts:118`). It reaches Zig through nothing: no
+/// `craft_ios_*` export carries it, no build option encodes it. So serving
+/// `haptic` from here means serving a *different action* from the one the spec
+/// defines — every app on the default config would start buzzing on
+/// `craft.haptics.impact()`, which is the entire shipped haptics surface, and
+/// no test in this repo could see it because the Taptic Engine has no readback.
+///
+/// The three ways to make that go away are all worse than saying so:
+///   - fire anyway → a behaviour change that is invisible in CI and obvious on
+///     a device;
+///   - hardcode the gate false → a permanent no-op that reports nothing, which
+///     is the shape of the nine Android handlers that were deleted;
+///   - reply `{"success":true}` → fabricated success, the thing this migration
+///     exists to stop.
+///
+/// So the handler refuses and the manifest says why. Unblocking it is small and
+/// deliberate: plumb the flag in (a `craft_ios_set_capabilities` export or a
+/// build option), then swap the refusal in `haptic()` for the mapping and the
+/// trigger below, both of which are written and pinned by the tests at the
+/// bottom of this file. What must not happen is the flip happening silently.
+///
+/// Note the inconsistency this preserves: `case "vibrate"` has no
+/// `enableHaptics` gate in the spec either, so `craft.vibrate([100])` already
+/// fires impacts on an app with haptics "disabled". `vibrate` stays ungated to
+/// match; the asymmetry is the spec's, not ours.
+const haptic_unavailable_reason =
+    "iOS gates haptic on config.enableHaptics, which defaults to false and is " ++
+    "not visible to Zig; serving it here would enable haptics for every app " ++
+    "that never opted in";
+
+pub const capability_actions = [_]capabilities.ActionDecl{
+    // `.none` is the action's contract regardless of status: the page's
+    // `craft.haptic()` returns undefined and the spec's `case "haptic"` never
+    // touches `resolveCallback`. An error still reaches the page — with no
+    // pending entry to settle, `craft-bridge.js` reports it to the console —
+    // so a refusal is logged rather than swallowed.
+    .{
+        .name = A.haptic,
+        .reply = .none,
+        .status = .unavailable,
+        .reason = haptic_unavailable_reason,
+    },
+    // `.result` carrying the JSON literal `true`. Not a shape worth improving:
+    // the hand-off path already delivers exactly this today, and `.none` would
+    // park any `_req`-based caller for the full 30s timeout.
+    .{ .name = A.vibrate, .reply = .result },
+};
+
+/// The reply `vibrate` sends, byte-identical to what the hand-off path delivers
+/// today. A bare `true`, not an object — the spec serialises with
+/// `.fragmentsAllowed`. It stays truthy on purpose: `craft-bridge.js` resolves
+/// with `payload || {}`, so `false` or `0` would arrive as `{}`.
+const vibrate_reply = "true";
+
+pub const HapticsBridge = struct {
+    allocator: std.mem.Allocator,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator) Self {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(_: *Self) void {}
+
+    pub fn handleMessage(self: *Self, action: []const u8, data: []const u8) !void {
+        if (std.mem.eql(u8, action, A.haptic)) {
+            return self.haptic(data);
+        } else if (std.mem.eql(u8, action, A.vibrate)) {
+            return self.vibrate(data);
+        }
+        return bridge_error.BridgeError.UnknownAction;
+    }
+
+    /// Refuses, for the reason recorded on `haptic_unavailable_reason`.
+    ///
+    /// The payload is not parsed first. Reporting a malformed `style` would
+    /// imply the style was going to be used, and it is not — a refusal that
+    /// sometimes reports a different cause is harder to act on than one that
+    /// always says the same thing.
+    ///
+    /// The error name is what lands in the device log; the page sees
+    /// `NATIVE_CALL_FAILED`, `ios_dispatch.asBridgeError`'s catch-all, because
+    /// the wire protocol has no code for "declared unavailable". The manifest
+    /// is where an app reads the actual reason.
+    fn haptic(_: *Self, _: []const u8) !void {
+        return error.HapticsGateNotVisibleToZig;
+    }
+
+    /// `case "vibrate"` (`CraftApp.swift:685-691`).
+    ///
+    /// Two paths, and which one runs is decided exactly the way Swift's
+    /// `body["pattern"] as? [Int]` decides it — see `patternArray`. A
+    /// well-formed array schedules impacts (possibly none, for `[]`); anything
+    /// else fires a single medium impact immediately.
+    ///
+    /// The `true` goes out only if the work succeeded. The spec replies `true`
+    /// unconditionally, but its work cannot visibly fail; ours can — a missing
+    /// `UIImpactFeedbackGenerator` is a real condition — and answering `true`
+    /// to a call that did nothing is the failure mode this migration exists to
+    /// remove. A caller that gets an error can retry or degrade; one that gets
+    /// `true` cannot.
+    fn vibrate(self: *Self, data: []const u8) !void {
+        const parsed = std.json.parseFromSlice(std.json.Value, self.allocator, data, .{}) catch
+            return bridge_error.BridgeError.InvalidJSON;
+        defer parsed.deinit();
+
+        const root = switch (parsed.value) {
+            .object => |obj| obj,
+            else => return bridge_error.BridgeError.InvalidJSON,
+        };
+
+        if (patternArray(root.get("pattern"))) |items| {
+            _ = try schedulePattern(items);
+        } else {
+            // Swift's else arm. Deliberately *not* `MissingData`: `craft.vibrate()`
+            // with no argument posts no `pattern` at all, and rejecting that
+            // would be stricter than the surface the page is written against.
+            try triggerHapticChecked(.impact_medium);
+        }
+
+        bridge_error.sendResultToJS(self.allocator, A.vibrate, vibrate_reply);
+    }
+};
+
+/// Swift's `if let pattern = body["pattern"] as? [Int]`, as a decision.
+///
+/// Returns the elements when the cast would succeed and null when it would
+/// fail — absent key, not an array, or an array holding anything that is not an
+/// integer. Note that an *empty* array is a successful cast, so `[]` returns an
+/// empty slice rather than null: `craft.haptics.vibrate()` sends `[]`, and it
+/// must schedule nothing rather than take the single-impact fallback.
+///
+/// Non-integer numbers fail the cast, matching `NSNumber`'s exact-representability
+/// rule. In practice `JSON.stringify` renders every integral JS number without a
+/// fraction, so a `.float` on the wire is always genuinely non-integral —
+/// `[100.5]` is the case this rejects, and it rejects it the way Swift does.
+///
+/// The returned slice points into the caller's `std.json.Parsed`, so it is only
+/// valid until that is deinitialised.
+fn patternArray(value: ?std.json.Value) ?[]const std.json.Value {
+    const v = value orelse return null;
+    const items = switch (v) {
+        .array => |a| a.items,
+        else => return null,
+    };
+    for (items) |item| {
+        if (item != .integer) return null;
+    }
+    return items;
+}
+
+/// How far from *now* entry `index` of a pattern lands, or null if it does
+/// nothing. Three facts from `vibratePattern` (`CraftApp.swift:3210-3220`),
+/// carried across deliberately:
+///
+///  1. Even indices only. The Web Vibration API reads odd entries as pauses;
+///     the spec reads them and then ignores them entirely, not even as timing.
+///  2. Only `duration > 0` fires. Zero and negative entries are skipped.
+///  3. **The delay is measured from now, not accumulated.** For
+///     `[100, 50, 100, 50, 200]` that puts indices 0 and 2 on the *same
+///     instant*, so the canonical five-element example produces two impacts,
+///     not three.
+///
+/// (3) is almost certainly not what "pattern" is meant to mean, and it is kept
+/// anyway: this is a migration, the Swift is the specification, and a running
+/// offset would be a silent behaviour change dressed as a port. It is written
+/// down here so the next reader knows it was a decision and not a transcription
+/// slip — changing it is a product call, not a cleanup.
+///
+/// The multiply saturates rather than overflowing: `duration` is whatever
+/// integer the page put in the array, and an overflowing multiply is a panic in
+/// a safe build. A clamped delay is a distant one, which is the same nothing an
+/// enormous delay would have been.
+fn impactDelayNs(index: usize, duration_ms: i64) ?i64 {
+    if (index % 2 != 0) return null;
+    if (duration_ms <= 0) return null;
+    return std.math.mul(i64, duration_ms, std.time.ns_per_ms) catch std.math.maxInt(i64);
+}
+
+/// Queue a medium impact for each firing entry, and report how many were
+/// queued.
+///
+/// The class and both selectors are resolved *before* anything is scheduled.
+/// The blocks run long after this function returns, by which point the reply is
+/// already on its way to the page and a failure has nowhere to be reported — so
+/// the one check that can still reach the caller is made while it still can.
+fn schedulePattern(items: []const std.json.Value) !usize {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    _ = objc.objc_getClass("UIImpactFeedbackGenerator") orelse return error.ClassNotFound;
+    _ = objc.sel_registerName("initWithStyle:") orelse return error.SelectorNotFound;
+    _ = objc.sel_registerName("impactOccurred") orelse return error.SelectorNotFound;
+
+    var scheduled: usize = 0;
+    for (items, 0..) |item, index| {
+        const duration_ms = switch (item) {
+            .integer => |n| n,
+            // `patternArray` guarantees this cannot happen; an explicit error
+            // beats `unreachable` if that guarantee is ever loosened.
+            else => return bridge_error.BridgeError.InvalidParameter,
+        };
+        const delay_ns = impactDelayNs(index, duration_ms) orelse continue;
+
+        const when = dispatch.dispatch_time(dispatch.DISPATCH_TIME_NOW, delay_ns);
+        dispatch.dispatch_after(when, &dispatch._dispatch_main_q, &medium_impact_block);
+        scheduled += 1;
+    }
+    return scheduled;
+}
+
+/// `mobile.iOS.triggerHaptic` with the failures reported instead of swallowed.
+///
+/// The existing one is `fn (HapticType) void` whose every failure path is
+/// `orelse return`, so a missing class and a fired haptic are the same value to
+/// a caller. That is fine for its two fire-and-forget callers and not fine for
+/// a bridge, which has to decide between replying and erroring. Same ObjC, same
+/// enum, same constants — only the return type differs.
+///
+/// No dispatch hop. `UIFeedbackGenerator` is main-thread-only, and the only
+/// path here starts in `craftDidReceiveScriptMessage`, a `WKScriptMessageHandler`
+/// callback that WebKit already delivers on the main thread.
+///
+/// What this still cannot tell you: whether anything was *felt*. The Taptic
+/// Engine is absent on the simulator and on iPad, and System Haptics can be off
+/// in Settings — all three are silent no-ops with no API that reports them. So
+/// "returned without error" means "UIKit accepted the call", never "the device
+/// buzzed", which is the other half of why `haptic` has no success reply to
+/// fabricate.
+fn triggerHapticChecked(haptic_type: HapticType) !void {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    switch (haptic_type) {
+        .selection => {
+            const class = objc.objc_getClass("UISelectionFeedbackGenerator") orelse
+                return error.ClassNotFound;
+            const sel_selection_changed = objc.sel_registerName("selectionChanged") orelse
+                return error.SelectorNotFound;
+
+            const generator = try objc.allocInit(class);
+            if (generator == null) return error.GeneratorNotCreated;
+            defer objc.release(generator);
+
+            objc.msgSend(generator, sel_selection_changed);
+        },
+        .impact_light, .impact_medium, .impact_heavy => {
+            const class = objc.objc_getClass("UIImpactFeedbackGenerator") orelse
+                return error.ClassNotFound;
+            const sel_init_with_style = objc.sel_registerName("initWithStyle:") orelse
+                return error.SelectorNotFound;
+            const sel_impact_occurred = objc.sel_registerName("impactOccurred") orelse
+                return error.SelectorNotFound;
+
+            // UIImpactFeedbackStyle. Light/Medium/Heavy; Soft(3) and Rigid(4)
+            // exist but nothing maps to them — see `hapticTypeForStyle`.
+            const style: i64 = switch (haptic_type) {
+                .impact_light => 0,
+                .impact_heavy => 2,
+                else => 1,
+            };
+
+            const allocated = try objc.alloc(class);
+            if (allocated == null) return error.GeneratorNotCreated;
+
+            // `initWithStyle:` takes an NSInteger, so the cast must say i64 —
+            // an object-argument msgSend here would pass the enum as a pointer
+            // and get a garbage style, silently.
+            const InitWithStyle = *const fn (objc.id, objc.SEL, i64) callconv(.c) objc.id;
+            const init_with_style: InitWithStyle = @ptrCast(&objc.objc_msgSend);
+            const generator = init_with_style(allocated, sel_init_with_style, style);
+            if (generator == null) {
+                objc.release(allocated);
+                return error.GeneratorNotCreated;
+            }
+            defer objc.release(generator);
+
+            objc.msgSend(generator, sel_impact_occurred);
+        },
+        .notification_success, .notification_warning, .notification_error => {
+            const class = objc.objc_getClass("UINotificationFeedbackGenerator") orelse
+                return error.ClassNotFound;
+            const sel_notification_occurred = objc.sel_registerName("notificationOccurred:") orelse
+                return error.SelectorNotFound;
+
+            const generator = try objc.allocInit(class);
+            if (generator == null) return error.GeneratorNotCreated;
+            defer objc.release(generator);
+
+            // UINotificationFeedbackType: Success/Warning/Error.
+            const feedback_type: i64 = switch (haptic_type) {
+                .notification_warning => 1,
+                .notification_error => 2,
+                else => 0,
+            };
+
+            const NotificationOccurred = *const fn (objc.id, objc.SEL, i64) callconv(.c) void;
+            const notification_occurred: NotificationOccurred = @ptrCast(&objc.objc_msgSend);
+            notification_occurred(generator, sel_notification_occurred, feedback_type);
+        },
+    }
+}
+
+/// `triggerHaptic(style:)` (`CraftApp.swift:2562-2579`) as a mapping.
+///
+/// Written, tested, and — while `haptic` is refused — not yet reachable from a
+/// handler. It is here because it is the finished half of the blocked action:
+/// once `enableHaptics` is visible to Zig, `haptic()` becomes a parse of
+/// `style` plus a call to this plus a call to `triggerHapticChecked`, with the
+/// mapping already pinned against the spec rather than re-derived under time
+/// pressure.
+///
+/// Two quirks are reproduced rather than fixed, because fixing either here
+/// would be a behaviour change hidden inside a migration:
+///
+///  - **`"soft"` maps to a medium impact, not a selection haptic.**
+///    `craft.haptics.selection()` posts `'soft'` (`CraftApp.swift:2334`), which
+///    hits the spec's `default:` arm — so the shipped `selection()` has never
+///    produced a selection haptic, and `.selection` is reachable only through a
+///    direct `craft.haptic('selection')`. `HapticType` has no `impact_soft`
+///    tag, so honouring `'soft'` as `UIImpactFeedbackStyleSoft` would mean
+///    widening the enum *and* changing what the shipped API does.
+///  - **An unknown style is absorbed, not rejected.** A typo is indistinguishable
+///    from `"medium"`. With no reply channel there is nowhere to report it, and
+///    the spec's `default:` swallows it too.
+///
+/// The field is `style`. Not `type` — `examples/web_to_native/app.html` posts
+/// `{type: ...}` but through a local `invoke` shim that never reaches this
+/// bridge, and `craft-bridge.d.ts`'s `triggerHaptic({style})` is a different
+/// action name in a different namespace.
+fn hapticTypeForStyle(style: []const u8) HapticType {
+    if (std.mem.eql(u8, style, "light")) return .impact_light;
+    if (std.mem.eql(u8, style, "heavy")) return .impact_heavy;
+    if (std.mem.eql(u8, style, "success")) return .notification_success;
+    if (std.mem.eql(u8, style, "warning")) return .notification_warning;
+    if (std.mem.eql(u8, style, "error")) return .notification_error;
+    if (std.mem.eql(u8, style, "selection")) return .selection;
+    return .impact_medium;
+}
+
+// =============================================================================
+// libdispatch, and the one block this file needs.
+//
+// Declared inside a struct so they stay lazily analysed: off Darwin the only
+// reference to any of them sits behind a comptime-false `isDarwin()` guard, so
+// a Linux host build never asks the linker for a symbol libSystem owns.
+// =============================================================================
+
+const dispatch = struct {
+    const DISPATCH_TIME_NOW: u64 = 0;
+
+    extern "c" fn dispatch_time(when: u64, delta: i64) u64;
+    extern "c" fn dispatch_after(when: u64, queue: *anyopaque, block: *const anyopaque) void;
+
+    /// `dispatch_get_main_queue()` is a macro over this symbol, not a function
+    /// call — the main queue *is* the address of this global.
+    extern var _dispatch_main_q: anyopaque;
+};
+
+const BlockDescriptor = extern struct {
+    reserved: usize = 0,
+    size: usize,
+};
+
+/// `dispatch_block_t` is `void (^)(void)`, so `invoke` takes one argument — the
+/// block itself — unlike the two-argument completion blocks in
+/// `bridge_permissions.zig`.
+const DispatchBlock = extern struct {
+    isa: *anyopaque,
+    flags: c_int,
+    reserved: c_int,
+    invoke: *const fn (*const anyopaque) callconv(.c) void,
+    descriptor: *const BlockDescriptor,
+};
+
+/// A *global* block, not a stack one — and that is the whole reason this is
+/// spelled out rather than copied from `bridge_permissions.zig`.
+///
+/// Those blocks are handed to `requestAccess…`, which consumes them
+/// synchronously, so `_NSConcreteStackBlock` is fine there. `dispatch_after`
+/// instead calls `Block_copy` on its argument and holds it until the block
+/// fires. `Block_copy` on a global block is the identity function; on a stack
+/// block it heap-copies and later releases, which happens to work for a
+/// non-capturing block but leans on an implementation detail of libclosure for
+/// a lifetime that outlives this call.
+///
+/// It captures nothing because the spec's block captures nothing: every
+/// scheduled entry is the same medium impact, so one file-scope constant serves
+/// an entire pattern.
+extern var _NSConcreteGlobalBlock: anyopaque;
+
+const BLOCK_IS_GLOBAL: c_int = 1 << 28;
+
+/// Runs on the main queue, after the reply has already gone out. There is no
+/// caller left to tell, so a failure is logged — the alternative is a silent
+/// nothing, which is how you end up unable to tell a broken generator from a
+/// device with System Haptics switched off.
+fn mediumImpactInvoke(_: *const anyopaque) callconv(.c) void {
+    triggerHapticChecked(.impact_medium) catch |err| {
+        std.log.warn("craft-bridge: scheduled vibrate impact did not fire: {}", .{err});
+    };
+}
+
+const medium_impact_descriptor = BlockDescriptor{ .size = @sizeOf(DispatchBlock) };
+
+const medium_impact_block = DispatchBlock{
+    .isa = &_NSConcreteGlobalBlock,
+    .flags = BLOCK_IS_GLOBAL,
+    .reserved = 0,
+    .invoke = mediumImpactInvoke,
+    .descriptor = &medium_impact_descriptor,
+};
+
+const testing = std.testing;
+
+test "the table declares exactly the two actions the dispatcher serves" {
+    try testing.expectEqual(@as(usize, 2), capability_actions.len);
+    try testing.expectEqualStrings(A.haptic, capability_actions[0].name);
+    try testing.expectEqualStrings(A.vibrate, capability_actions[1].name);
+
+    // The replies are the halves that go wrong invisibly: a `.result` that
+    // never replies parks the caller for 30s, and a `.none` that is awaited
+    // resolves immediately and means nothing.
+    try testing.expectEqual(capabilities.Reply.none, capability_actions[0].reply);
+    try testing.expectEqual(capabilities.Reply.result, capability_actions[1].reply);
+}
+
+test "an unavailable action carries the reason with it" {
+    // Without a reason, `unavailable` tells an app that something is broken and
+    // nothing about what to do next — which is most of the value of declaring
+    // it at all.
+    for (capability_actions) |decl| {
+        if (decl.status != .unavailable) continue;
+        try testing.expect(decl.reason != null);
+        try testing.expect(decl.reason.?.len > 0);
+    }
+    try testing.expectEqual(capabilities.ActionStatus.unavailable, capability_actions[0].status);
+    try testing.expectEqual(capabilities.ActionStatus.live, capability_actions[1].status);
+}
+
+test "every declared action dispatches — none of them falls through as unknown" {
+    // The drift this whole effort exists to make impossible: a name in the
+    // table that the chain does not compare against would be reported to the
+    // page as served, and reach the host shim instead.
+    var bridge = HapticsBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    for (capability_actions) |decl| {
+        bridge.handleMessage(decl.name, "{}") catch |err| {
+            try testing.expect(err != bridge_error.BridgeError.UnknownAction);
+            continue;
+        };
+    }
+}
+
+test "an action the namespace does not serve is reported, not ignored" {
+    var bridge = HapticsBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("noSuchAction", "{}"),
+    );
+
+    // Near-misses too: the shipped surface has a `craft.haptics` namespace
+    // object, and `haptics` is not `haptic`.
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("haptics", "{}"),
+    );
+}
+
+test "haptic refuses rather than firing an ungated haptic" {
+    // The refusal is the migration's honest answer while `config.enableHaptics`
+    // has no Zig representation. If this test starts failing because someone
+    // implemented the action, the flag has to have been plumbed through first —
+    // that is the conversation this assertion exists to force.
+    var bridge = HapticsBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        error.HapticsGateNotVisibleToZig,
+        bridge.handleMessage(A.haptic, "{\"style\":\"medium\"}"),
+    );
+}
+
+test "every style the shipped surface posts maps the way the spec's switch does" {
+    try testing.expectEqual(HapticType.impact_light, hapticTypeForStyle("light"));
+    try testing.expectEqual(HapticType.impact_heavy, hapticTypeForStyle("heavy"));
+    try testing.expectEqual(HapticType.notification_success, hapticTypeForStyle("success"));
+    try testing.expectEqual(HapticType.notification_warning, hapticTypeForStyle("warning"));
+    try testing.expectEqual(HapticType.notification_error, hapticTypeForStyle("error"));
+    try testing.expectEqual(HapticType.selection, hapticTypeForStyle("selection"));
+    try testing.expectEqual(HapticType.impact_medium, hapticTypeForStyle("medium"));
+}
+
+test "the spec's default arm absorbs everything else, including 'soft'" {
+    // `craft.haptics.selection()` posts 'soft', which lands here — so the
+    // shipped selection() has never produced a selection haptic. Pinned as a
+    // known quirk so it is not rediscovered as a bug, and not fixed here
+    // because fixing it is a behaviour change, not a port.
+    try testing.expectEqual(HapticType.impact_medium, hapticTypeForStyle("soft"));
+    try testing.expectEqual(HapticType.impact_medium, hapticTypeForStyle("rigid"));
+    // A typo is indistinguishable from "medium". There is no reply channel to
+    // say otherwise on, which is exactly what the spec does too.
+    try testing.expectEqual(HapticType.impact_medium, hapticTypeForStyle("mediuim"));
+    try testing.expectEqual(HapticType.impact_medium, hapticTypeForStyle(""));
+}
+
+/// Parse a payload and classify its `pattern` the way `vibrate` does.
+fn classify(json: []const u8) !?[]const std.json.Value {
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    // The slice would dangle past `parsed.deinit()`, so tests assert on length
+    // and on the null/non-null decision rather than holding the elements.
+    const items = patternArray(parsed.value.object.get("pattern")) orelse return null;
+    return items[0..0];
+}
+
+test "a well-formed integer pattern takes the loop path" {
+    const parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        testing.allocator,
+        "{\"pattern\":[100,50,100,50,200]}",
+        .{},
+    );
+    defer parsed.deinit();
+
+    const items = patternArray(parsed.value.object.get("pattern")).?;
+    try testing.expectEqual(@as(usize, 5), items.len);
+    try testing.expectEqual(@as(i64, 100), items[0].integer);
+}
+
+test "an empty pattern is a successful cast, so it schedules nothing" {
+    // The asymmetry that matters: `craft.haptics.vibrate()` sends `[]`, which
+    // must fire nothing, while a *missing* pattern fires one medium impact.
+    // Collapsing the two would make the common call buzz.
+    const parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        testing.allocator,
+        "{\"pattern\":[]}",
+        .{},
+    );
+    defer parsed.deinit();
+
+    const items = patternArray(parsed.value.object.get("pattern"));
+    try testing.expect(items != null);
+    try testing.expectEqual(@as(usize, 0), items.?.len);
+}
+
+test "an absent, non-array, or non-integer pattern takes the single-impact arm" {
+    // All three are `as? [Int]` failures in the spec, and all three still reply
+    // `true`. Returning MissingData for the absent case would be stricter than
+    // the surface: `craft.vibrate()` with no argument posts no `pattern` at all.
+    try testing.expectEqual(@as(?[]const std.json.Value, null), try classify("{}"));
+    try testing.expectEqual(@as(?[]const std.json.Value, null), try classify("{\"pattern\":null}"));
+    try testing.expectEqual(@as(?[]const std.json.Value, null), try classify("{\"pattern\":100}"));
+    try testing.expectEqual(@as(?[]const std.json.Value, null), try classify("{\"pattern\":\"100\"}"));
+    // One bad element spoils the cast, exactly as `[Any] as? [Int]` does.
+    try testing.expectEqual(@as(?[]const std.json.Value, null), try classify("{\"pattern\":[100.5]}"));
+    try testing.expectEqual(@as(?[]const std.json.Value, null), try classify("{\"pattern\":[100,\"x\"]}"));
+    try testing.expectEqual(@as(?[]const std.json.Value, null), try classify("{\"pattern\":[100,null]}"));
+}
+
+test "odd entries are pauses that do nothing at all, not even to timing" {
+    try testing.expectEqual(@as(?i64, null), impactDelayNs(1, 50));
+    try testing.expectEqual(@as(?i64, null), impactDelayNs(3, 5000));
+    try testing.expect(impactDelayNs(0, 50) != null);
+    try testing.expect(impactDelayNs(2, 50) != null);
+}
+
+test "zero and negative durations are skipped" {
+    try testing.expectEqual(@as(?i64, null), impactDelayNs(0, 0));
+    try testing.expectEqual(@as(?i64, null), impactDelayNs(0, -100));
+}
+
+test "delays are measured from now, so the canonical pattern collapses to two" {
+    // [100, 50, 100, 50, 200] fires at +100ms, +100ms and +200ms — indices 0
+    // and 2 land on the same instant. This is the spec's semantics and it is
+    // almost certainly not what "pattern" means; it is reproduced on purpose,
+    // and this assertion is here so a future reader can tell the difference
+    // between a bug and a decision before changing it.
+    const pattern = [_]i64{ 100, 50, 100, 50, 200 };
+    var delays: [3]i64 = undefined;
+    var count: usize = 0;
+    for (pattern, 0..) |duration_ms, index| {
+        if (impactDelayNs(index, duration_ms)) |delay| {
+            delays[count] = delay;
+            count += 1;
+        }
+    }
+
+    try testing.expectEqual(@as(usize, 3), count);
+    try testing.expectEqual(@as(i64, 100 * std.time.ns_per_ms), delays[0]);
+    try testing.expectEqual(delays[0], delays[1]);
+    try testing.expectEqual(@as(i64, 200 * std.time.ns_per_ms), delays[2]);
+}
+
+test "an absurd duration saturates instead of panicking" {
+    // The page controls these integers. An overflowing multiply is a panic in a
+    // safe build, which would turn a malformed payload into a dead app.
+    try testing.expectEqual(
+        @as(?i64, std.math.maxInt(i64)),
+        impactDelayNs(0, std.math.maxInt(i64)),
+    );
+}
+
+test "the vibrate reply is the bare JSON literal the hand-off path already sends" {
+    // Not `{"success":true}`. The spec serialises with `.fragmentsAllowed`, so
+    // a page on the hand-off path receives `true` today, and it must keep
+    // receiving `true`. Truthy also matters: `craft-bridge.js` resolves with
+    // `payload || {}`, which would turn `false` into an empty object.
+    try testing.expectEqualStrings("true", vibrate_reply);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, vibrate_reply, .{});
+    defer parsed.deinit();
+    try testing.expectEqual(true, parsed.value.bool);
+}
+
+test "the scheduled block is global, so dispatch_after's Block_copy is a no-op" {
+    // A stack block would be heap-copied and later released by libclosure —
+    // workable for a non-capturing block, but a lifetime that outlives the call
+    // resting on an implementation detail. The flag is what makes Block_copy
+    // return the same pointer.
+    try testing.expectEqual(@as(c_int, 0x10000000), BLOCK_IS_GLOBAL);
+    try testing.expectEqual(@sizeOf(DispatchBlock), medium_impact_descriptor.size);
+
+    // Asserted on the block, not only on the constants it is assembled from.
+    // Without these two the test name is a claim nothing checks: swapping in
+    // the `_NSConcreteStackBlock` spelling that five other files in this tree
+    // use leaves `BLOCK_IS_GLOBAL` and the descriptor size both correct and the
+    // block no longer global. Guarded because naming `_NSConcreteGlobalBlock`
+    // is what pulls the symbol into the link.
+    if (!builtin.target.os.tag.isDarwin()) return error.SkipZigTest;
+    try testing.expectEqual(BLOCK_IS_GLOBAL, medium_impact_block.flags);
+    try testing.expectEqual(&_NSConcreteGlobalBlock, medium_impact_block.isa);
+    try testing.expectEqual(&medium_impact_descriptor, medium_impact_block.descriptor);
+}

--- a/packages/zig/src/bridge_mobile_storage.zig
+++ b/packages/zig/src/bridge_mobile_storage.zig
@@ -1,0 +1,950 @@
+//! The shared-storage actions of the `mobile` namespace: `setSharedItem`,
+//! `getSharedItem`, `removeSharedItem`.
+//!
+//! **These are Keychain Services, not `NSUserDefaults`.** The Swift helpers are
+//! `setSharedKeychainItem` / `getSharedKeychainItem` / `removeSharedKeychainItem`
+//! and they call `SecItemAdd` / `SecItemCopyMatching` / `SecItemDelete`. There
+//! is no suite name and no key namespacing anywhere in the iOS path: an item is
+//! identified by `kSecClass` + `kSecAttrAccount` (+ `kSecAttrAccessGroup`), and
+//! `kSecAttrService` is never set. Android is the platform that uses
+//! preferences — `CraftBridge.kt.template` does `getSharedPreferences(...)` —
+//! and `UserDefaults(suiteName:)` in `CraftApp.swift` belongs to `updateWidget`,
+//! a different action. Adding a service attribute or a key prefix here would
+//! make items written by Zig invisible to the Swift shim and vice versa, which
+//! is the one thing a partial migration must not do.
+//!
+//! ## What is carried across exactly, because it is the observable contract
+//!
+//!  - **`remove` treats `errSecItemNotFound` as success**, and `get` treats it
+//!    as `{"value":null}`. Only `set` has no not-found case.
+//!  - **Accessibility is `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`** —
+//!    device-local, never iCloud-synced, unreadable while the device is locked.
+//!    Set on the add only; `get` and `remove` do not mention it.
+//!  - **The reply shapes are the Swift dictionary literals verbatim**:
+//!    `{"success":true,"key":…}` for set/remove, `{"value":…,"key":…}` for get.
+//!    `packages/typescript/types/craft.d.ts:626` claims `{set:boolean}` and
+//!    `{removed:boolean}`; no implementation has ever sent either field —
+//!    Swift and Android both send `success`/`key`. The runtime is the truth and
+//!    the `.d.ts` is a separate, pre-existing bug, not something to satisfy by
+//!    inventing fields here.
+//!
+//! ## What is deliberately not carried across
+//!
+//! **Swift's silent hang.** Each dispatcher arm is an `if let` with no `else`,
+//! so a missing `key` — or a `value` that is not a string — falls out of the
+//! `switch` having replied nothing at all. The page's promise then never
+//! settles (the injected `_callbacks` have no timeout of their own). Every path
+//! in this file ends in a reply or an error.
+//!
+//! **A `key` or `group` with an embedded NUL.** Swift stores it whole; this
+//! file refuses it, because the route Zig has to the keychain
+//! (`stringWithUTF8String:`) truncates at the NUL and would file the item under
+//! a shorter name than the caller gave. See `requireNulFree`.
+//!
+//! **Swift's shared delete/add dictionary.** `setSharedKeychainItem` hands the
+//! *same* dictionary — `kSecValueData` and `kSecAttrAccessible` included — to
+//! both `SecItemDelete` and `SecItemAdd`, and discards the delete's status. If
+//! `SecItemDelete` rejects a query carrying `kSecValueData`, the discarded
+//! status hides it and the following add returns `errSecDuplicateItem`, i.e.
+//! overwriting an existing key fails. Nothing in this repo exercises `set`
+//! twice, so which way it actually goes is unproven. `keychainSet` below builds
+//! the delete-scoped query first (class + account + access group, the same shape
+//! `remove` already uses successfully) and only then adds the value attributes.
+//! That is behaviourally identical wherever the Swift already works, and works
+//! in the case where it may not.
+//!
+//! ## Two gaps that are real and are not papered over
+//!
+//! 1. **`group` cannot work on a signed device build from this toolchain.**
+//!    `renderEntitlements` in `packages/ios/src/index.ts` emits
+//!    `associated-domains`, `application-groups`, `healthkit` and
+//!    `aps-environment` — never `keychain-access-groups`. So passing a `group`
+//!    on hardware returns `errSecMissingEntitlement` (-34018) no matter which
+//!    language serves the action. The simulator does not enforce keychain
+//!    entitlements, so it will appear to work there and fail on device. This is
+//!    a pre-existing spec gap; `failStatus` surfaces it and names it in the log
+//!    rather than hiding it. Closing it means a `keychainAccessGroups` config
+//!    key and an entitlements entry, which is out of scope here.
+//! 2. **`packages/zig/src/keychain.zig` is not reused, on purpose.** Its Apple
+//!    arms are `_ = account; return;` for set and `return null` for get, under
+//!    an `if (os.tag == .macos or os.tag == .ios)` — so on Apple platforms every
+//!    write silently succeeds and every read is empty. That is precisely the
+//!    fabricated-success class this migration exists to remove, and building on
+//!    it would inherit it. The Security calls here are written fresh.
+//!
+//! ## Build note
+//!
+//! These are the first Zig-side references to Security.framework. A generated
+//! app is fine — `CraftApp.swift` does `import Security`, which autolinks it —
+//! and `packages/ios/fixtures/zig-slice/build-and-run.sh` now passes
+//! `-framework Security` explicitly, which it must: nothing else in the fixture
+//! links it. `packages/ios/templates/project.yml.template` declares no frameworks
+//! at all and relies entirely on Swift autolinking, so an app template that ever
+//! drops `import Security` breaks this handler too.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const capabilities = @import("capabilities.zig");
+const bridge_error = @import("bridge_error.zig");
+const objc_runtime = @import("objc_runtime.zig");
+
+const objc = objc_runtime.objc;
+
+/// The same type as `objc.id` — `?*anyopaque` — spelled locally.
+///
+/// `objc_runtime.objc` is an empty struct off Darwin, and a function
+/// *signature* is analysed even when a comptime platform guard makes its body
+/// unreachable, so naming `objc.id` in the signatures below would break the
+/// host build. It stays a single optional pointer, never `?objc.id`, because a
+/// double optional is illegal in a `callconv(.c)` type.
+const Id = ?*anyopaque;
+
+/// `CFTypeRef` is the same `?*anyopaque`, but the distinction is worth keeping
+/// in the signatures: the `kSec*` values below are CoreFoundation globals that
+/// happen to be toll-free bridged, not objects Zig created or owns.
+const CFTypeRef = ?*anyopaque;
+
+/// `SInt32`. Not `c_int` — the width of an `OSStatus` is fixed by the ABI, and
+/// every keychain status of interest is negative.
+const OSStatus = i32;
+
+// Security.framework and CoreFoundation. C functions and CFString globals —
+// there is no Objective-C messaging in `SecItem*`; the only ObjC work in this
+// file is building the query dictionary and moving bytes out of the result.
+// Modelled on `prefs_macos.zig`, which declares CoreFoundation the same way.
+extern "c" fn SecItemAdd(attributes: CFTypeRef, result: ?*CFTypeRef) OSStatus;
+extern "c" fn SecItemCopyMatching(query: CFTypeRef, result: ?*CFTypeRef) OSStatus;
+extern "c" fn SecItemDelete(query: CFTypeRef) OSStatus;
+extern "c" fn CFRelease(cf: CFTypeRef) void;
+
+extern "c" const kSecClass: CFTypeRef;
+extern "c" const kSecClassGenericPassword: CFTypeRef;
+extern "c" const kSecAttrAccount: CFTypeRef;
+extern "c" const kSecAttrAccessGroup: CFTypeRef;
+extern "c" const kSecAttrAccessible: CFTypeRef;
+extern "c" const kSecAttrAccessibleWhenUnlockedThisDeviceOnly: CFTypeRef;
+extern "c" const kSecValueData: CFTypeRef;
+extern "c" const kSecReturnData: CFTypeRef;
+extern "c" const kSecMatchLimit: CFTypeRef;
+extern "c" const kSecMatchLimitOne: CFTypeRef;
+extern "c" const kCFBooleanTrue: CFTypeRef;
+
+/// Only the two statuses this file *branches* on, plus the one it maps to a
+/// distinct `BridgeError`.
+///
+/// Deliberately not a full transcription of `SecBase.h`: a mis-typed constant
+/// would silently reclassify a failure as some other failure, which is strictly
+/// worse than leaving it unmapped. Everything else is reported by its raw
+/// number in the log and as `NativeCallFailed` to the page.
+const errSecSuccess: OSStatus = 0;
+const errSecItemNotFound: OSStatus = -25300;
+const errSecMissingEntitlement: OSStatus = -34018;
+
+/// The action names, spelled exactly as the Swift `case` labels spell them.
+///
+/// `test/ios_conformance_test.zig` matches the two lists by string in both
+/// directions, so a tidier spelling here does not read as "migrated" — it reads
+/// as "Zig serves an action the spec does not have", and the Swift arm stays
+/// live forever.
+pub const A = struct {
+    pub const set_shared_item = "setSharedItem";
+    pub const get_shared_item = "getSharedItem";
+    pub const remove_shared_item = "removeSharedItem";
+};
+
+/// All three `.result`. Each Swift path terminates in exactly one
+/// `resolveCallback` or `rejectCallback`, and each injected JS method returns a
+/// promise the page awaits — `craft.sharedKeychain.get(...)` is consumed as
+/// `result.value`. Declaring any of them `.none` would strand that caller for
+/// the whole request timeout.
+///
+/// All three are `.live`, including the `group` argument: the no-group path
+/// works everywhere, and the entitlement gap described in the module comment is
+/// a property of one optional argument on device builds, not of the action. It
+/// is reported, per call, when it bites.
+pub const capability_actions = [_]capabilities.ActionDecl{
+    .{ .name = A.set_shared_item, .reply = .result },
+    .{ .name = A.get_shared_item, .reply = .result },
+    .{ .name = A.remove_shared_item, .reply = .result },
+};
+
+/// One request's fields, after validation.
+///
+/// `group` is `?[]const u8` where null means "no access group" — which JSON
+/// `null` and an absent field both mean, because the injected JS sends
+/// `group || null` and Swift's `body["group"] as? String` turns `NSNull` into
+/// `nil`. An *empty string* is not null: it is passed to the keychain verbatim
+/// and the OSStatus is allowed to speak. Mapping `""` to "no group" would be a
+/// silently-dropped payload field of exactly the `craft.fs.writeFile` shape.
+const Request = struct {
+    key: []const u8,
+    value: ?[]const u8 = null,
+    group: ?[]const u8 = null,
+};
+
+pub const StorageBridge = struct {
+    allocator: std.mem.Allocator,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator) Self {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(_: *Self) void {}
+
+    pub fn handleMessage(self: *Self, action: []const u8, data: []const u8) !void {
+        if (std.mem.eql(u8, action, A.set_shared_item)) {
+            try self.setSharedItem(data);
+        } else if (std.mem.eql(u8, action, A.get_shared_item)) {
+            try self.getSharedItem(data);
+        } else if (std.mem.eql(u8, action, A.remove_shared_item)) {
+            try self.removeSharedItem(data);
+        } else {
+            return bridge_error.BridgeError.UnknownAction;
+        }
+    }
+
+    /// Store `value` under `key`, replacing whatever was there.
+    fn setSharedItem(self: *Self, data: []const u8) !void {
+        var parsed = try parsePayload(self.allocator, data);
+        defer parsed.deinit();
+
+        const request = try parseRequest(parsed.value, .value_required);
+        // Not `request.value.?`: `parseRequest` guarantees it, but an unwrap
+        // that only holds because of an argument two frames up is the kind of
+        // invariant that survives exactly until someone reorders the callers.
+        const value = request.value orelse return bridge_error.BridgeError.MissingData;
+
+        try keychainSet(self.allocator, request.key, value, request.group);
+
+        const json = try successReply(self.allocator, request.key);
+        defer self.allocator.free(json);
+        bridge_error.sendResultToJS(self.allocator, A.set_shared_item, json);
+    }
+
+    /// Read `key`, or report that there is nothing under it.
+    ///
+    /// A missing item is a *success* with `"value":null`, not an error — that
+    /// is what the page distinguishes, and what `packages/ios/README.md`
+    /// documents (`console.log(result.value)`).
+    fn getSharedItem(self: *Self, data: []const u8) !void {
+        var parsed = try parsePayload(self.allocator, data);
+        defer parsed.deinit();
+
+        const request = try parseRequest(parsed.value, .value_absent);
+
+        const found = try keychainGet(self.allocator, request.key, request.group);
+        defer if (found) |bytes| self.allocator.free(bytes);
+
+        const json = try valueReply(self.allocator, request.key, found);
+        defer self.allocator.free(json);
+        bridge_error.sendResultToJS(self.allocator, A.get_shared_item, json);
+    }
+
+    /// Delete `key`. "It was not there" is success, exactly as in Swift —
+    /// `remove` is idempotent and a caller cannot act on the difference.
+    fn removeSharedItem(self: *Self, data: []const u8) !void {
+        var parsed = try parsePayload(self.allocator, data);
+        defer parsed.deinit();
+
+        const request = try parseRequest(parsed.value, .value_absent);
+
+        try keychainRemove(self.allocator, request.key, request.group);
+
+        const json = try successReply(self.allocator, request.key);
+        defer self.allocator.free(json);
+        bridge_error.sendResultToJS(self.allocator, A.remove_shared_item, json);
+    }
+};
+
+/// Whether the action being served needs a `value` field.
+const ValueRule = enum { value_required, value_absent };
+
+/// Parse `d`, distinguishing a bad payload from a failed allocation.
+///
+/// Telling the page INVALID_JSON about its own perfectly good JSON sends
+/// whoever debugs it to the wrong side of the bridge, so `OutOfMemory`
+/// propagates as itself.
+fn parsePayload(allocator: std.mem.Allocator, data: []const u8) !std.json.Parsed(std.json.Value) {
+    return std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => return bridge_error.BridgeError.InvalidJSON,
+    };
+}
+
+/// The `key`/`value`/`group` triple, or the reason it cannot be used.
+///
+/// Pure, so the host tests can pin every outcome that Swift's `as? String`
+/// collapsed into one silent fall-through. The field names are the three the
+/// page posts and are pinned on both sides of the migration: `handleAction` in
+/// `CraftApp.swift` parses `d` straight into `body`, and the un-migrated shim
+/// reads `body["key"]`, `body["value"]`, `body["group"]`. A prettier spelling
+/// here would make the Zig handler and the fallback read different payloads.
+///
+/// A `group` that is present but not a string is `InvalidParameter` rather than
+/// ignored. Swift's `as? String` would drop it and quietly operate on the
+/// *default* access group — a different item than the caller named, reported as
+/// success.
+fn parseRequest(payload: std.json.Value, rule: ValueRule) !Request {
+    const object = switch (payload) {
+        .object => |o| o,
+        else => return bridge_error.BridgeError.InvalidJSON,
+    };
+
+    const key_field = object.get("key") orelse return bridge_error.BridgeError.MissingData;
+    const key = switch (key_field) {
+        .string => |s| s,
+        else => return bridge_error.BridgeError.InvalidParameter,
+    };
+    try requireNulFree(key);
+
+    var request = Request{ .key = key };
+
+    if (rule == .value_required) {
+        const value_field = object.get("value") orelse return bridge_error.BridgeError.MissingData;
+        request.value = switch (value_field) {
+            .string => |s| s,
+            else => return bridge_error.BridgeError.InvalidParameter,
+        };
+    }
+
+    if (object.get("group")) |group_field| {
+        request.group = switch (group_field) {
+            // `group || null` in the injected JS, so `null` is the normal way
+            // for a page to say "no access group" — as common as omitting it.
+            .null => null,
+            .string => |s| blk: {
+                try requireNulFree(s);
+                break :blk s;
+            },
+            else => return bridge_error.BridgeError.InvalidParameter,
+        };
+    }
+
+    return request;
+}
+
+/// Refuse a `key` or `group` carrying the one byte it cannot survive.
+///
+/// Both reach the keychain as NSStrings built by `objc.createNSString`, i.e.
+/// `+[NSString stringWithUTF8String:]`, which stops at the first NUL. A page can
+/// reach that: `\u0000` is a legal JSON escape and `std.json` decodes it to the
+/// byte rather than rejecting it. Without the check,
+/// `set("a\u0000b", secret)` would write the item named `"a"` and reply
+/// `{"success":true,"key":"a\u0000b"}` over the top of it, and a later
+/// `get("a")` would hand back a secret filed under a different page key. That
+/// is a silently-altered payload field reported as success: the two failures
+/// this migration exists to remove, at once.
+///
+/// Swift keeps the NUL (`body["key"] as? String` bridges the whole string), so
+/// refusing is a deliberate divergence. It is the only answer available here
+/// that is not "a different item than you named, reported as success"; storing
+/// it faithfully would mean a `stringWithBytes:length:encoding:` helper this
+/// file does not otherwise need.
+///
+/// `value` needs no equivalent: `makeData` passes bytes and a length, and the
+/// NSData round-trip test below pins that a NUL survives it.
+fn requireNulFree(s: []const u8) !void {
+    if (std.mem.indexOfScalar(u8, s, 0) != null) return bridge_error.BridgeError.InvalidParameter;
+}
+
+/// `{"success":true,"key":"…"}` — the set/remove reply.
+///
+/// Built with `appendJsonEscaped` rather than `bufPrint`, unlike
+/// `bridge_mobile.describeDevice`: `key` is page-controlled and is echoed back,
+/// so a `"` or `\` in it would produce broken JavaScript at `formatResultJS`.
+/// Device fields come from UIKit and cannot contain a quote; a keychain key can.
+fn successReply(allocator: std.mem.Allocator, key: []const u8) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.appendSlice(allocator, "{\"success\":true,\"key\":\"");
+    try bridge_error.appendJsonEscaped(allocator, &out, key);
+    try out.appendSlice(allocator, "\"}");
+
+    return out.toOwnedSlice(allocator);
+}
+
+/// `{"value":"…","key":"…"}`, or `{"value":null,"key":"…"}` when absent.
+///
+/// JSON `null` and the empty string are different answers and stay different:
+/// a stored `""` is a value the page wrote and must read back as `""`.
+fn valueReply(allocator: std.mem.Allocator, key: []const u8, value: ?[]const u8) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.appendSlice(allocator, "{\"value\":");
+    if (value) |v| {
+        try out.append(allocator, '"');
+        try bridge_error.appendJsonEscaped(allocator, &out, v);
+        try out.append(allocator, '"');
+    } else {
+        try out.appendSlice(allocator, "null");
+    }
+    try out.appendSlice(allocator, ",\"key\":\"");
+    try bridge_error.appendJsonEscaped(allocator, &out, key);
+    try out.appendSlice(allocator, "\"}");
+
+    return out.toOwnedSlice(allocator);
+}
+
+/// The nearest `BridgeError` to an OSStatus. Pure, so the mapping is testable.
+///
+/// The mapping is lossy and there is no route that is not: `sendErrorToJS`
+/// takes a `BridgeError` enum, so the number cannot ride along and the page
+/// cannot be told Swift's `"Keychain error: -34018"`. `ios_dispatch.zig` has a
+/// free-text error route (`craft_ios_deliver_error`), but it is the shim's
+/// entry point and `ios_dispatch.zig` imports the mobile bridges — reaching
+/// back for it would be a circular import bought for a nicer string. So the raw
+/// status goes to the log instead; see `failStatus`.
+fn errorForStatus(status: OSStatus) bridge_error.BridgeError {
+    return switch (status) {
+        errSecItemNotFound => bridge_error.BridgeError.NotFound,
+        errSecMissingEntitlement => bridge_error.BridgeError.PermissionDenied,
+        else => bridge_error.BridgeError.NativeCallFailed,
+    };
+}
+
+/// Log a failed keychain call and return the error the page will see.
+///
+/// The log line is the whole diagnostic on a device — there is no console to
+/// watch — and it carries the one thing the page cannot be given, the raw
+/// OSStatus. The `key` is logged because it names the failing call; the
+/// **value is never logged**, here or anywhere else in this file, because it is
+/// the secret the caller chose the keychain for.
+fn failStatus(op: []const u8, key: []const u8, group: ?[]const u8, status: OSStatus) bridge_error.BridgeError {
+    std.log.warn("keychain {s} failed for key '{s}': OSStatus {d}", .{ op, key, status });
+    if (group) |g| {
+        std.log.warn(
+            "  ...with access group '{s}'. `renderEntitlements` (packages/ios/src/index.ts) never emits " ++
+                "`keychain-access-groups`, so a signed device build gets -34018 here whatever the language; " ++
+                "the simulator does not enforce it and will appear to work.",
+            .{g},
+        );
+    }
+    return errorForStatus(status);
+}
+
+/// The query every one of the three operations starts from: class + account,
+/// plus the access group when the caller named one.
+///
+/// No `kSecAttrService`, matching the Swift exactly — identity is class +
+/// account (+ group). Adding one would partition the store so that items
+/// written by Zig and by the un-migrated Swift shim could not see each other.
+///
+/// The dictionary is an autoreleased `NSMutableDictionary`, drained at the end
+/// of this run-loop turn; the whole handler completes inside the
+/// `WKScriptMessageHandler` callback, so there is always a pool. It is handed to
+/// `SecItem*` as a `CFDictionaryRef` — toll-free bridging, which is what
+/// `query as CFDictionary` does in Swift.
+fn newQuery(allocator: std.mem.Allocator, key: []const u8, group: ?[]const u8) !Id {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const NSMutableDictionary = objc.objc_getClass("NSMutableDictionary") orelse return error.ClassNotFound;
+    const sel_dictionary = objc.sel_registerName("dictionary") orelse return error.SelectorNotFound;
+    const query = objc.msgSendId(NSMutableDictionary, sel_dictionary);
+    if (query == null) return error.QueryAllocationFailed;
+
+    try setQueryValue(query, kSecClass, kSecClassGenericPassword);
+
+    const account = try objc.createNSString(key, allocator);
+    try setQueryValue(query, kSecAttrAccount, account);
+
+    if (group) |g| {
+        const ns_group = try objc.createNSString(g, allocator);
+        try setQueryValue(query, kSecAttrAccessGroup, ns_group);
+    }
+
+    return query;
+}
+
+/// `-[NSMutableDictionary setObject:forKey:]`, with the nil check that keeps a
+/// missing constant from becoming a crash.
+///
+/// `setObject:forKey:` raises an `NSInvalidArgumentException` on a nil key or
+/// value. An ObjC exception cannot be caught from Zig, so it would take the app
+/// down with a stack that names AppKit rather than this file. A null `kSec*`
+/// global means Security.framework is not in the process — a real condition, and
+/// one worth naming rather than discovering as a crash.
+///
+/// The key is a `CFStringRef` passed as an `id`: `CFString` is toll-free bridged
+/// to `NSString` and so conforms to `NSCopying`, which is all `forKey:` asks.
+fn setQueryValue(dict: Id, cf_key: CFTypeRef, value: Id) !void {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    if (cf_key == null or value == null) return error.MissingKeychainConstant;
+
+    const sel_set = objc.sel_registerName("setObject:forKey:") orelse return error.SelectorNotFound;
+    objc.msgSendVoid2(dict, sel_set, value, cf_key);
+}
+
+/// `+[NSData dataWithBytes:length:]`, autoreleased.
+///
+/// The payload is `value`'s bytes as-is: `std.json` has already validated them
+/// as UTF-8, so there is no conversion step and nothing that can fail the way
+/// Swift's `value.data(using: .utf8)!` force-unwrap could.
+fn makeData(bytes: []const u8) !Id {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const NSData = objc.objc_getClass("NSData") orelse return error.ClassNotFound;
+    const sel_data = objc.sel_registerName("dataWithBytes:length:") orelse return error.SelectorNotFound;
+
+    // The length must be an explicit `c_ulong` (`NSUInteger`): the variadic
+    // `objc_msgSend` cast takes the argument type from what is passed, and a
+    // Zig `usize` literal would be a different type in the signature.
+    const data = objc.msgSendId2(NSData, sel_data, bytes.ptr, @as(c_ulong, @intCast(bytes.len)));
+    if (data == null) return error.NSDataCreationFailed;
+    return data;
+}
+
+/// Store `value` under `key`, replacing any existing item.
+///
+/// Delete-then-add, as in Swift, but with the delete given the *scoped* query —
+/// see the module comment for why. The delete's status is discarded exactly as
+/// Swift discards it: "there was nothing to replace" is the common case and is
+/// not a failure. The add's status is never discarded.
+fn keychainSet(allocator: std.mem.Allocator, key: []const u8, value: []const u8, group: ?[]const u8) !void {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const query = try newQuery(allocator, key, group);
+
+    _ = SecItemDelete(query);
+
+    try setQueryValue(query, kSecValueData, try makeData(value));
+    // Device-local and unreadable while locked. On the add only — naming it in
+    // a delete or a match query would filter by it rather than set it.
+    try setQueryValue(query, kSecAttrAccessible, kSecAttrAccessibleWhenUnlockedThisDeviceOnly);
+
+    const status = SecItemAdd(query, null);
+    if (status != errSecSuccess) return failStatus("set", key, group, status);
+}
+
+/// Read `key`, returning an owned copy of its bytes, or null when absent.
+///
+/// Copied out rather than borrowed because the result of
+/// `SecItemCopyMatching` arrives **+1 retained** — ARC released it for Swift,
+/// Zig must not — and the copy is what lets the `CFRelease` sit next to the
+/// read on every path. Forgetting it leaks a page-sized allocation per `get`.
+fn keychainGet(allocator: std.mem.Allocator, key: []const u8, group: ?[]const u8) !?[]u8 {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const query = try newQuery(allocator, key, group);
+    // `kCFBooleanTrue`, not an `NSNumber` built here. Swift's `true` bridges to
+    // the `__NSCFBoolean` singleton, and `prefs_macos.zig` already records what
+    // confusing the two costs.
+    try setQueryValue(query, kSecReturnData, kCFBooleanTrue);
+    try setQueryValue(query, kSecMatchLimit, kSecMatchLimitOne);
+
+    var result: CFTypeRef = null;
+    const status = SecItemCopyMatching(query, &result);
+
+    if (status == errSecItemNotFound) return null;
+    if (status != errSecSuccess) return failStatus("get", key, group, status);
+
+    const data = result orelse {
+        // errSecSuccess with no object back should be impossible; if it happens
+        // it is not "the key is empty" and must not be answered as one.
+        std.log.warn("keychain get for key '{s}' returned errSecSuccess with no data", .{key});
+        return bridge_error.BridgeError.NativeCallFailed;
+    };
+    defer CFRelease(data);
+
+    // Swift's `result as? Data`. With `kSecReturnData` + `kSecMatchLimitOne`
+    // this is always a `CFDataRef`, and the type check costs one message send
+    // to be sure it is not something that would be read as raw bytes anyway.
+    if (!try isData(data)) {
+        std.log.warn("keychain get for key '{s}' returned a non-CFData result", .{key});
+        return bridge_error.BridgeError.NativeCallFailed;
+    }
+
+    const len = try dataLength(data);
+    const bytes: []const u8 = if (len == 0)
+        // `-bytes` is documented to return nil for empty data, so a zero length
+        // is answered without dereferencing anything.
+        &[_]u8{}
+    else
+        (try dataBytes(data) orelse {
+            std.log.warn("keychain get for key '{s}' returned {d} bytes at a nil pointer", .{ key, len });
+            return bridge_error.BridgeError.NativeCallFailed;
+        })[0..len];
+
+    if (!std.unicode.utf8ValidateSlice(bytes)) {
+        // Swift's `String(data:encoding:.utf8)` failing falls into the `else`
+        // and rejects with `"Keychain error: 0"` — a status that means success.
+        // Neither `BridgeError` fits well: the native call did succeed, so
+        // `NativeCallFailed` is wrong, and the caller's parameters were fine, so
+        // `InvalidParameter` is only right in the sense that the item under this
+        // key is not something a string-valued API can return. The log line is
+        // the part that is actually diagnostic.
+        std.log.warn("keychain item for key '{s}' is not valid UTF-8; this API only returns strings", .{key});
+        return bridge_error.BridgeError.InvalidParameter;
+    }
+
+    return try allocator.dupe(u8, bytes);
+}
+
+/// Delete `key`. Absent is success, as in Swift.
+fn keychainRemove(allocator: std.mem.Allocator, key: []const u8, group: ?[]const u8) !void {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const query = try newQuery(allocator, key, group);
+    const status = SecItemDelete(query);
+    if (status == errSecSuccess or status == errSecItemNotFound) return;
+    return failStatus("remove", key, group, status);
+}
+
+/// `-[NSObject isKindOfClass:[NSData class]]`. `CFData` is toll-free bridged, so
+/// this is true for the `CFDataRef` the keychain hands back.
+fn isData(obj: Id) !bool {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const NSData = objc.objc_getClass("NSData") orelse return error.ClassNotFound;
+    const sel_kind = objc.sel_registerName("isKindOfClass:") orelse return error.SelectorNotFound;
+    const Fn = *const fn (objc.id, objc.SEL, objc.id) callconv(.c) bool;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    return func(obj, sel_kind, NSData);
+}
+
+/// `-[NSData length]`. `NSUInteger`, hence `c_ulong`.
+fn dataLength(data: Id) !usize {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const sel_length = objc.sel_registerName("length") orelse return error.SelectorNotFound;
+    const Fn = *const fn (objc.id, objc.SEL) callconv(.c) c_ulong;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    return @intCast(func(data, sel_length));
+}
+
+/// `-[NSData bytes]`. Not `-UTF8String`: the keychain returns a `CFDataRef`,
+/// which has no such selector — sending it would be a runtime crash rather than
+/// a compile error, which is why the selector strings here are worth reading
+/// twice.
+///
+/// The pointer is valid until the data is released, which the caller does after
+/// copying.
+fn dataBytes(data: Id) !?[*]const u8 {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const sel_bytes = objc.sel_registerName("bytes") orelse return error.SelectorNotFound;
+    const Fn = *const fn (objc.id, objc.SEL) callconv(.c) ?[*]const u8;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    return func(data, sel_bytes);
+}
+
+const testing = std.testing;
+
+test "the declared actions are the ones the handler serves" {
+    try testing.expectEqual(@as(usize, 3), capability_actions.len);
+    try testing.expectEqualStrings(A.set_shared_item, capability_actions[0].name);
+    try testing.expectEqualStrings(A.get_shared_item, capability_actions[1].name);
+    try testing.expectEqualStrings(A.remove_shared_item, capability_actions[2].name);
+
+    for (capability_actions) |decl| {
+        try testing.expectEqual(capabilities.Reply.result, decl.reply);
+        try testing.expectEqual(capabilities.ActionStatus.live, decl.status);
+    }
+}
+
+test "the action names match the Swift case labels exactly" {
+    // The conformance ratchet compares these strings against the `case "…":`
+    // labels in `CraftApp.swift`, in both directions. A prettier spelling would
+    // register as Zig serving an action the spec does not have.
+    try testing.expectEqualStrings("setSharedItem", A.set_shared_item);
+    try testing.expectEqualStrings("getSharedItem", A.get_shared_item);
+    try testing.expectEqualStrings("removeSharedItem", A.remove_shared_item);
+}
+
+test "every declared action dispatches to something" {
+    // `{}` has no `key`, so all three fail validation *before* any Security
+    // call — which is what makes this safe to run on a developer's machine: the
+    // host keychain is never touched. What it rules out is a name in the table
+    // that `handleMessage` does not compare against.
+    var bridge = StorageBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    for (capability_actions) |decl| {
+        try testing.expectError(
+            bridge_error.BridgeError.MissingData,
+            bridge.handleMessage(decl.name, "{}"),
+        );
+    }
+}
+
+test "an action the namespace does not serve is reported, not ignored" {
+    var bridge = StorageBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("clearSharedItems", "{}"),
+    );
+    // The Swift *helper* names, which are not action names. Accepting one would
+    // mean the conformance scan sees an action the spec's dispatcher lacks.
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("setSharedKeychainItem", "{\"key\":\"k\",\"value\":\"v\"}"),
+    );
+    // The desktop keychain namespace's spelling, which is a different bridge.
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("setPassword", "{\"key\":\"k\",\"value\":\"v\"}"),
+    );
+}
+
+test "a malformed payload is reported as bad JSON, not as a missing field" {
+    var bridge = StorageBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidJSON,
+        bridge.handleMessage(A.get_shared_item, "{not json"),
+    );
+}
+
+/// Parse a literal payload and hand the `Request` to `check` while the backing
+/// `std.json.Parsed` is still alive — the slices in a `Request` point into it.
+fn expectRequest(
+    json: []const u8,
+    rule: ValueRule,
+    check: fn (Request) anyerror!void,
+) !void {
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try check(try parseRequest(parsed.value, rule));
+}
+
+fn expectRequestError(json: []const u8, rule: ValueRule, expected: anyerror) !void {
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectError(expected, parseRequest(parsed.value, rule));
+}
+
+test "the three field names the page sends are the three that are read" {
+    try expectRequest(
+        "{\"key\":\"token\",\"value\":\"abc123\",\"group\":\"group.app.shared\"}",
+        .value_required,
+        struct {
+            fn check(request: Request) !void {
+                try testing.expectEqualStrings("token", request.key);
+                try testing.expectEqualStrings("abc123", request.value.?);
+                try testing.expectEqualStrings("group.app.shared", request.group.?);
+            }
+        }.check,
+    );
+}
+
+test "an absent key is refused rather than defaulted" {
+    try expectRequestError("{\"value\":\"v\"}", .value_required, bridge_error.BridgeError.MissingData);
+    try expectRequestError("{}", .value_absent, bridge_error.BridgeError.MissingData);
+}
+
+test "an absent value is refused rather than stored as empty" {
+    // Swift's `if let value = body["value"] as? String` fails here and replies
+    // nothing at all. A default of `""` would be worse still: it would silently
+    // overwrite a real secret with an empty string and report success.
+    try expectRequestError("{\"key\":\"k\"}", .value_required, bridge_error.BridgeError.MissingData);
+}
+
+test "a non-string key or value is refused, not coerced" {
+    try expectRequestError("{\"key\":7,\"value\":\"v\"}", .value_required, bridge_error.BridgeError.InvalidParameter);
+    try expectRequestError("{\"key\":\"k\",\"value\":7}", .value_required, bridge_error.BridgeError.InvalidParameter);
+    try expectRequestError("{\"key\":null}", .value_absent, bridge_error.BridgeError.InvalidParameter);
+}
+
+test "an explicitly empty value is a value, and is stored" {
+    // Distinct from an absent one. Writing `""` is a legitimate request and the
+    // page can read it back; only the absent case is an error.
+    try expectRequest(
+        "{\"key\":\"k\",\"value\":\"\"}",
+        .value_required,
+        struct {
+            fn check(request: Request) !void {
+                try testing.expectEqualStrings("", request.value.?);
+            }
+        }.check,
+    );
+}
+
+test "null and absent group both mean no access group" {
+    // The injected JS sends `group || null`, so `null` is how a page normally
+    // says it wants none — as common as omitting the field.
+    const cases = [_][]const u8{
+        "{\"key\":\"k\",\"group\":null}",
+        "{\"key\":\"k\"}",
+    };
+    for (cases) |json| {
+        try expectRequest(json, .value_absent, struct {
+            fn check(request: Request) !void {
+                try testing.expect(request.group == null);
+            }
+        }.check);
+    }
+}
+
+test "an empty group is passed through, not turned into no group" {
+    // The dropped-field regression. `""` is not `null`: silently promoting it
+    // would search the default access group instead of the one the caller named
+    // and report the answer as if it came from theirs.
+    try expectRequest(
+        "{\"key\":\"k\",\"group\":\"\"}",
+        .value_absent,
+        struct {
+            fn check(request: Request) !void {
+                try testing.expect(request.group != null);
+                try testing.expectEqualStrings("", request.group.?);
+            }
+        }.check,
+    );
+}
+
+test "a key or group with an embedded NUL is refused, not truncated" {
+    // `createNSString` goes through `stringWithUTF8String:`, which stops at the
+    // first NUL, so an unchecked "a\u0000b" would address the keychain item
+    // named "a" while the reply echoed the full key back. Two distinct page
+    // keys would then share one item, and `set` would report success for a key
+    // it did not use. `\u0000` is a legal JSON escape and `std.json` decodes it
+    // to the byte, so a page can reach this.
+    try expectRequestError(
+        "{\"key\":\"a\\u0000b\",\"value\":\"v\"}",
+        .value_required,
+        bridge_error.BridgeError.InvalidParameter,
+    );
+    // The access group takes the same route into the query and so takes the
+    // same check: a truncated group names a different access group.
+    try expectRequestError(
+        "{\"key\":\"k\",\"group\":\"g\\u0000x\"}",
+        .value_absent,
+        bridge_error.BridgeError.InvalidParameter,
+    );
+
+    // The *value* keeps its NUL and is not refused: `makeData` passes bytes and
+    // a length, so there is nothing to truncate. Refusing it would be dropping
+    // a payload field the handler can carry perfectly well.
+    try expectRequest(
+        "{\"key\":\"k\",\"value\":\"a\\u0000b\"}",
+        .value_required,
+        struct {
+            fn check(request: Request) !void {
+                try testing.expectEqualSlices(u8, &[_]u8{ 'a', 0, 'b' }, request.value.?);
+            }
+        }.check,
+    );
+}
+
+test "a group that is not a string is refused rather than ignored" {
+    // Swift's `as? String` drops it and quietly operates on the default access
+    // group — a different item than the caller named, reported as success.
+    try expectRequestError("{\"key\":\"k\",\"group\":42}", .value_absent, bridge_error.BridgeError.InvalidParameter);
+}
+
+test "a payload that is not an object is bad JSON, not a missing field" {
+    try expectRequestError("[]", .value_absent, bridge_error.BridgeError.InvalidJSON);
+    try expectRequestError("\"key\"", .value_absent, bridge_error.BridgeError.InvalidJSON);
+}
+
+test "the set and remove reply is the Swift dictionary verbatim" {
+    const json = try successReply(testing.allocator, "token");
+    defer testing.allocator.free(json);
+    try testing.expectEqualStrings("{\"success\":true,\"key\":\"token\"}", json);
+}
+
+test "a found value and a missing one are different replies" {
+    const found = try valueReply(testing.allocator, "token", "abc123");
+    defer testing.allocator.free(found);
+    try testing.expectEqualStrings("{\"value\":\"abc123\",\"key\":\"token\"}", found);
+
+    const missing = try valueReply(testing.allocator, "token", null);
+    defer testing.allocator.free(missing);
+    try testing.expectEqualStrings("{\"value\":null,\"key\":\"token\"}", missing);
+
+    // A stored empty string is not a missing item, and the page must be able to
+    // tell them apart.
+    const empty = try valueReply(testing.allocator, "token", "");
+    defer testing.allocator.free(empty);
+    try testing.expectEqualStrings("{\"value\":\"\",\"key\":\"token\"}", empty);
+}
+
+test "a page-controlled key or value cannot break the reply" {
+    // Both are echoed into JavaScript that `evaluateJavaScript:` parses as
+    // source. `bufPrint` with `{s}`, which `describeDevice` can safely use for
+    // UIKit-sourced strings, would produce a syntax error in the page here.
+    const json = try valueReply(testing.allocator, "we\"ird\\key", "line\none\ttwo\x01");
+    defer testing.allocator.free(json);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("we\"ird\\key", parsed.value.object.get("key").?.string);
+    try testing.expectEqualStrings("line\none\ttwo\x01", parsed.value.object.get("value").?.string);
+}
+
+test "an OSStatus maps to the nearest error, and nothing else is guessed at" {
+    try testing.expectEqual(bridge_error.BridgeError.NotFound, errorForStatus(errSecItemNotFound));
+    // The entitlement gap: a `group` on a signed device build lands here.
+    try testing.expectEqual(bridge_error.BridgeError.PermissionDenied, errorForStatus(errSecMissingEntitlement));
+    // errSecDuplicateItem, errSecParam, errSecInteractionNotAllowed and the
+    // rest are deliberately unmapped — a mis-transcribed constant that
+    // reclassifies one failure as another is worse than a generic one, and the
+    // raw number reaches the log either way.
+    try testing.expectEqual(bridge_error.BridgeError.NativeCallFailed, errorForStatus(-25299));
+    try testing.expectEqual(bridge_error.BridgeError.NativeCallFailed, errorForStatus(-50));
+    try testing.expectEqual(bridge_error.BridgeError.NativeCallFailed, errorForStatus(-25308));
+}
+
+test "the constants that are branched on are the documented ones" {
+    // These three numbers are load-bearing: `errSecItemNotFound` is the
+    // difference between `{"value":null}` and a rejection, and a wrong
+    // `errSecSuccess` would make every call look like a failure.
+    try testing.expectEqual(@as(OSStatus, 0), errSecSuccess);
+    try testing.expectEqual(@as(OSStatus, -25300), errSecItemNotFound);
+    try testing.expectEqual(@as(OSStatus, -34018), errSecMissingEntitlement);
+}
+
+// The remaining tests exercise the Objective-C half against the live runtime.
+// They need no device, no UIKit and no keychain — only libobjc and Foundation,
+// which a macOS host has — and they are skipped off Darwin. They are here
+// because a wrong selector string is not a compile error: it is a runtime crash
+// or a silent no-op, and nothing else in this file would catch one.
+//
+// The keychain calls themselves stay untested. `SecItemCopyMatching` for an
+// absent key was run by hand during development and answered
+// `errSecItemNotFound` — which proves the `kSec*` globals resolve, the
+// dictionary bridges to `CFDictionaryRef`, and the not-found branch is reached —
+// but a headless CI runner may have no login keychain at all, and a test that
+// depends on that is a flake, not a gate. A write/read/delete round trip needs
+// the simulator.
+
+test "the NSData selectors round-trip bytes, embedded NUL included" {
+    if (!builtin.target.os.tag.isDarwin()) return error.SkipZigTest;
+
+    // The NUL is the point: `length`/`bytes` are used rather than
+    // `UTF8String` + `std.mem.span`, which would truncate a stored value at the
+    // first zero byte and report the truncation as the value.
+    const payload = "he\x00llo";
+    const data = try makeData(payload);
+    try testing.expect(try isData(data));
+
+    const len = try dataLength(data);
+    try testing.expectEqual(@as(usize, payload.len), len);
+
+    const bytes = (try dataBytes(data)).?;
+    try testing.expectEqualSlices(u8, payload, bytes[0..len]);
+}
+
+test "an empty value is empty data, and is never dereferenced" {
+    if (!builtin.target.os.tag.isDarwin()) return error.SkipZigTest;
+
+    const data = try makeData("");
+    try testing.expect(try isData(data));
+    try testing.expectEqual(@as(usize, 0), try dataLength(data));
+}
+
+test "the CFData type check rejects something that is not data" {
+    if (!builtin.target.os.tag.isDarwin()) return error.SkipZigTest;
+
+    // Swift's `result as? Data`. An NSString stands in for "the keychain
+    // returned something else", which is the case that must not be read as raw
+    // bytes and handed to the page as a value.
+    const ns = try objc.createNSString("not data", testing.allocator);
+    try testing.expect(!try isData(ns));
+}

--- a/packages/zig/src/bridge_mobile_system.zig
+++ b/packages/zig/src/bridge_mobile_system.zig
@@ -1,0 +1,1043 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const capabilities = @import("capabilities.zig");
+const bridge_error = @import("bridge_error.zig");
+const objc_runtime = @import("objc_runtime.zig");
+const ios_dispatch = @import("ios_dispatch.zig");
+const request_context = @import("request_context.zig");
+
+const objc = objc_runtime.objc;
+
+/// Whether this build can talk to UIKit at all.
+///
+/// `objc_runtime.zig` degrades `objc` to an empty struct off Darwin, so a
+/// reference to `objc.objc_getClass` on a Linux host is a compile error, not a
+/// runtime one. Every UIKit call in this file therefore sits behind a
+/// *comptime* `if`/`else` — a bare `if (!is_darwin) return error.X;` would not
+/// help, because Zig still analyses the code that follows it.
+const is_darwin = builtin.target.os.tag.isDarwin();
+
+/// Three system actions the page can ask the OS to perform on its behalf.
+///
+/// They share one property that separates them from `getDeviceInfo`: none of
+/// them can answer immediately and truthfully. `openURL` only learns whether
+/// the URL opened when iOS calls back; `share` only learns whether the user
+/// picked an activity when the sheet closes; `requestReview` never learns
+/// anything at all. The Swift implementations all resolved `true` at the point
+/// of asking, before iOS had decided anything — which is the fabricated
+/// success this migration exists to stop.
+///
+/// Two porting decisions are deliberate and are not accidents of translation:
+///
+/// **`openURL` applies no scheme filter**, matching Swift. `external_link.zig`
+/// allows only `http:`/`https:`, but it governs *page-initiated* navigation on
+/// content the app does not control; `craft.openURL` is an app-facing call
+/// where the app chose the URL, and `tel:`, `mailto:`, `shortcuts://` and
+/// custom app schemes are its main use. Filtering here would silently break
+/// them.
+///
+/// **`share` is served unconditionally.** Swift gates it on
+/// `config.enableShare` and replies `CAPABILITY_DISABLED`; `ios.zig`'s
+/// `AppConfig` has no such field, so Zig cannot reproduce the gate. An app that
+/// set `enableShare: false` will now get a share sheet. Restoring the gate
+/// means adding the field to `AppConfig`, not adding a guess here.
+pub const A = struct {
+    pub const open_url = "openURL";
+    pub const share = "share";
+    pub const request_review = "requestReview";
+};
+
+pub const capability_actions = [_]capabilities.ActionDecl{
+    .{ .name = A.open_url, .reply = .result },
+    .{ .name = A.share, .reply = .result },
+    // Live, but only in a host app that links StoreKit: the framework is
+    // resolved by name at runtime, and `objc_getClass` returning null produces
+    // an explicit error rather than a silent success. The fixture's link line
+    // (`packages/ios/fixtures/zig-slice/build-and-run.sh`) does not carry
+    // `-framework StoreKit`, so the simulator harness will see that error until
+    // it does.
+    .{ .name = A.request_review, .reply = .result },
+};
+
+/// The exact reply bodies this file puts on the wire.
+///
+/// Named rather than written inline at each `sendResultToJS`, so the test that
+/// pins their shape reads the same bytes the handlers send instead of a copy
+/// of them that can drift. Every one is a JSON *object* carrying a boolean:
+/// `craft-bridge.js` resolves with `payload || {}`, so a bare `false` and an
+/// empty reply are the same value to the page — a fabricated success wearing
+/// the shape of an honest one.
+const R = struct {
+    const opened = "{\"opened\":true}";
+    const not_opened = "{\"opened\":false}";
+    const completed = "{\"completed\":true}";
+    const not_completed = "{\"completed\":false}";
+    const requested = "{\"requested\":true}";
+
+    const all = [_][]const u8{ opened, not_opened, completed, not_completed, requested };
+};
+
+pub const SystemBridge = struct {
+    allocator: std.mem.Allocator,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator) Self {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(_: *Self) void {}
+
+    pub fn handleMessage(self: *Self, action: []const u8, data: []const u8) !void {
+        if (std.mem.eql(u8, action, A.open_url)) {
+            try self.openURL(data);
+        } else if (std.mem.eql(u8, action, A.share)) {
+            try self.share(data);
+        } else if (std.mem.eql(u8, action, A.request_review)) {
+            try self.requestReview();
+        } else {
+            return bridge_error.BridgeError.UnknownAction;
+        }
+    }
+
+    /// `craft.openURL(url)` — hand a URL to iOS and report what iOS did with it.
+    ///
+    /// The reply is sent from the completion handler, not from here, so this
+    /// function returning is *not* the call being answered. That is the whole
+    /// difference from the Swift version, which resolved `true` before
+    /// `open:` had decided anything and so reported success for an unhandled
+    /// scheme.
+    fn openURL(self: *Self, data: []const u8) !void {
+        const parsed = std.json.parseFromSlice(std.json.Value, self.allocator, data, .{}) catch
+            return bridge_error.BridgeError.InvalidJSON;
+        defer parsed.deinit();
+
+        const root = switch (parsed.value) {
+            .object => |obj| obj,
+            else => return bridge_error.BridgeError.InvalidJSON,
+        };
+
+        // `url`, top level — the page's `openURL` posts it flat, not under
+        // `options`. Swift's `if let` fell through when it was absent and never
+        // settled the callback at all, leaving the page's promise to time out
+        // with nothing to point at.
+        const url = try stringField(root, "url");
+        if (url.len == 0) return bridge_error.BridgeError.MissingData;
+
+        try uikit.openURL(self.allocator, url, capturedRequestId());
+    }
+
+    /// `craft.share(text)` and `craft.share.share(options)` — the same action,
+    /// two payload shapes, both of which have live callers.
+    fn share(self: *Self, data: []const u8) !void {
+        const parsed = std.json.parseFromSlice(std.json.Value, self.allocator, data, .{}) catch
+            return bridge_error.BridgeError.InvalidJSON;
+        defer parsed.deinit();
+
+        const root = switch (parsed.value) {
+            .object => |obj| obj,
+            else => return bridge_error.BridgeError.InvalidJSON,
+        };
+
+        // The strings borrow `parsed`'s arena, which outlives this call: the
+        // sheet is built and presented before `parsed.deinit()` runs, and
+        // UIKit has copied everything it needs into NSStrings by then.
+        var request = try parseShareRequest(self.allocator, root);
+        defer request.deinit(self.allocator);
+
+        try uikit.share(self.allocator, request, capturedRequestId());
+    }
+
+    /// `craft.requestReview()` — ask StoreKit to consider showing the rating
+    /// prompt.
+    ///
+    /// Takes no payload; `ios_dispatch.payloadOf` hands this handler `"{}"` and
+    /// there is nothing in it to read.
+    fn requestReview(self: *Self) !void {
+        try uikit.requestReview(self.allocator);
+    }
+};
+
+/// The id of the call being served, frozen as a plain integer.
+///
+/// `request_context` is a threadlocal stack that `ios_dispatch.handleMessage`
+/// pops on return, so a completion handler firing later sees it empty and
+/// `sendResultToJS` would stamp the reply `id = null`. A null id sends the
+/// reply down `craft-bridge.js`'s action-name FIFO instead of to the waiting
+/// promise, which hands one caller's answer to another whenever two shares are
+/// in flight. `handOffToHost` solves the same problem the same way, including
+/// the negative sentinel for "the page sent no id".
+fn capturedRequestId() i64 {
+    return if (request_context.current()) |id| @intCast(id) else -1;
+}
+
+/// A string field, or `""` when the page did not send one.
+///
+/// A wrong *type* is an error rather than a miss: quietly treating
+/// `{"url": 42}` as absent is how a payload field goes missing and the caller
+/// is told everything went fine.
+fn stringField(obj: std.json.ObjectMap, name: []const u8) ![]const u8 {
+    const v = obj.get(name) orelse return "";
+    return switch (v) {
+        .string => |s| s,
+        // `JSON.stringify` keeps an explicit null where it drops an undefined,
+        // so null is the page saying "no value", not a type error.
+        .null => "",
+        else => bridge_error.BridgeError.InvalidParameter,
+    };
+}
+
+/// What the page wants to share, in the order `UIActivityViewController` must
+/// receive it.
+///
+/// The order is load-bearing: an activity decides what it gets from the type
+/// and position of each item, so title-then-text-then-url-then-files is the
+/// behaviour being ported, not an arbitrary field ordering.
+pub const ShareRequest = struct {
+    title: []const u8 = "",
+    text: []const u8 = "",
+    url: []const u8 = "",
+    files: []const []const u8 = &.{},
+
+    /// Frees the `files` slice. The strings themselves belong to the JSON
+    /// arena the request was parsed from.
+    pub fn deinit(self: *ShareRequest, allocator: std.mem.Allocator) void {
+        allocator.free(self.files);
+        self.files = &.{};
+    }
+};
+
+/// Read a `share` payload in either of the two shapes that reach it.
+///
+/// `craft.share.share(options)` goes through `_invoke`, which nests everything
+/// one level under `options`. The legacy `craft.share(text)` posts `text` flat
+/// and is still live in the injected script. Reading only one of them breaks
+/// the other half of the callers — the same field-name mismatch that had
+/// `craft.fs.writeFile` writing empty files.
+///
+/// Where this is deliberately wider than Swift: when there is no `options`,
+/// Swift rebuilds the payload as `["text": text]` and drops any `url`, `title`
+/// or `files` that were sent alongside. Here the top-level object is read
+/// whole. Nothing that works today stops working, and a field the page sent is
+/// not thrown away.
+///
+/// Empty strings are skipped rather than shared, so `share({text: ''})` is
+/// "nothing to share" and not an empty sheet.
+pub fn parseShareRequest(allocator: std.mem.Allocator, root: std.json.ObjectMap) !ShareRequest {
+    const source: std.json.ObjectMap = if (root.get("options")) |v| switch (v) {
+        .object => |o| o,
+        else => root,
+    } else root;
+
+    var request = ShareRequest{
+        .title = try stringField(source, "title"),
+        .text = try stringField(source, "text"),
+        .url = try stringField(source, "url"),
+    };
+
+    if (source.get("files")) |v| switch (v) {
+        .array => |entries| {
+            var list: std.ArrayListUnmanaged([]const u8) = .empty;
+            errdefer list.deinit(allocator);
+            for (entries.items) |entry| switch (entry) {
+                .string => |s| if (s.len > 0) try list.append(allocator, s),
+                // `files` is declared `string[]`. A non-string element is the
+                // caller getting the type wrong, and saying so beats sharing a
+                // shorter list than was asked for.
+                else => return bridge_error.BridgeError.InvalidParameter,
+            };
+            request.files = try list.toOwnedSlice(allocator);
+        },
+        .null => {},
+        else => return bridge_error.BridgeError.InvalidParameter,
+    };
+    errdefer request.deinit(allocator);
+
+    // Swift's "Nothing to share" / INVALID_ARGUMENT. Checked here so an
+    // obviously empty request fails before any UIKit object is built; the
+    // authoritative check is on the assembled item array, because a `files`
+    // entry that names nothing on disk contributes no item.
+    if (request.title.len == 0 and request.text.len == 0 and
+        request.url.len == 0 and request.files.len == 0)
+    {
+        return bridge_error.BridgeError.InvalidParameter;
+    }
+
+    return request;
+}
+
+// =============================================================================
+// Objective-C block layouts
+//
+// `{ isa, flags, reserved, invoke, descriptor }` is the ABI every block on
+// Apple platforms has; `_NSConcreteStackBlock` is the symbol the isa points at
+// for a block that starts life on the stack. Same shape `bridge_permissions.zig`
+// and `macos.zig` already hand to AppKit, with one addition: a trailing capture.
+//
+// The existing two are capture-free statics, which cannot carry a request id —
+// and without the id an async reply cannot name the call it answers. A capture
+// is just a field appended after `descriptor`, with `descriptor.size` grown to
+// match: `_Block_copy` memcpys exactly that many bytes onto the heap and
+// retargets `isa` to `_NSConcreteMallocBlock`. `flags = 0` (no
+// `BLOCK_HAS_COPY_DISPOSE`) is right for a plain integer capture, which needs
+// no copy/dispose helpers.
+//
+// The blocks are built on the handler's stack because both callees —
+// `openURL:options:completionHandler:` and `setCompletionWithItemsHandler:` —
+// copy the block before returning.
+//
+// The pointer fields are written `?*anyopaque` rather than `objc.id` even
+// though `objc_runtime.zig:32` defines them as the same type, so these layouts
+// still compile on a host where `objc` is an empty struct.
+// =============================================================================
+
+const BlockDescriptor = extern struct {
+    reserved: usize = 0,
+    size: usize,
+};
+
+extern var _NSConcreteStackBlock: anyopaque;
+
+/// `void (^)(BOOL success)` — what `openURL:options:completionHandler:` calls.
+const OpenURLBlock = extern struct {
+    isa: ?*anyopaque,
+    flags: c_int,
+    reserved: c_int,
+    invoke: *const fn (*const anyopaque, bool) callconv(.c) void,
+    descriptor: *const BlockDescriptor,
+    /// The captured `i` of the call this answers; negative for "the page sent
+    /// none". `invoke` is handed a pointer to the block itself, so it reads
+    /// this back out of its own storage.
+    request_id: i64,
+};
+
+const open_url_block_descriptor = BlockDescriptor{ .size = @sizeOf(OpenURLBlock) };
+
+/// `void (^)(UIActivityType, BOOL completed, NSArray *, NSError *)` — what
+/// `UIActivityViewController.completionWithItemsHandler` calls.
+const ShareBlock = extern struct {
+    isa: ?*anyopaque,
+    flags: c_int,
+    reserved: c_int,
+    invoke: *const fn (*const anyopaque, ?*anyopaque, bool, ?*anyopaque, ?*anyopaque) callconv(.c) void,
+    descriptor: *const BlockDescriptor,
+    request_id: i64,
+};
+
+const share_block_descriptor = BlockDescriptor{ .size = @sizeOf(ShareBlock) };
+
+/// Deliver `json` as the answer to `request_id`, from outside any dispatch.
+///
+/// The dispatch frame is long gone by the time a completion handler runs, so
+/// the id is pushed back before replying and popped after — the shape
+/// `craft_ios_deliver_result` already uses. The allocator is
+/// `std.heap.c_allocator` and not the bridge's, for the same reason: the
+/// `SystemBridge` that started this call was destroyed when `handleMessage`
+/// returned.
+fn replyFromCallback(request_id: i64, action: []const u8, json: []const u8) void {
+    request_context.push(if (request_id < 0) null else @intCast(request_id));
+    defer request_context.pop();
+    bridge_error.sendResultToJS(std.heap.c_allocator, action, json);
+}
+
+fn failFromCallback(request_id: i64, action: []const u8, err: bridge_error.BridgeError) void {
+    request_context.push(if (request_id < 0) null else @intCast(request_id));
+    defer request_context.pop();
+    bridge_error.sendErrorToJS(std.heap.c_allocator, action, err);
+}
+
+// =============================================================================
+// UIKit
+// =============================================================================
+
+/// Everything that touches UIKit, selected at comptime.
+///
+/// The non-Darwin arm is not a stub that pretends to work — it returns
+/// `error.UnsupportedPlatform`, which `ios_dispatch.asBridgeError` turns into
+/// `PLATFORM_NOT_SUPPORTED` for the page.
+const uikit = if (is_darwin) struct {
+    /// `[[UIApplication sharedApplication] openURL:options:completionHandler:]`
+    ///
+    /// The modern three-argument selector, never the deprecated one-argument
+    /// `openURL:` — that one returns `BOOL` synchronously and casting
+    /// `objc_msgSend` to the wrong shape is a runtime crash, not a compile
+    /// error.
+    ///
+    /// No `canOpenURL:` pre-check: it answers `NO` for any custom scheme the
+    /// app has not listed in `LSApplicationQueriesSchemes`, so gating on it
+    /// would refuse URLs that `open:` would in fact have opened. The completion
+    /// handler's BOOL is the only truthful answer available.
+    fn openURL(allocator: std.mem.Allocator, url_string: []const u8, request_id: i64) !void {
+        const UIApplication = objc.objc_getClass("UIApplication") orelse return error.ClassNotFound;
+        const sel_shared = objc.sel_registerName("sharedApplication") orelse return error.SelectorNotFound;
+        const app = objc.msgSendId(UIApplication, sel_shared);
+        if (app == null) return error.NoApplication;
+
+        // `+[NSURL URLWithString:]` returns nil for a string it cannot parse.
+        // Swift hit the same nil and then settled nothing at all.
+        const url = try objc.createNSURL(url_string, allocator);
+        if (url == null) return bridge_error.BridgeError.InvalidParameter;
+
+        // `options:` is declared nonnull; an empty dictionary is the documented
+        // way to pass no options.
+        const NSDictionary = objc.objc_getClass("NSDictionary") orelse return error.ClassNotFound;
+        const sel_dictionary = objc.sel_registerName("dictionary") orelse return error.SelectorNotFound;
+        const options = objc.msgSendId(NSDictionary, sel_dictionary);
+        if (options == null) return error.NativeCallFailed;
+
+        const sel_open = objc.sel_registerName("openURL:options:completionHandler:") orelse
+            return error.SelectorNotFound;
+
+        var block = OpenURLBlock{
+            .isa = &_NSConcreteStackBlock,
+            .flags = 0,
+            .reserved = 0,
+            .invoke = openURLDidFinish,
+            .descriptor = &open_url_block_descriptor,
+            .request_id = request_id,
+        };
+
+        const Fn = *const fn (objc.id, objc.SEL, objc.id, objc.id, objc.id) callconv(.c) void;
+        const func: Fn = @ptrCast(&objc.objc_msgSend);
+        func(app, sel_open, url, options, @as(objc.id, @ptrCast(&block)));
+    }
+
+    fn openURLDidFinish(block: *const anyopaque, opened: bool) callconv(.c) void {
+        const self: *const OpenURLBlock = @ptrCast(@alignCast(block));
+        replyFromCallback(self.request_id, A.open_url, if (opened) R.opened else R.not_opened);
+    }
+
+    /// Build the activity items, present the sheet, and answer when it closes.
+    fn share(allocator: std.mem.Allocator, request: ShareRequest, request_id: i64) !void {
+        const NSMutableArray = objc.objc_getClass("NSMutableArray") orelse return error.ClassNotFound;
+        const sel_array = objc.sel_registerName("array") orelse return error.SelectorNotFound;
+        const sel_add = objc.sel_registerName("addObject:") orelse return error.SelectorNotFound;
+
+        const items = objc.msgSendId(NSMutableArray, sel_array);
+        if (items == null) return error.NativeCallFailed;
+
+        if (request.title.len > 0) try addString(allocator, items, sel_add, request.title);
+        if (request.text.len > 0) try addString(allocator, items, sel_add, request.text);
+        if (request.url.len > 0) {
+            // The same condition `openURL` refuses, refused the same way. Swift
+            // dropped an unparseable `url` and shared whatever else was in the
+            // request, so a caller who asked to share a link got a sheet with
+            // only its text and was told the share completed — a payload field
+            // silently discarded under a success.
+            const url = try objc.createNSURL(request.url, allocator);
+            if (url == null) return bridge_error.BridgeError.InvalidParameter;
+            objc.msgSendVoid1(items, sel_add, url);
+        }
+        if (request.files.len > 0) try appendFiles(allocator, items, sel_add, request.files);
+
+        // The authoritative "Nothing to share": a `files` entry that is neither
+        // a file URL nor an existing path contributes no item, so a request
+        // that looked non-empty on the way in can still assemble to nothing.
+        // An empty sheet is not the answer — an error is.
+        const sel_count = objc.sel_registerName("count") orelse return error.SelectorNotFound;
+        const CountFn = *const fn (objc.id, objc.SEL) callconv(.c) c_ulong;
+        const count_fn: CountFn = @ptrCast(&objc.objc_msgSend);
+        if (count_fn(items, sel_count) == 0) return bridge_error.BridgeError.InvalidParameter;
+
+        // Resolved before the controller is built so a missing presenter is an
+        // error rather than a leaked, never-presented view controller.
+        const presenter = try topmostViewController();
+
+        const UIActivityViewController = objc.objc_getClass("UIActivityViewController") orelse
+            return error.ClassNotFound;
+        const allocated = try objc.alloc(UIActivityViewController);
+        const sel_init = objc.sel_registerName("initWithActivityItems:applicationActivities:") orelse
+            return error.SelectorNotFound;
+        const InitFn = *const fn (objc.id, objc.SEL, objc.id, objc.id) callconv(.c) objc.id;
+        const init_fn: InitFn = @ptrCast(&objc.objc_msgSend);
+        const activity_vc = init_fn(allocated, sel_init, items, null);
+        if (activity_vc == null) return error.NativeCallFailed;
+        // `alloc` gave us +1. The presenting controller retains the sheet for
+        // the life of the presentation, so ours is the reference to drop —
+        // and on the error paths below it is the only one there is.
+        defer objc.release(activity_vc);
+
+        var block = ShareBlock{
+            .isa = &_NSConcreteStackBlock,
+            .flags = 0,
+            .reserved = 0,
+            .invoke = shareDidFinish,
+            .descriptor = &share_block_descriptor,
+            .request_id = request_id,
+        };
+        const sel_set_handler = objc.sel_registerName("setCompletionWithItemsHandler:") orelse
+            return error.SelectorNotFound;
+        objc.msgSendVoid1(activity_vc, sel_set_handler, @as(objc.id, @ptrCast(&block)));
+
+        try anchorPopover(activity_vc, presenter);
+
+        const sel_present = objc.sel_registerName("presentViewController:animated:completion:") orelse
+            return error.SelectorNotFound;
+        const PresentFn = *const fn (objc.id, objc.SEL, objc.id, bool, objc.id) callconv(.c) void;
+        const present_fn: PresentFn = @ptrCast(&objc.objc_msgSend);
+        present_fn(presenter, sel_present, activity_vc, true, null);
+    }
+
+    /// `[items addObject:@"…"]`, refusing rather than passing nil.
+    ///
+    /// `+[NSString stringWithUTF8String:]` answers nil for bytes that are not
+    /// valid UTF-8, and `-[NSMutableArray addObject:]` raises
+    /// `NSInvalidArgumentException` on nil. That is an ObjC exception, so from
+    /// Zig it is an uncatchable crash rather than something the page can be
+    /// told about — which is why this is a check and not a comment.
+    fn addString(allocator: std.mem.Allocator, items: objc.id, sel_add: objc.SEL, s: []const u8) !void {
+        const ns = try objc.createNSString(s, allocator);
+        if (ns == null) return bridge_error.BridgeError.InvalidParameter;
+        objc.msgSendVoid1(items, sel_add, ns);
+    }
+
+    /// Turn each `files` entry into an NSURL the way Swift does: a string that
+    /// parses as a file URL is used as-is, otherwise a file that exists at that
+    /// literal path becomes a `fileURLWithPath:`.
+    ///
+    /// An entry that is neither is dropped, matching Swift. Unlike a `url` the
+    /// page sent that will not parse, which is refused, this is a fact about
+    /// the filesystem rather than about the payload — the path is well-formed
+    /// and simply names nothing. The caller finds out only when *every* item
+    /// was dropped and there was nothing else to share, because that is what
+    /// the count check below catches. A files-plus-text request that loses its
+    /// files still reports the share completed, which is the one place this
+    /// file knowingly keeps Swift's silence; changing it means deciding whether
+    /// a stale path should fail an otherwise valid share.
+    fn appendFiles(
+        allocator: std.mem.Allocator,
+        items: objc.id,
+        sel_add: objc.SEL,
+        files: []const []const u8,
+    ) !void {
+        const NSURL = objc.objc_getClass("NSURL") orelse return error.ClassNotFound;
+        const NSFileManager = objc.objc_getClass("NSFileManager") orelse return error.ClassNotFound;
+        const sel_default_manager = objc.sel_registerName("defaultManager") orelse return error.SelectorNotFound;
+        const sel_exists = objc.sel_registerName("fileExistsAtPath:") orelse return error.SelectorNotFound;
+        const sel_is_file_url = objc.sel_registerName("isFileURL") orelse return error.SelectorNotFound;
+        const sel_file_url = objc.sel_registerName("fileURLWithPath:") orelse return error.SelectorNotFound;
+
+        const file_manager = objc.msgSendId(NSFileManager, sel_default_manager);
+        if (file_manager == null) return error.NativeCallFailed;
+
+        const ExistsFn = *const fn (objc.id, objc.SEL, objc.id) callconv(.c) bool;
+        const exists_fn: ExistsFn = @ptrCast(&objc.objc_msgSend);
+
+        for (files) |path| {
+            const as_url: objc.id = objc.createNSURL(path, allocator) catch null;
+            if (as_url != null and objc.msgSendBool(as_url, sel_is_file_url)) {
+                objc.msgSendVoid1(items, sel_add, as_url);
+                continue;
+            }
+
+            const ns_path = try objc.createNSString(path, allocator);
+            if (!exists_fn(file_manager, sel_exists, ns_path)) continue;
+
+            const file_url = objc.msgSendId1(NSURL, sel_file_url, ns_path);
+            if (file_url != null) objc.msgSendVoid1(items, sel_add, file_url);
+        }
+    }
+
+    /// Give the sheet an anchor before it is presented.
+    ///
+    /// On a regular size class — every iPad, and iPhone in some multitasking
+    /// configurations — `UIActivityViewController` presents as a popover, and
+    /// UIKit raises `NSGenericException` from `-viewWillAppear:` if neither
+    /// `sourceView` nor `barButtonItem` is set. That is an ObjC exception, so
+    /// from Zig it is an uncatchable crash. The Swift implementation sets
+    /// neither and crashes on iPad today.
+    ///
+    /// `popoverPresentationController` is nil when UIKit did not choose a
+    /// popover (iPhone), so the whole block is skipped there rather than
+    /// guessed at. The rect is centred and `permittedArrowDirections` is set to
+    /// 0 — the *empty* `UIPopoverArrowDirection` option set, Swift's `[]`, which
+    /// draws no arrow. It is emphatically not `UIPopoverArrowDirectionUnknown`,
+    /// which is `NSUIntegerMax`: passing that would permit every direction and
+    /// point an arrow at the middle of the screen.
+    fn anchorPopover(activity_vc: objc.id, presenter: objc.id) !void {
+        const sel_popover = objc.sel_registerName("popoverPresentationController") orelse
+            return error.SelectorNotFound;
+        const popover = objc.msgSendId(activity_vc, sel_popover);
+        if (popover == null) return;
+
+        const sel_view = objc.sel_registerName("view") orelse return error.SelectorNotFound;
+        const host_view = objc.msgSendId(presenter, sel_view);
+        if (host_view == null) return error.NoPresenterView;
+
+        const sel_set_source_view = objc.sel_registerName("setSourceView:") orelse
+            return error.SelectorNotFound;
+        objc.msgSendVoid1(popover, sel_set_source_view, host_view);
+
+        const sel_bounds = objc.sel_registerName("bounds") orelse return error.SelectorNotFound;
+        const BoundsFn = *const fn (objc.id, objc.SEL) callconv(.c) objc.CGRect;
+        const bounds_fn: BoundsFn = @ptrCast(&objc.objc_msgSend);
+        const bounds = bounds_fn(host_view, sel_bounds);
+
+        const sel_set_source_rect = objc.sel_registerName("setSourceRect:") orelse
+            return error.SelectorNotFound;
+        const RectFn = *const fn (objc.id, objc.SEL, objc.CGRect) callconv(.c) void;
+        const rect_fn: RectFn = @ptrCast(&objc.objc_msgSend);
+        rect_fn(popover, sel_set_source_rect, .{
+            .origin = .{ .x = bounds.size.width / 2, .y = bounds.size.height / 2 },
+            .size = .{ .width = 0, .height = 0 },
+        });
+
+        const sel_set_arrows = objc.sel_registerName("setPermittedArrowDirections:") orelse
+            return error.SelectorNotFound;
+        const ArrowFn = *const fn (objc.id, objc.SEL, c_ulong) callconv(.c) void;
+        const arrow_fn: ArrowFn = @ptrCast(&objc.objc_msgSend);
+        arrow_fn(popover, sel_set_arrows, 0);
+    }
+
+    fn shareDidFinish(
+        block: *const anyopaque,
+        _: ?*anyopaque,
+        completed: bool,
+        _: ?*anyopaque,
+        activity_error: ?*anyopaque,
+    ) callconv(.c) void {
+        const self: *const ShareBlock = @ptrCast(@alignCast(block));
+
+        // An NSError from the activity is a failure, not a `completed:false`.
+        // Resolving it would make the page's promise succeed with a
+        // share that did not happen, and the app's catch block never runs.
+        if (activity_error != null) {
+            failFromCallback(self.request_id, A.share, bridge_error.BridgeError.NativeCallFailed);
+            return;
+        }
+
+        replyFromCallback(self.request_id, A.share, if (completed) R.completed else R.not_completed);
+    }
+
+    /// `+[SKStoreReviewController requestReviewInScene:]`
+    ///
+    /// The reply says `requested`, not `shown`, because "shown" is a question
+    /// the API cannot answer: the selector returns void and calls nothing back,
+    /// and iOS suppresses the prompt on its own terms — roughly three per user
+    /// per year, never in TestFlight, and off entirely if the user disabled it
+    /// in Settings. `{"requested":true}` is the strongest true statement
+    /// available. Anything that fails before the call is an error, never
+    /// `{"requested":false}` dressed up as a success — which is what Swift did,
+    /// resolving `true` from outside the `DispatchQueue.main.async` block that
+    /// had not run yet and might have found no scene when it did.
+    fn requestReview(allocator: std.mem.Allocator) !void {
+        // StoreKit first, scene second. Both are required and either can be the
+        // reason this cannot run, but only one of them is a *build* problem: an
+        // app that has not linked the framework has to be told that, not sent
+        // looking for a window scene it already has. Ordering is the only thing
+        // that decides which of the two errors the page is given.
+        const SKStoreReviewController = objc.objc_getClass("SKStoreReviewController") orelse
+            return error.StoreKitNotLinked;
+
+        // `sel_registerName` registers a selector whether or not anything
+        // implements it, so it is not a guard. `requestReviewInScene:` is
+        // deprecated as of iOS 18 in favour of `AppStore.requestReview(in:)`,
+        // which is a SwiftUI environment action with no Objective-C
+        // counterpart and so is unreachable from here. When a future SDK drops
+        // the deprecated method this must fail loudly, not crash.
+        const sel_request = objc.sel_registerName("requestReviewInScene:") orelse
+            return error.SelectorNotFound;
+        const sel_responds = objc.sel_registerName("respondsToSelector:") orelse
+            return error.SelectorNotFound;
+        const RespondsFn = *const fn (objc.id, objc.SEL, objc.SEL) callconv(.c) bool;
+        const responds_fn: RespondsFn = @ptrCast(&objc.objc_msgSend);
+        if (!responds_fn(SKStoreReviewController, sel_responds, sel_request)) {
+            return error.ReviewPromptUnavailable;
+        }
+
+        const scene = try keyWindowScene();
+
+        const Fn = *const fn (objc.id, objc.SEL, objc.id) callconv(.c) void;
+        const func: Fn = @ptrCast(&objc.objc_msgSend);
+        func(SKStoreReviewController, sel_request, scene);
+
+        // Synchronous: there is no callback to wait for, so the dispatch frame
+        // is still live and `sendResultToJS` stamps the right id by itself.
+        bridge_error.sendResultToJS(allocator, A.request_review, R.requested);
+    }
+
+    /// The view controller a modal should be presented from.
+    ///
+    /// Reached through the webview rather than `connectedScenes`: the webview
+    /// is already held by `ios_dispatch`, `[[webview window] rootViewController]`
+    /// is two messages instead of six, and it works the same in a pure-Zig app
+    /// and in a Swift-hosted app that registered its webview. Every nil on the
+    /// way is a real condition and gets its own error — a skipped presentation
+    /// would leave the page's promise unsettled forever.
+    ///
+    /// The walk up `presentedViewController` is the part Swift is missing:
+    /// presenting on a controller that is already presenting something logs
+    /// "which is already presenting" and silently does nothing, so the
+    /// completion handler never fires and the caller waits out its timeout.
+    fn topmostViewController() !objc.id {
+        const webview = ios_dispatch.getWebView() orelse
+            return bridge_error.BridgeError.WebViewHandleNotSet;
+        if (webview == null) return bridge_error.BridgeError.WebViewHandleNotSet;
+
+        const sel_window = objc.sel_registerName("window") orelse return error.SelectorNotFound;
+        const window = objc.msgSendId(webview, sel_window);
+        if (window == null) return error.NoWindow;
+
+        const sel_root = objc.sel_registerName("rootViewController") orelse return error.SelectorNotFound;
+        var vc = objc.msgSendId(window, sel_root);
+        if (vc == null) return error.NoRootViewController;
+
+        const sel_presented = objc.sel_registerName("presentedViewController") orelse
+            return error.SelectorNotFound;
+        // Bounded: a cycle in the presentation chain should hang nothing.
+        var hops: usize = 0;
+        while (hops < 32) : (hops += 1) {
+            const next = objc.msgSendId(vc, sel_presented);
+            if (next == null) break;
+            vc = next;
+        }
+        return vc;
+    }
+
+    /// The `UIWindowScene` the app's window belongs to.
+    ///
+    /// craft builds a classic `UIWindow` with `initWithFrame:` and declares no
+    /// `UIApplicationSceneManifest`, so whether iOS attaches an implicit scene
+    /// to it has not been verified on a device. If it did not, `windowScene` is
+    /// nil and that is reported — it is not a reason to fall back to the
+    /// pre-iOS-14 `+requestReview`, which is deprecated and may be gone, and it
+    /// is certainly not a reason to reply success having done nothing.
+    fn keyWindowScene() !objc.id {
+        const webview = ios_dispatch.getWebView() orelse
+            return bridge_error.BridgeError.WebViewHandleNotSet;
+        if (webview == null) return bridge_error.BridgeError.WebViewHandleNotSet;
+
+        const sel_window = objc.sel_registerName("window") orelse return error.SelectorNotFound;
+        const window = objc.msgSendId(webview, sel_window);
+        if (window == null) return error.NoWindow;
+
+        const sel_scene = objc.sel_registerName("windowScene") orelse return error.SelectorNotFound;
+        const scene = objc.msgSendId(window, sel_scene);
+        if (scene == null) return error.NoWindowScene;
+        return scene;
+    }
+} else struct {
+    fn openURL(_: std.mem.Allocator, _: []const u8, _: i64) !void {
+        return error.UnsupportedPlatform;
+    }
+    fn share(_: std.mem.Allocator, _: ShareRequest, _: i64) !void {
+        return error.UnsupportedPlatform;
+    }
+    fn requestReview(_: std.mem.Allocator) !void {
+        return error.UnsupportedPlatform;
+    }
+};
+
+// =============================================================================
+// Tests
+//
+// Host-only. Nothing here presents a sheet, opens a URL, or asks for a review;
+// the payload shapes and the action table are what a host can check, and they
+// are where the bugs being ported around actually lived.
+// =============================================================================
+
+const testing = std.testing;
+
+/// Parse `json` and hand its root object to `parseShareRequest`.
+///
+/// The arena has to outlive the request, whose strings borrow it, so the caller
+/// gets both back and frees them together.
+fn shareRequestFrom(json: []const u8) !struct {
+    parsed: std.json.Parsed(std.json.Value),
+    request: ShareRequest,
+
+    fn deinit(self: *@This()) void {
+        self.request.deinit(testing.allocator);
+        self.parsed.deinit();
+    }
+} {
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    errdefer parsed.deinit();
+    return .{ .parsed = parsed, .request = try parseShareRequest(testing.allocator, parsed.value.object) };
+}
+
+test "every declared action is one the handler serves" {
+    try testing.expectEqual(@as(usize, 3), capability_actions.len);
+    try testing.expectEqualStrings(A.open_url, capability_actions[0].name);
+    try testing.expectEqualStrings(A.share, capability_actions[1].name);
+    try testing.expectEqualStrings(A.request_review, capability_actions[2].name);
+    for (capability_actions) |decl| {
+        // All three answer a waiting caller. An action declared `.result` whose
+        // handler never replies parks the page until its timeout, and a `.none`
+        // that a caller awaits resolves immediately and means nothing.
+        try testing.expectEqual(capabilities.Reply.result, decl.reply);
+        try testing.expectEqual(capabilities.ActionStatus.live, decl.status);
+    }
+
+    // And the dispatcher agrees. The payloads are ones that fail before any
+    // UIKit object is touched, so this is a routing check and not a device
+    // test: `openURL` has no url, `share` has nothing to share, and
+    // `requestReview` finds no webview registered on the host.
+    var bridge = SystemBridge.init(testing.allocator);
+    defer bridge.deinit();
+    for (capability_actions) |decl| {
+        bridge.handleMessage(decl.name, "{}") catch |err| {
+            try testing.expect(err != bridge_error.BridgeError.UnknownAction);
+            continue;
+        };
+        // None of these can succeed on a host, so reaching here means a handler
+        // reported success without doing anything.
+        try testing.expect(false);
+    }
+}
+
+test "an action the namespace does not serve is reported, not ignored" {
+    var bridge = SystemBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    for ([_][]const u8{ "openurl", "openUrl", "sharing", "review", "" }) |action| {
+        try testing.expectError(
+            bridge_error.BridgeError.UnknownAction,
+            bridge.handleMessage(action, "{}"),
+        );
+    }
+}
+
+test "openURL without a url reports it rather than settling nothing" {
+    // Swift's `if let` fell through here and never resolved or rejected the
+    // callback, so the page waited out a 30-second timeout with no cause to
+    // report. Silence is the one answer ruled out.
+    var bridge = SystemBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(bridge_error.BridgeError.MissingData, bridge.handleMessage(A.open_url, "{}"));
+    try testing.expectError(
+        bridge_error.BridgeError.MissingData,
+        bridge.handleMessage(A.open_url, "{\"url\":\"\"}"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        bridge.handleMessage(A.open_url, "{\"url\":42}"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidJSON,
+        bridge.handleMessage(A.open_url, "not json"),
+    );
+}
+
+test "the url is read from the top level, which is where the page puts it" {
+    const parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        testing.allocator,
+        "{\"url\":\"tel:+15551234\",\"callbackId\":\"cb_1\"}",
+        .{},
+    );
+    defer parsed.deinit();
+    try testing.expectEqualStrings("tel:+15551234", try stringField(parsed.value.object, "url"));
+}
+
+test "share reads the nested options the SDK sends" {
+    var got = try shareRequestFrom(
+        \\{"options":{"title":"T","text":"X","url":"https://e.com","files":["/a","/b"]}}
+    );
+    defer got.deinit();
+
+    try testing.expectEqualStrings("T", got.request.title);
+    try testing.expectEqualStrings("X", got.request.text);
+    try testing.expectEqualStrings("https://e.com", got.request.url);
+    try testing.expectEqual(@as(usize, 2), got.request.files.len);
+    try testing.expectEqualStrings("/a", got.request.files[0]);
+    try testing.expectEqualStrings("/b", got.request.files[1]);
+}
+
+test "share still reads the flat text the legacy call sends" {
+    // `craft.share('hello')` is live in the injected script and posts `text` at
+    // the top level with no `options` wrapper. Reading only the nested shape
+    // would break it silently, which is the `craft.fs.writeFile` failure.
+    var got = try shareRequestFrom("{\"text\":\"hello\"}");
+    defer got.deinit();
+
+    try testing.expectEqualStrings("hello", got.request.text);
+    try testing.expectEqualStrings("", got.request.title);
+    try testing.expectEqual(@as(usize, 0), got.request.files.len);
+}
+
+test "a flat payload keeps every field it sent, not just text" {
+    // Wider than Swift, which rebuilds the payload as `["text": text]` and
+    // throws the rest away. Nothing that works today changes; a field the page
+    // sent is not dropped on the floor.
+    var got = try shareRequestFrom("{\"text\":\"X\",\"url\":\"https://e.com\"}");
+    defer got.deinit();
+
+    try testing.expectEqualStrings("X", got.request.text);
+    try testing.expectEqualStrings("https://e.com", got.request.url);
+}
+
+test "an empty string is not something to share" {
+    // `!title.isEmpty` / `!text.isEmpty` in Swift. Without it, `share({text:''})`
+    // presents an empty sheet instead of telling the caller it asked for
+    // nothing.
+    const parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        testing.allocator,
+        "{\"options\":{\"text\":\"\",\"title\":\"\",\"url\":\"\",\"files\":[]}}",
+        .{},
+    );
+    defer parsed.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        parseShareRequest(testing.allocator, parsed.value.object),
+    );
+}
+
+test "an empty options object is nothing to share, not an empty sheet" {
+    const parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        testing.allocator,
+        "{\"options\":{}}",
+        .{},
+    );
+    defer parsed.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        parseShareRequest(testing.allocator, parsed.value.object),
+    );
+}
+
+test "a files entry of the wrong type is refused, not quietly skipped" {
+    // `files` is declared `string[]`. Sharing a shorter list than was asked for
+    // and calling it success is the bug class this file is being written to
+    // avoid.
+    const parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        testing.allocator,
+        "{\"options\":{\"files\":[\"/a\",7]}}",
+        .{},
+    );
+    defer parsed.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        parseShareRequest(testing.allocator, parsed.value.object),
+    );
+}
+
+test "an explicit null is the page sending no value, not a type error" {
+    var got = try shareRequestFrom("{\"options\":{\"text\":\"X\",\"url\":null,\"files\":null}}");
+    defer got.deinit();
+
+    try testing.expectEqualStrings("X", got.request.text);
+    try testing.expectEqualStrings("", got.request.url);
+    try testing.expectEqual(@as(usize, 0), got.request.files.len);
+}
+
+test "files-only is a valid request" {
+    // Nothing textual, but plenty to share. The final emptiness check happens
+    // on the assembled item array, because a path that names nothing on disk
+    // contributes no item.
+    var got = try shareRequestFrom("{\"options\":{\"files\":[\"/tmp/a.png\"]}}");
+    defer got.deinit();
+
+    try testing.expectEqual(@as(usize, 1), got.request.files.len);
+    try testing.expectEqualStrings("", got.request.text);
+}
+
+test "a url the page sent that iOS cannot parse is refused, not left out of the sheet" {
+    // Swift shared the text, dropped the link, and reported the share
+    // completed — the caller asked for a link and got a sheet without one, with
+    // nothing to indicate anything was missing. `openURL` already refuses this
+    // exact condition; `share` refuses it the same way.
+    //
+    // Runs on any Darwin host: `+[NSURL URLWithString:]` is Foundation, and
+    // `share` reaches it before it needs anything from UIKit.
+    if (!is_darwin) return error.SkipZigTest;
+
+    var bridge = SystemBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        bridge.handleMessage(A.share, "{\"options\":{\"text\":\"hi\",\"url\":\"http://exa mple.com\"}}"),
+    );
+}
+
+test "a request id survives being captured for a callback that fires later" {
+    // The completion handlers run after `ios_dispatch.handleMessage` has popped
+    // the dispatch frame, so the id has to be read while the frame is live and
+    // pushed back before replying. Without it the reply is stamped `null` and
+    // goes down the action-name FIFO, which hands one caller's answer to
+    // another whenever two shares are in flight.
+    request_context.resetForTesting();
+
+    request_context.push(31);
+    const captured = capturedRequestId();
+    request_context.pop();
+
+    try testing.expectEqual(@as(i64, 31), captured);
+    try testing.expectEqual(@as(?u64, null), request_context.current());
+
+    request_context.push(if (captured < 0) null else @intCast(captured));
+    defer request_context.pop();
+    try testing.expectEqual(@as(?u64, 31), request_context.current());
+}
+
+test "a message the page sent without an id captures the absent-id sentinel" {
+    request_context.resetForTesting();
+    request_context.push(null);
+    defer request_context.pop();
+    try testing.expectEqual(@as(i64, -1), capturedRequestId());
+}
+
+test "a block carries its capture without disturbing the ABI prefix" {
+    // Pinned as absolute offsets, not as `descriptor.size == @sizeOf(TheBlock)`
+    // — that compares the constant against the expression that defines it and
+    // so cannot fail. These can: they catch a reordered field, a widened
+    // `flags`, and an `extern` that went missing and let Zig pick its own
+    // layout, each of which hands `_Block_copy` and `objc_msgSend` a block
+    // whose `invoke` and `descriptor` are not where the runtime looks.
+    //
+    // The offsets are the 64-bit ABI. iOS is 64-bit only and so is every host
+    // that runs this suite; a 32-bit host would pad `request_id` differently
+    // and is skipped rather than asserted about wrongly.
+    if (@sizeOf(usize) != 8) return error.SkipZigTest;
+
+    inline for (.{ OpenURLBlock, ShareBlock }) |Block| {
+        try testing.expectEqual(@as(usize, 0), @offsetOf(Block, "isa"));
+        try testing.expectEqual(@as(usize, 8), @offsetOf(Block, "flags"));
+        try testing.expectEqual(@as(usize, 12), @offsetOf(Block, "reserved"));
+        try testing.expectEqual(@as(usize, 16), @offsetOf(Block, "invoke"));
+        try testing.expectEqual(@as(usize, 24), @offsetOf(Block, "descriptor"));
+        // The capture, after the five fields the ABI reserves.
+        try testing.expectEqual(@as(usize, 32), @offsetOf(Block, "request_id"));
+    }
+
+    // `_Block_copy` memcpys exactly `descriptor->size` bytes onto the heap, so
+    // a size that stopped at the ABI prefix would leave the callback reading a
+    // truncated id out of uninitialised memory.
+    try testing.expect(open_url_block_descriptor.size >=
+        @offsetOf(OpenURLBlock, "request_id") + @sizeOf(i64));
+    try testing.expect(share_block_descriptor.size >=
+        @offsetOf(ShareBlock, "request_id") + @sizeOf(i64));
+}
+
+test "every reply is a JSON object naming what happened, never a bare boolean" {
+    // Reads `R`, which is what the handlers actually send. Asserting against
+    // copies of those literals would pass unchanged if a handler started
+    // replying `true` — coverage that cannot fail is worse than none.
+    //
+    // `craft-bridge.js` resolves with `payload || {}`, so a bare `false` and an
+    // empty reply are the same value to the page.
+    for (R.all) |json| {
+        const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+        defer parsed.deinit();
+        try testing.expect(parsed.value == .object);
+        try testing.expectEqual(@as(usize, 1), parsed.value.object.count());
+
+        // And the member is a boolean the caller can branch on, not a string or
+        // a number that reads as truthy whatever it says.
+        var it = parsed.value.object.iterator();
+        try testing.expect(it.next().?.value_ptr.* == .bool);
+    }
+
+    // Non-vacuity: every assertion above is satisfied by an empty list.
+    try testing.expectEqual(@as(usize, 5), R.all.len);
+    try testing.expect(!std.mem.eql(u8, R.opened, R.not_opened));
+    try testing.expect(!std.mem.eql(u8, R.completed, R.not_completed));
+}

--- a/packages/zig/src/ios.zig
+++ b/packages/zig/src/ios.zig
@@ -3,6 +3,15 @@ const objc_runtime = @import("objc_runtime.zig");
 const mobile = @import("mobile.zig");
 const ios_dispatch = @import("ios_dispatch.zig");
 
+// Test collection, not a test. Zig only collects `test` blocks from
+// containers the test root *references*, and `ios_dispatch` is a non-pub
+// import — so without this, its tests and every mobile module's tests were
+// silently absent from `zig build test:ios`. That was found with a canary:
+// a deliberately failing test in a module, and a green run.
+test {
+    _ = ios_dispatch;
+}
+
 /// iOS Application Infrastructure
 /// Provides UIApplicationDelegate, UIViewController, and full app lifecycle management
 /// Re-exported so `test/ios_surface_test.zig` can reach the runtime without

--- a/packages/zig/src/ios_dispatch.zig
+++ b/packages/zig/src/ios_dispatch.zig
@@ -259,6 +259,74 @@ export fn craft_ios_deliver_result(
     bridge_error.sendResultToJS(std.heap.c_allocator, action, json);
 }
 
+/// Deliver an error the host shim produced.
+///
+/// A separate export from `craft_ios_deliver_result` because results and
+/// errors reach the page by different routes — `__craftBridgeResult` resolves
+/// the pending promise, `__craftBridgeError` rejects it. Delivering a shim
+/// rejection as a result would make the caller's promise *resolve* with an
+/// error-shaped object, which is the fabricated-success bug wearing a
+/// different hat: the catch block the app wrote never runs.
+///
+/// The message and code are free text from the shim, escaped here with the
+/// same `appendJsonEscaped` every native error already goes through — the
+/// Swift side must not hand-escape (its own attempt replaced only `'` and
+/// let backslashes break out of the string literal).
+export fn craft_ios_deliver_error(
+    action_ptr: [*]const u8,
+    action_len: usize,
+    message_ptr: [*]const u8,
+    message_len: usize,
+    code_ptr: [*]const u8,
+    code_len: usize,
+    request_id: i64,
+) callconv(.c) void {
+    const allocator = std.heap.c_allocator;
+    const action = action_ptr[0..action_len];
+    const message = message_ptr[0..message_len];
+    const code = code_ptr[0..code_len];
+
+    var json: std.ArrayListUnmanaged(u8) = .empty;
+    defer json.deinit(allocator);
+
+    buildShimError(allocator, &json, action, message, code, request_id) catch return;
+
+    const js = std.fmt.allocPrint(
+        allocator,
+        "if(window.__craftBridgeError)window.__craftBridgeError({s});",
+        .{json.items},
+    ) catch return;
+    defer allocator.free(js);
+
+    evalJS(js) catch |err| {
+        std.log.warn("ios bridge: could not deliver shim error for '{s}': {}", .{ action, err });
+    };
+}
+
+/// The `__craftBridgeError` payload for a shim-raised error. Split out so the
+/// host tests can pin the exact shape without a webview.
+fn buildShimError(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    action: []const u8,
+    message: []const u8,
+    code: []const u8,
+    request_id: i64,
+) !void {
+    try out.appendSlice(allocator, "{\"error\":true,\"code\":\"");
+    try bridge_error.appendJsonEscaped(allocator, out, code);
+    try out.appendSlice(allocator, "\",\"action\":\"");
+    try bridge_error.appendJsonEscaped(allocator, out, action);
+    try out.appendSlice(allocator, "\",\"message\":\"");
+    try bridge_error.appendJsonEscaped(allocator, out, message);
+    try out.append(allocator, '"');
+    if (request_id >= 0) {
+        try out.appendSlice(allocator, ",\"id\":");
+        try out.print(allocator, "{d}", .{request_id});
+    }
+    try out.append(allocator, '}');
+}
+
 const testing = std.testing;
 
 test "an envelope without a type is rejected" {
@@ -375,4 +443,28 @@ test "a request id survives the trip out to the host and back" {
     request_context.push(if (captured < 0) null else @intCast(captured));
     defer request_context.pop();
     try testing.expectEqual(@as(?u64, 7), request_context.current());
+}
+
+test "a shim error carries its code, message, and id, correctly escaped" {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(testing.allocator);
+
+    // The message contains the three characters Swift's hand-escaping got
+    // wrong: a backslash, a quote, and a newline.
+    try buildShimError(testing.allocator, &out, "share", "path \\ \"x\"\ngone", "NOT_FOUND", 9);
+    try testing.expectEqualStrings(
+        "{\"error\":true,\"code\":\"NOT_FOUND\",\"action\":\"share\",\"message\":\"path \\\\ \\\"x\\\"\\ngone\",\"id\":9}",
+        out.items,
+    );
+}
+
+test "a shim error with no request id omits the id field entirely" {
+    // Omitted, not null or -1: the page's error handler treats a present id as
+    // a promise to reject, and a sentinel would reject nothing — or worse,
+    // someone else's call.
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(testing.allocator);
+
+    try buildShimError(testing.allocator, &out, "share", "m", "E", -1);
+    try testing.expect(std.mem.indexOf(u8, out.items, "\"id\"") == null);
 }

--- a/packages/zig/src/ios_dispatch.zig
+++ b/packages/zig/src/ios_dispatch.zig
@@ -4,6 +4,12 @@ const objc_runtime = @import("objc_runtime.zig");
 const request_context = @import("request_context.zig");
 const bridge_error = @import("bridge_error.zig");
 const bridge_mobile = @import("bridge_mobile.zig");
+const bridge_mobile_clipboard = @import("bridge_mobile_clipboard.zig");
+const bridge_mobile_haptics = @import("bridge_mobile_haptics.zig");
+const bridge_mobile_device = @import("bridge_mobile_device.zig");
+const bridge_mobile_system = @import("bridge_mobile_system.zig");
+const bridge_mobile_display = @import("bridge_mobile_display.zig");
+const bridge_mobile_storage = @import("bridge_mobile_storage.zig");
 
 const objc = objc_runtime.objc;
 
@@ -149,21 +155,27 @@ fn payloadOf(root: std.json.ObjectMap) ![]const u8 {
 /// diagnostic a bridge can give.
 fn route(allocator: std.mem.Allocator, msg_type: []const u8, action: []const u8, data: []const u8) !void {
     if (std.mem.eql(u8, msg_type, "mobile")) {
-        var bridge = bridge_mobile.MobileBridge.init(allocator);
-        defer bridge.deinit();
+        // First module that recognises the action wins. UnknownAction means
+        // "not mine, ask the next"; any other error means a handler ran and
+        // failed, and its answer is final — retrying the same action against
+        // another module (or the shim) would replace a specific failure with
+        // whatever the next thing happens to say.
+        //
+        // The conformance test guarantees no action appears in two modules'
+        // tables, so first-match is deterministic rather than order-dependent.
+        inline for (mobile_bridges) |Bridge| {
+            var bridge = Bridge.init(allocator);
+            defer bridge.deinit();
 
-        if (bridge.handleMessage(action, data)) |_| {
-            return;
-        } else |err| switch (err) {
-            // The only error worth handing on. Anything else means a handler
-            // ran and failed, and it has already decided what the real answer
-            // is — asking the shim to try the same action again would replace
-            // a specific failure with whatever it happens to say.
-            bridge_error.BridgeError.UnknownAction => {},
-            else => {
-                bridge_error.sendErrorToJS(allocator, action, asBridgeError(err));
-                return err;
-            },
+            if (bridge.handleMessage(action, data)) |_| {
+                return;
+            } else |err| switch (err) {
+                bridge_error.BridgeError.UnknownAction => {},
+                else => {
+                    bridge_error.sendErrorToJS(allocator, action, asBridgeError(err));
+                    return err;
+                },
+            }
         }
 
         if (try handOffToHost(action, data)) return;
@@ -175,6 +187,22 @@ fn route(allocator: std.mem.Allocator, msg_type: []const u8, action: []const u8,
     bridge_error.sendErrorToJS(allocator, action, bridge_error.BridgeError.UnknownAction);
     return error.UnknownNamespace;
 }
+
+/// Every Zig module serving the `mobile` namespace, in dispatch order.
+///
+/// Growing this list is what a migration phase does. The conformance test in
+/// `test/ios_conformance_test.zig` embeds the same files and holds the ratchet,
+/// so adding a module here without listing it there — or vice versa — fails
+/// the build rather than silently narrowing the served surface.
+const mobile_bridges = .{
+    bridge_mobile.MobileBridge,
+    bridge_mobile_clipboard.ClipboardBridge,
+    bridge_mobile_haptics.HapticsBridge,
+    bridge_mobile_device.DeviceBridge,
+    bridge_mobile_system.SystemBridge,
+    bridge_mobile_display.DisplayBridge,
+    bridge_mobile_storage.StorageBridge,
+};
 
 /// Narrow an arbitrary handler error to one the page's error codes can express.
 ///

--- a/packages/zig/test/ios_conformance_test.zig
+++ b/packages/zig/test/ios_conformance_test.zig
@@ -18,7 +18,20 @@ const testing = std.testing;
 /// Embedded with `@embedFile` rather than read from disk, so the test is
 /// hermetic and reads exactly the bytes the build saw.
 const swift_spec = @embedFile("CraftApp.swift");
-const zig_actions = @embedFile("src/bridge_mobile.zig");
+
+/// Every Zig module that serves part of the `mobile` namespace. A module
+/// migrating actions out of the Swift spec adds itself here — and the ratchet
+/// below is what forces that to happen, because migrated actions the scan
+/// cannot see would read as "dropped" and fail the build.
+const zig_sources = [_][]const u8{
+    @embedFile("src/bridge_mobile.zig"),
+    @embedFile("src/bridge_mobile_clipboard.zig"),
+    @embedFile("src/bridge_mobile_haptics.zig"),
+    @embedFile("src/bridge_mobile_device.zig"),
+    @embedFile("src/bridge_mobile_system.zig"),
+    @embedFile("src/bridge_mobile_display.zig"),
+    @embedFile("src/bridge_mobile_storage.zig"),
+};
 
 /// The action list lives in the `switch action` block, and nowhere else.
 ///
@@ -39,7 +52,10 @@ const dispatch_end = "func webView(";
 /// If this ever needs raising, something has been removed from Zig without
 /// being removed from the spec, and that is the conversation this constant
 /// exists to force.
-const max_not_yet_migrated: usize = 105;
+///
+/// History: 105 after the vertical slice (getDeviceInfo); 86 after Tier 0
+/// landed clipboard, haptics, device, system, display, and storage.
+const max_not_yet_migrated: usize = 86;
 
 fn dispatcherRegion() []const u8 {
     const begin = std.mem.indexOf(u8, swift_spec, dispatch_begin) orelse return "";
@@ -79,26 +95,28 @@ fn collectPostedActions(allocator: std.mem.Allocator) !std.StringHashMap(void) {
     return set;
 }
 
-/// Every action name declared in `bridge_mobile.zig`'s `A` block.
+/// Every action name declared in the `A` blocks of every mobile module.
 fn collectZigActions(allocator: std.mem.Allocator) !std.StringHashMap(void) {
     var set = std.StringHashMap(void).init(allocator);
     errdefer set.deinit();
 
-    var it = std.mem.splitScalar(u8, zig_actions, '\n');
-    var in_block = false;
-    while (it.next()) |line| {
-        const trimmed = std.mem.trim(u8, line, " \t\r");
-        if (std.mem.startsWith(u8, trimmed, "pub const A = struct {")) {
-            in_block = true;
-            continue;
-        }
-        if (in_block and std.mem.eql(u8, trimmed, "};")) break;
-        if (!in_block) continue;
+    for (zig_sources) |source| {
+        var it = std.mem.splitScalar(u8, source, '\n');
+        var in_block = false;
+        while (it.next()) |line| {
+            const trimmed = std.mem.trim(u8, line, " \t\r");
+            if (std.mem.startsWith(u8, trimmed, "pub const A = struct {")) {
+                in_block = true;
+                continue;
+            }
+            if (in_block and std.mem.eql(u8, trimmed, "};")) break;
+            if (!in_block) continue;
 
-        // pub const get_device_info = "getDeviceInfo";
-        const open = std.mem.indexOfScalar(u8, trimmed, '"') orelse continue;
-        const close = std.mem.indexOfScalarPos(u8, trimmed, open + 1, '"') orelse continue;
-        try set.put(trimmed[open + 1 .. close], {});
+            // pub const get_device_info = "getDeviceInfo";
+            const open = std.mem.indexOfScalar(u8, trimmed, '"') orelse continue;
+            const close = std.mem.indexOfScalarPos(u8, trimmed, open + 1, '"') orelse continue;
+            try set.put(trimmed[open + 1 .. close], {});
+        }
     }
     return set;
 }

--- a/packages/zig/test/ios_surface_test.zig
+++ b/packages/zig/test/ios_surface_test.zig
@@ -1,5 +1,16 @@
 const std = @import("std");
 const ios = @import("../src/ios.zig");
+
+// Test *collection*, distinct from the analysis the gate below forces.
+// `refAllDeclsRecursive` makes the compiler check every declaration, which is
+// what catches compile errors — but it does not enroll imported files' `test`
+// blocks. Only this idiom does. Without it, every test in ios.zig,
+// ios_dispatch.zig, and the mobile modules was silently absent from the run:
+// found with a canary — a deliberately failing test in a module, and a green
+// build.
+test {
+    _ = ios;
+}
 const objc = ios.objc;
 
 // `std.testing.refAllDeclsRecursive` is gone in 0.17 — only the shallow


### PR DESCRIPTION
Follow-on to #83 and #84. The first phase where the migration visibly moves: **19 actions cross from the Swift spec into Zig**, the conformance ratchet drops from 105 to 86, and the seam that makes it safe is now wired into the real `CraftApp.swift`.

## The seam, wired and proven both ways

`CraftApp.swift`'s dispatcher splits: the `WKScriptMessageHandler` entry becomes a thin wrapper, and the action switch is reachable from both the page and `CraftSwiftShim.handleAction`. Hand-off replies carry a synthetic `zig:<id>:<action>` callbackId that the reply helpers route back through Zig — **one reply path**, owned by whichever side received the page's message.

Discovery is symmetric and runtime-only: Zig finds the shim by `objc_getClass`; the shim finds Zig's exports by `dlsym`. Neither links the other, so a pure-Swift app and a fully-migrated app both build with no dead dependency. **Whether `dlsym` finds statically-linked Zig exports was the design's load-bearing assumption** — now a simulator assertion, not a hope.

Rejections get their own export (`craft_ios_deliver_error` → `__craftBridgeError`), so a shim rejection **rejects** the page's promise. Delivering it as a result would run the app's then-branch with an error-shaped object — fabricated success wearing a different hat. The fixture pushes a message containing a backslash, a quote, and a newline through it and asserts all three arrive intact. (Fixing that also fixed the pre-existing Swift escaping bug: `rejectCallback` escaped `'` and `\n` but not backslash.)

## Six new modules, 19 actions

| module | actions |
|---|---|
| clipboard | clipboardRead, clipboardWrite |
| haptics | haptic, vibrate |
| device | getMemoryUsage, getAppState, getNetworkStatus, log |
| system | openURL, share, requestReview |
| display | setBadge, clearBadge, setKeepAwake, lockOrientation, unlockOrientation |
| storage | setSharedItem, getSharedItem, removeSharedItem |

Each was written against the Swift implementation **and** the injected JS read together — the JS is what shows the exact field names a page sends and the reply shape it consumes, which is the part this repo has repeatedly shipped wrong. Where the spec surprises, the modules follow the spec: storage is **Keychain** (not NSUserDefaults), and `getAppState` replies with a bare JSON string because Swift serialises with `.fragmentsAllowed`.

An adversarial review pass per module found real defects before they shipped, including a **fabricated success reachable from a page**: a clipboard write containing a NUL byte truncated inside `stringWithUTF8String:`, bumped `changeCount`, and replied `true` for a write that stored a different string than the page sent. Refused as `InvalidParameter` now. Also an unchecked nil that would have raised `NSInvalidArgumentException` — an ObjC exception Zig cannot catch.

## Two build-system defects found and fixed

**Module tests were not running at all.** Zig collects tests only from the root *module* — `test { _ = import }` chains through a named-module import enroll nothing. Proven with a canary: a deliberately failing test in a module, and a green build, under two successive "fixes" that didn't work. The arrangement that does: a test artifact rooted at `src/ios.zig`. The canary now fails the build and passes when removed.

**The iOS archives now bundle compiler-rt.** They're linked by clang/swiftc, not Zig, and `std.json`'s number parsing wants f128 soft-float intrinsics no later link step provides.

## Verification

Ten fixture assertions on an iPhone 17 Pro simulator (iOS 26.5), each individually proven non-vacuous at some point in this branch's history:

```
ok: page -> native (i=1 seen 1x)
ok: native -> page, round trip closed (i=2 seen 1x)
ok: no feedback loop
ok: user script ran at document start
ok: unserved action reached the dispatcher (i=4 seen 1x)
ok: hand-off to host shim closed (i=5 seen 1x)
ok: rejecting action reached the dispatcher (i=6 seen 1x)
ok: error route closed with escaping intact (i=7 seen 1x)
ok: Tier-0 action served by Zig with a live UIKit value (i=8 seen 1x)
PASS
```

Plus: `zig build test` / `test:ios` / desktop / `build-ios` / `build-ios-simulator` / `build-android`, `zig fmt --check`, `verify:cimports`, `pickier`, and `CraftApp.swift` type-checks via the new `packages/ios/scripts/typecheck-template.sh` (exit-code based — the file is full of `error:` argument labels that a grep counts as compiler errors).

The ratchet at 86 only goes down from here. Remaining: the permission/Keychain tier (async replies), presented UI, subscriptions — per `docs/ios-development.md`.