### PR TITLE
iOS Phase 4: the secure tier — async replies, Keychain, permissions; ratchet 86 → 74

### DIFF
--- a/packages/ios/fixtures/zig-slice/build-and-run.sh
+++ b/packages/ios/fixtures/zig-slice/build-and-run.sh
@@ -33,6 +33,24 @@ clang -isysroot "$SDK" -target "$TRIPLE" -fobjc-arc -O1 -c \
 clang -isysroot "$SDK" -target "$TRIPLE" -fobjc-arc -O1 -c \
     "$FIXTURE/page.m" -o "$OUT/page.o"
 
+# Simulator keychain identity. On the simulator, application-identifier and
+# keychain-access-groups are NOT signed in — a signature carrying them is
+# refused at launch (POSIX 163 from RunningBoard, bisected: the same signature
+# without them launches). Xcode instead embeds them as a __TEXT,__entitlements
+# section and the simulator's security layer reads them from there. Without
+# any identity, SecItemAdd fails with errSecMissingEntitlement (-34018).
+cat > "$OUT/sim.entitlements" <<'ENTS'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>application-identifier</key><string>SLICE00000.app.craft.slice</string>
+    <key>keychain-access-groups</key>
+    <array><string>SLICE00000.app.craft.slice</string></array>
+</dict>
+</plist>
+ENTS
+
 echo "==> linking CraftSlice"
 # The shim class has to survive into the binary for
 # `objc_getClass("CraftSwiftShim")` to find it at runtime. Compiling it into
@@ -45,9 +63,15 @@ swiftc -target "$TRIPLE" -sdk "$SDK" \
     "$OUT/main.o" "$OUT/page.o" \
     "$ROOT/packages/zig/zig-out/lib/$LIB" \
     -framework UIKit -framework WebKit -framework Foundation -framework Security \
+    -Xlinker -sectcreate -Xlinker __TEXT -Xlinker __entitlements -Xlinker "$OUT/sim.entitlements" \
     -o "$APP/CraftSlice"
 
 cp "$FIXTURE/Info.plist" "$APP/Info.plist"
+
+# Ad-hoc signature. The identity entitlements live in the __entitlements
+# section above; signing them in instead makes the launch be denied.
+codesign --force --sign - "$APP"
+
 
 echo "==> booting a simulator"
 UDID="$(xcrun simctl list devices available -j \
@@ -66,7 +90,7 @@ LAUNCH_PID=$!
 # The round trip is fast, but a cold simulator is not. Poll rather than sleep a
 # fixed amount, so a slow boot does not read as a failure.
 for _ in $(seq 1 60); do
-    if grep -q 'i=7' "$LOG" 2>/dev/null && grep -q 'i=8' "$LOG" 2>/dev/null; then sleep 1; break; fi
+    if grep -q 'i=7' "$LOG" 2>/dev/null && grep -q 'i=10' "$LOG" 2>/dev/null; then sleep 1; break; fi
     sleep 1
 done
 kill "$LAUNCH_PID" 2>/dev/null || true
@@ -125,5 +149,9 @@ echo "ok: error route closed with escaping intact (i=7 seen ${C7}x)"
 C8="$(count 8)"
 [ "$C8" -ge 1 ] || { echo "FAIL: the Tier-0 action's reply never carried a real app state"; exit 1; }
 echo "ok: Tier-0 action served by Zig with a live UIKit value (i=8 seen ${C8}x)"
+
+C10="$(count 10)"
+[ "$C10" -ge 1 ] || { echo "FAIL: the Keychain round trip never completed byte-identical"; exit 1; }
+echo "ok: secureSet/secureGet round-tripped a secret through the Keychain (i=10 seen ${C10}x)"
 
 echo "PASS"

--- a/packages/ios/fixtures/zig-slice/page.m
+++ b/packages/ios/fixtures/zig-slice/page.m
@@ -13,6 +13,9 @@
 //   i=5  that reply came back, having been answered by the host shim
 //   i=8  the page called a Tier-0 action Zig newly serves (getAppState) and
 //        its reply named a real UIKit application state
+//   i=9  secureSet stored a secret in the real Keychain and replied true
+//   i=10 secureGet read the same secret back, byte-identical — proving the
+//        write went through SecItemAdd and the escaping survived both ways
 //   i=6  the page called an action the shim answers by *rejecting*
 //   i=7  the rejection arrived via __craftBridgeError with its id, code, and
 //        an unmangled message — proving the error route and Zig-side escaping
@@ -27,7 +30,7 @@ const char craft_slice_page[] =
     "<!DOCTYPE html><html><head><meta charset=\"utf-8\">"
     "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">"
     "</head><body><h1 id=\"s\">craft slice</h1><script>\n"
-    "var sentRoundTrip = false, sentHandOff = false, sentTierZero = false;\n"
+    "var sentRoundTrip = false, sentHandOff = false, sentTierZero = false, sentSecure = false;\n"
     "var bridge = window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.craft;\n"
     "\n"
     "// Read before anything else touches it: the user script is installed at\n"
@@ -50,6 +53,7 @@ const char craft_slice_page[] =
     "    bridge.postMessage({t:'mobile', a:'getDeviceInfo', i:7});\n"
     "  }\n"
     "};\n"
+    "var SECRET = 'sl\\\\ice \"v\" 1';\n"
     "window.__craftBridgeResult = function (action, payload, id) {\n"
     "  window.__craftSliceAck = JSON.stringify({action: action, id: id, payload: payload});\n"
     "  document.getElementById('s').textContent = window.__craftSliceAck;\n"
@@ -66,6 +70,13 @@ const char craft_slice_page[] =
     "  // protocol it uses for its own actions.\n"
     "  // A Tier-0 action served by Zig itself: the reply carries the UIKit\n"
     "  // application state, which only a live foregrounded process reports.\n"
+    "  if (action === 'secureSet' && payload === true) {\n"
+    "    bridge.postMessage({t:'mobile', a:'secureGet', d: JSON.stringify({key:'slice-key'}), i:31});\n"
+    "  }\n"
+    "  if (!sentSecure && action === 'secureGet' && payload === SECRET) {\n"
+    "    sentSecure = true;\n"
+    "    bridge.postMessage({t:'mobile', a:'getDeviceInfo', i:10});\n"
+    "  }\n"
     "  if (!sentTierZero && (payload === 'active' || payload === 'inactive')) {\n"
     "    sentTierZero = true;\n"
     "    bridge.postMessage({t:'mobile', a:'getDeviceInfo', i:8});\n"
@@ -81,6 +92,10 @@ const char craft_slice_page[] =
     "  bridge.postMessage({t:'mobile', a:'getDeviceInfo', i:1});\n"
     "  // An action Zig does not serve, so it must reach the host shim.\n"
     "  bridge.postMessage({t:'mobile', a:'hostOnlyPing', i:4});\n"
+    "  // Round-trip a secret through the real Keychain: set, then get on the\n"
+    "  // reply, then confirm byte-identity. The secret carries a quote and a\n"
+    "  // backslash so the escaping is proven in both directions.\n"
+    "  bridge.postMessage({t:'mobile', a:'secureSet', d: JSON.stringify({key:'slice-key', value:SECRET}), i:30});\n"
     "  // A Tier-0 action migrated in this phase, served by Zig directly.\n"
     "  bridge.postMessage({t:'mobile', a:'getAppState', i:88});\n"
     "  // And one the shim answers by rejecting, to prove the error route.\n"

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -409,6 +409,21 @@ pub fn build(b: *std.Build) void {
     ios_conformance_tests.root_module.addAnonymousImport("src/bridge_mobile_storage.zig", .{
         .root_source_file = b.path("src/bridge_mobile_storage.zig"),
     });
+    ios_conformance_tests.root_module.addAnonymousImport("src/bridge_mobile_misc.zig", .{
+        .root_source_file = b.path("src/bridge_mobile_misc.zig"),
+    });
+    ios_conformance_tests.root_module.addAnonymousImport("src/bridge_mobile_shortcuts.zig", .{
+        .root_source_file = b.path("src/bridge_mobile_shortcuts.zig"),
+    });
+    ios_conformance_tests.root_module.addAnonymousImport("src/bridge_mobile_securestore.zig", .{
+        .root_source_file = b.path("src/bridge_mobile_securestore.zig"),
+    });
+    ios_conformance_tests.root_module.addAnonymousImport("src/bridge_mobile_biometric.zig", .{
+        .root_source_file = b.path("src/bridge_mobile_biometric.zig"),
+    });
+    ios_conformance_tests.root_module.addAnonymousImport("src/bridge_mobile_permissions.zig", .{
+        .root_source_file = b.path("src/bridge_mobile_permissions.zig"),
+    });
 
     const menubar_tests = b.addTest(.{
         .root_module = b.createModule(.{

--- a/packages/zig/src/bridge_mobile_biometric.zig
+++ b/packages/zig/src/bridge_mobile_biometric.zig
@@ -1,0 +1,658 @@
+//! The biometric "session persistence" actions of the `mobile` namespace:
+//! `setBiometricPersistence`, `checkBiometricPersistence`,
+//! `clearBiometricPersistence`.
+//!
+//! **Despite the name, there is no Keychain, no `SecAccessControl` and no
+//! `LAContext` here.** Swift implements all three against one in-memory field —
+//! `private var biometricSessionExpiry: Date?` (CraftApp.swift:4434) — and
+//! nothing else in that file reads it: the actual biometric prompt never
+//! consults it. The "session" is bookkeeping the page asked to be kept and
+//! reads back, which makes this the rare mobile action set that is pure Zig —
+//! module state plus a millisecond clock, no Objective-C at all, and therefore
+//! no Darwin gate anywhere in this file. It behaves identically on every
+//! platform the dispatch chain compiles for.
+//!
+//! ## What is carried across exactly, because it is the observable contract
+//!
+//!  - **The reply shapes**, per `craft.d.ts:1256` and the Swift dictionary
+//!    literals: enable answers `{"enabled":true,"duration":…,"expiresAt":…}`,
+//!    disable `{"enabled":false}`, check `{"isValid":…,"remainingSeconds":…}`,
+//!    clear `{"cleared":true}` — always, even when nothing was set.
+//!  - **The unit mismatch.** `expiresAt` is epoch *milliseconds*
+//!    (`timeIntervalSince1970 * 1000`); `remainingSeconds` is *seconds*.
+//!    Ugly, shipped, load-bearing.
+//!  - **An absent `duration` defaults to 300**, in agreement with both layers
+//!    above this one: the injected JS posts `duration || 300` and the Swift
+//!    dispatcher falls back with `?? 300`. A *present* `0` or negative reaches
+//!    Swift as itself and makes an instantly-expired session, so it does here.
+//!  - **`check` never clears an expired session.** It answers
+//!    `{"isValid":false,"remainingSeconds":0}` and leaves the stale expiry in
+//!    place, exactly as Swift leaves the stale `Date`. Only an explicit
+//!    `clear` or a disable drops it. Expired and never-set are the same reply,
+//!    indistinguishable by design.
+//!  - **Strict `<` at the boundary**: Swift's `Date() < expiry` means the
+//!    session is already invalid at the exact instant it expires.
+//!
+//! ## What is deliberately not carried across
+//!
+//! **Swift's silent hang.** The dispatcher arm is
+//! `if let enabled = body["enabled"] as? Bool` with no else
+//! (CraftApp.swift:1003), so a missing or non-bool `enabled` replies nothing
+//! and the page's promise never settles. Here it is `MissingData` /
+//! `InvalidParameter`.
+//!
+//! **Swift's silent re-typing of `duration`.** `as? Double ?? 300` rewrites a
+//! present-but-non-numeric `duration` into 300 and reports success — a payload
+//! field the page sent, replaced with a different value. Here it is
+//! `InvalidParameter`; only *absence* defaults, because absence is what the
+//! injected JS actually sends on the disable path.
+//!
+//! **`biometricSessionDuration`** (CraftApp.swift:4435) — written on every
+//! enable, read by nothing, ever. Not replicated.
+//!
+//! ## The one migration hazard: the state must move whole
+//!
+//! The expiry lives in whichever language serves the action. If Zig served
+//! `check` while the un-migrated Swift shim still served `set`, the two would
+//! each hold their own expiry and a session Swift enabled would check as
+//! invalid. All three actions therefore live in this one module and enter
+//! `mobile_bridges` together; serving a subset of them from Zig is the one
+//! wrong way to deploy this file.
+//!
+//! The state is a module-level `?f64` with no lock: every access happens
+//! inside `handleMessage`, which runs in the `WKScriptMessageHandler` callback
+//! on the main thread (the same argument `readApplicationState` in
+//! `bridge_mobile_device.zig` records). It does not survive relaunch — but
+//! neither did Swift's, and outliving the process would be a *stronger*
+//! promise than the page was given.
+
+const std = @import("std");
+const capabilities = @import("capabilities.zig");
+const bridge_error = @import("bridge_error.zig");
+const compat = @import("compat.zig");
+
+/// The action names, spelled exactly as the Swift `case` labels spell them.
+/// The conformance ratchet matches these strings against `CraftApp.swift` in
+/// both directions, so a tidier spelling would register as Zig serving an
+/// action the spec does not have.
+pub const A = struct {
+    pub const set_biometric_persistence = "setBiometricPersistence";
+    pub const check_biometric_persistence = "checkBiometricPersistence";
+    pub const clear_biometric_persistence = "clearBiometricPersistence";
+};
+
+/// All three `.result` and `.live`: every Swift path ends in exactly one
+/// `resolveCallback`, every injected `craft.authPersistence` method returns a
+/// promise the page awaits, and nothing here needs a framework, an
+/// entitlement, or a device.
+pub const capability_actions = [_]capabilities.ActionDecl{
+    .{ .name = A.set_biometric_persistence, .reply = .result },
+    .{ .name = A.check_biometric_persistence, .reply = .result },
+    .{ .name = A.clear_biometric_persistence, .reply = .result },
+};
+
+/// Which handler an action selects, or null for one this namespace does not
+/// serve. Split from `handleMessage` so the table-versus-dispatch agreement
+/// is assertable without driving the handlers.
+const Route = enum { set_persistence, check_persistence, clear_persistence };
+
+fn routeFor(action: []const u8) ?Route {
+    if (std.mem.eql(u8, action, A.set_biometric_persistence)) return .set_persistence;
+    if (std.mem.eql(u8, action, A.check_biometric_persistence)) return .check_persistence;
+    if (std.mem.eql(u8, action, A.clear_biometric_persistence)) return .clear_persistence;
+    return null;
+}
+
+/// When the current session stops being valid, in epoch milliseconds — the
+/// unit `expiresAt` is answered in — or null when no session is set.
+///
+/// `f64` rather than `i64` because Swift's arithmetic is all `Double`: a
+/// fractional `duration` is legal JSON, accepted by Swift, and produces a
+/// fractional expiry that `check` must subtract from faithfully. The one
+/// non-finite route into this variable is closed at `expiryFor`.
+///
+/// Module state, not instance state, and `init` must never touch it: the
+/// dispatch chain constructs a fresh bridge per message, and an `init` that
+/// reset this would wipe the session between the `set` that stored it and the
+/// `check` that reads it. Tests reset it explicitly for the same reason.
+var session_expiry_ms: ?f64 = null;
+
+pub const BiometricStoreBridge = struct {
+    allocator: std.mem.Allocator,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator) Self {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(_: *Self) void {}
+
+    pub fn handleMessage(self: *Self, action: []const u8, data: []const u8) !void {
+        const route = routeFor(action) orelse return bridge_error.BridgeError.UnknownAction;
+        // Exhaustive, so a `Route` added without a handler is a compile error
+        // instead of a silently unreachable action.
+        return switch (route) {
+            .set_persistence => self.setBiometricPersistence(data),
+            // `check` and `clear` carry no payload — the injected JS posts
+            // only the callback id — so `data` is ignored the way
+            // `getAppState` ignores it, rather than validated against a
+            // contract that does not exist.
+            .check_persistence => self.checkBiometricPersistence(),
+            .clear_persistence => self.clearBiometricPersistence(),
+        };
+    }
+
+    /// Start a session (`enabled:true`) or drop it (`enabled:false`).
+    ///
+    /// The state is written only after every fallible step, so a refused
+    /// payload cannot half-apply: an `InvalidParameter` set leaves whatever
+    /// session existed exactly as it was, which is what the error told the
+    /// page.
+    fn setBiometricPersistence(self: *Self, data: []const u8) !void {
+        var parsed = try parsePayload(self.allocator, data);
+        defer parsed.deinit();
+
+        const request = try parseSetRequest(parsed.value);
+
+        var buf: [768]u8 = undefined;
+        const json: []const u8 = if (request.enabled) blk: {
+            const now: f64 = @floatFromInt(compat.milliTimestamp());
+            const expiry = try expiryFor(now, request.duration_seconds);
+            // Reply built *before* the state is committed: `enableReply` is
+            // fallible in type (`bufPrint` can refuse), and a failure after
+            // the write would enable a session while telling the page it
+            // failed — the half-applied outcome this ordering rules out.
+            const reply = try enableReply(&buf, request.duration_seconds, expiry);
+            session_expiry_ms = expiry;
+            break :blk reply;
+        } else blk: {
+            session_expiry_ms = null;
+            break :blk disable_reply;
+        };
+        bridge_error.sendResultToJS(self.allocator, A.set_biometric_persistence, json);
+    }
+
+    /// Is there a live session, and for how much longer.
+    fn checkBiometricPersistence(self: *Self) !void {
+        var buf: [512]u8 = undefined;
+        const now: f64 = @floatFromInt(compat.milliTimestamp());
+        const json = try checkReply(&buf, session_expiry_ms, now);
+        bridge_error.sendResultToJS(self.allocator, A.check_biometric_persistence, json);
+    }
+
+    /// Drop the session. Unconditionally `{"cleared":true}`, as in Swift —
+    /// clearing a session that never existed is not a failure a caller could
+    /// act on, and `clear` is idempotent the way `removeSharedItem` is.
+    fn clearBiometricPersistence(self: *Self) !void {
+        session_expiry_ms = null;
+        bridge_error.sendResultToJS(self.allocator, A.clear_biometric_persistence, clear_reply);
+    }
+};
+
+/// One `set` request, after validation.
+const SetRequest = struct {
+    enabled: bool,
+    /// Seconds, as the page sends it. 300 when absent — the default both
+    /// layers above already apply.
+    duration_seconds: f64 = 300,
+};
+
+/// Parse `d`, distinguishing a bad payload from a failed allocation.
+/// `OutOfMemory` propagates as itself: telling the page INVALID_JSON about
+/// its own good JSON sends whoever debugs it to the wrong side of the bridge.
+fn parsePayload(allocator: std.mem.Allocator, data: []const u8) !std.json.Parsed(std.json.Value) {
+    return std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => return bridge_error.BridgeError.InvalidJSON,
+    };
+}
+
+/// The `enabled`/`duration` pair, or the reason it cannot be used.
+///
+/// Pure, so the host tests can pin every outcome Swift's `if let` collapsed
+/// into one silent fall-through. The field names are pinned on both sides of
+/// the migration: `handleAction` in `CraftApp.swift` parses `d` straight into
+/// `body` and the un-migrated arm reads `body["enabled"]` and
+/// `body["duration"]`.
+///
+/// `duration` is read — and type-checked — on the disable path too, where its
+/// value goes unused. The injected JS never sends it there, so anything
+/// present came from a hand-rolled post, and a request malformed in the field
+/// it chose to send is refused whole rather than half-read.
+fn parseSetRequest(payload: std.json.Value) !SetRequest {
+    const object = switch (payload) {
+        .object => |o| o,
+        else => return bridge_error.BridgeError.InvalidJSON,
+    };
+
+    const enabled_field = object.get("enabled") orelse return bridge_error.BridgeError.MissingData;
+    const enabled = switch (enabled_field) {
+        .bool => |b| b,
+        else => return bridge_error.BridgeError.InvalidParameter,
+    };
+
+    var request = SetRequest{ .enabled = enabled };
+
+    if (object.get("duration")) |duration_field| {
+        request.duration_seconds = switch (duration_field) {
+            .integer => |i| @floatFromInt(i),
+            .float => |f| f,
+            else => return bridge_error.BridgeError.InvalidParameter,
+        };
+        // JSON cannot spell NaN or a literal infinity, but it can spell
+        // `1e999`, which `std.json` parses to +inf rather than refusing. An
+        // infinite duration would put `inf` — not JSON — into the reply.
+        // Swift fares no better: it stores the infinite Date and its
+        // `resolveCallback` then dies inside `JSONSerialization`, which
+        // refuses non-finite numbers. Refusing up front is the honest version
+        // of the same outcome.
+        if (!std.math.isFinite(request.duration_seconds)) return bridge_error.BridgeError.InvalidParameter;
+    }
+
+    return request;
+}
+
+/// `Date(timeIntervalSinceNow: duration)`, in epoch milliseconds.
+///
+/// Fallible because f64 arithmetic can leave the finite range even when
+/// `duration` itself is finite: a duration near 1.8e305 seconds survives
+/// `parseSetRequest`'s check and overflows in the `* 1000.0` here. An
+/// infinite expiry would render as `inf` and break every later reply, so
+/// "a duration no clock can represent" is `InvalidParameter`.
+fn expiryFor(now_ms: f64, duration_seconds: f64) !f64 {
+    const expiry = now_ms + duration_seconds * 1000.0;
+    if (!std.math.isFinite(expiry)) return bridge_error.BridgeError.InvalidParameter;
+    return expiry;
+}
+
+/// `{"enabled":true,"duration":…,"expiresAt":…}` — the enable reply.
+///
+/// `bufPrint`, not the escaping builder `bridge_mobile_storage.zig` needs:
+/// every interpolated value is a number this module computed, and `{d}` on a
+/// finite f64 always renders plain decimal — never scientific, never `inf` —
+/// which is exactly the JSON number grammar. Whole values print without a
+/// trailing `.0`, so `"duration":300` reaches the page as the integer it
+/// sent; JavaScript does not distinguish.
+fn enableReply(buf: []u8, duration_seconds: f64, expires_at_ms: f64) ![]const u8 {
+    return std.fmt.bufPrint(
+        buf,
+        "{{\"enabled\":true,\"duration\":{d},\"expiresAt\":{d}}}",
+        .{ duration_seconds, expires_at_ms },
+    );
+}
+
+/// The disable reply. No `duration` and no `expiresAt`: Swift's disable arm
+/// answers the one field, and inventing the others would describe a session
+/// that no longer exists.
+const disable_reply = "{\"enabled\":false}";
+
+/// Doubles as the expired-session reply: Swift renders "never set" and
+/// "expired" identically (`isValid:false, remainingSeconds:0`), and the page
+/// cannot tell them apart by design.
+const no_session_reply = "{\"isValid\":false,\"remainingSeconds\":0}";
+
+/// The clear reply. Unconditional, as in Swift.
+const clear_reply = "{\"cleared\":true}";
+
+/// `{"isValid":…,"remainingSeconds":…}` — the check reply.
+///
+/// Pure in `(expiry, now)` so every branch is a host test with a chosen
+/// clock. Three Swift behaviours are pinned here: an expired-but-set timer is
+/// `false`/`0` and never a negative remainder; `Date() < expiry` is strict,
+/// so the exact expiry instant is already invalid; and `remainingSeconds` is
+/// *seconds* while the stored expiry (and `expiresAt`) are milliseconds — the
+/// divide by 1000 is the contract, not a tidy-up.
+fn checkReply(buf: []u8, expiry_ms: ?f64, now_ms: f64) ![]const u8 {
+    const expiry = expiry_ms orelse return no_session_reply;
+    if (!(now_ms < expiry)) return no_session_reply;
+    return std.fmt.bufPrint(
+        buf,
+        "{{\"isValid\":true,\"remainingSeconds\":{d}}}",
+        .{(expiry - now_ms) / 1000.0},
+    );
+}
+
+const testing = std.testing;
+
+test "every declared action is one the dispatcher routes" {
+    // The failure the mechanism exists to prevent: a name in the table that
+    // `handleMessage` has never heard of, which the manifest then promises.
+    for (capability_actions) |decl| {
+        if (routeFor(decl.name) == null) {
+            std.debug.print("declared action '{s}' does not route\n", .{decl.name});
+            return error.DeclaredActionDoesNotRoute;
+        }
+    }
+}
+
+test "every route the dispatcher has is a declared action" {
+    // The other direction. `handleMessage` switches exhaustively over
+    // `Route`, so a route without a handler cannot compile; this catches a
+    // route with a handler and no declaration. Each declaration must claim a
+    // *distinct* route — two rows naming one action would leave another
+    // route undeclared while the count still matched.
+    var claimed = std.mem.zeroes([std.enums.values(Route).len]bool);
+    for (capability_actions) |decl| {
+        const route = routeFor(decl.name) orelse return error.DeclaredActionDoesNotRoute;
+        const slot = @backingInt(route);
+        if (claimed[slot]) {
+            std.debug.print("two declarations route to {s}\n", .{@tagName(route)});
+            return error.TwoDeclarationsShareARoute;
+        }
+        claimed[slot] = true;
+    }
+    for (claimed, 0..) |taken, slot| {
+        if (!taken) {
+            std.debug.print(
+                "route {s} has a handler but no capability_actions row\n",
+                .{@tagName(@as(Route, @fromBackingInt(@intCast(slot))))},
+            );
+            return error.RouteNotDeclared;
+        }
+    }
+}
+
+test "the action names are the ones the Swift dispatcher answers" {
+    // The wire contract, spelled out: a rename here is invisible until a page
+    // stops being answered.
+    try testing.expectEqualStrings("setBiometricPersistence", A.set_biometric_persistence);
+    try testing.expectEqualStrings("checkBiometricPersistence", A.check_biometric_persistence);
+    try testing.expectEqualStrings("clearBiometricPersistence", A.clear_biometric_persistence);
+}
+
+test "all three actions resolve a promise and none is declared beyond its means" {
+    // `.live` is honest here precisely because nothing native is involved:
+    // there is no framework to be missing and no entitlement to lack.
+    for (capability_actions) |decl| {
+        try testing.expectEqual(capabilities.Reply.result, decl.reply);
+        try testing.expectEqual(capabilities.ActionStatus.live, decl.status);
+    }
+}
+
+test "an action the namespace does not serve is reported, not ignored" {
+    var bridge = BiometricStoreBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("noSuchAction", "{}"),
+    );
+    // Casing is how a real typo arrives.
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("setbiometricpersistence", "{}"),
+    );
+    // The desktop biometric bridge's vocabulary, which is a different
+    // namespace this module must not shadow.
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("evaluate", "{}"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("getBiometryType", "{}"),
+    );
+}
+
+test "a malformed payload is reported as bad JSON, not as a missing field" {
+    var bridge = BiometricStoreBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidJSON,
+        bridge.handleMessage(A.set_biometric_persistence, "{not json"),
+    );
+}
+
+/// Parse a literal payload straight through to a `SetRequest`. Unlike
+/// storage's `Request`, this one holds no slices into the parsed tree, so it
+/// can be returned past the parse's deinit.
+fn parseSetFromLiteral(json: []const u8) !SetRequest {
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    return parseSetRequest(parsed.value);
+}
+
+test "the two field names the page sends are the two that are read" {
+    const request = try parseSetFromLiteral("{\"enabled\":true,\"duration\":300}");
+    try testing.expect(request.enabled);
+    try testing.expectEqual(@as(f64, 300), request.duration_seconds);
+}
+
+test "a missing enabled is refused, not left hanging" {
+    // Swift's `if let enabled = body["enabled"] as? Bool` has no else, so
+    // this exact payload leaves the page's promise pending forever. Every
+    // path here answers.
+    try testing.expectError(bridge_error.BridgeError.MissingData, parseSetFromLiteral("{}"));
+    try testing.expectError(
+        bridge_error.BridgeError.MissingData,
+        parseSetFromLiteral("{\"duration\":300}"),
+    );
+}
+
+test "a non-bool enabled is refused, not coerced" {
+    // JavaScript truthiness stops at the bridge: 1 and "true" are not `true`,
+    // and guessing which way the page meant them would enable or disable a
+    // session it did not ask about.
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        parseSetFromLiteral("{\"enabled\":1}"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        parseSetFromLiteral("{\"enabled\":\"true\"}"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        parseSetFromLiteral("{\"enabled\":null}"),
+    );
+}
+
+test "an absent duration defaults to 300, matching both layers above" {
+    const enable = try parseSetFromLiteral("{\"enabled\":true}");
+    try testing.expectEqual(@as(f64, 300), enable.duration_seconds);
+    // The disable path is where absence is the *normal* case: the injected
+    // JS `disable()` sends no duration field at all.
+    const disable = try parseSetFromLiteral("{\"enabled\":false}");
+    try testing.expect(!disable.enabled);
+    try testing.expectEqual(@as(f64, 300), disable.duration_seconds);
+}
+
+test "a present duration is taken at its word, zero and negative included" {
+    // The injected JS maps a falsy duration to 300 *before posting*, so a 0
+    // arriving here was sent deliberately by a hand-rolled post — and Swift
+    // honours it as an instantly-expired session. Re-defaulting it would
+    // silently alter a field the page sent.
+    try testing.expectEqual(@as(f64, 0), (try parseSetFromLiteral("{\"enabled\":true,\"duration\":0}")).duration_seconds);
+    try testing.expectEqual(@as(f64, -60), (try parseSetFromLiteral("{\"enabled\":true,\"duration\":-60}")).duration_seconds);
+    try testing.expectEqual(@as(f64, 2.5), (try parseSetFromLiteral("{\"enabled\":true,\"duration\":2.5}")).duration_seconds);
+}
+
+test "a non-numeric duration is refused, not silently replaced with 300" {
+    // Swift's `as? Double ?? 300` rewrites `"duration":"300"` into 300 and
+    // reports success — the dropped-payload-field bug, verbatim.
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        parseSetFromLiteral("{\"enabled\":true,\"duration\":\"300\"}"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        parseSetFromLiteral("{\"enabled\":true,\"duration\":{}}"),
+    );
+    // The disable path validates too: the value is unused there, but a
+    // request malformed in the field it chose to send is refused whole.
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        parseSetFromLiteral("{\"enabled\":false,\"duration\":[]}"),
+    );
+}
+
+test "a duration JSON can spell but no clock can hold is refused" {
+    // `1e999` is legal JSON and `std.json` parses it to +inf rather than
+    // refusing. Left through, it would print `inf` into the reply — which is
+    // not JSON — and Swift's own reply serialisation refuses non-finite
+    // numbers anyway.
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        parseSetFromLiteral("{\"enabled\":true,\"duration\":1e999}"),
+    );
+}
+
+test "a payload that is not an object is bad JSON, not a missing field" {
+    try testing.expectError(bridge_error.BridgeError.InvalidJSON, parseSetFromLiteral("[]"));
+    try testing.expectError(bridge_error.BridgeError.InvalidJSON, parseSetFromLiteral("true"));
+}
+
+test "the expiry is now plus the duration, in milliseconds" {
+    try testing.expectEqual(@as(f64, 1301000), try expiryFor(1001000, 300));
+    // Fractional durations survive: 1.5005 s is 1500.5 ms.
+    try testing.expectEqual(@as(f64, 1001500.5), try expiryFor(1000000, 1.5005));
+    // A negative duration is a legal, instantly-expired session, as in
+    // Swift's `Date(timeIntervalSinceNow:)`.
+    try testing.expectEqual(@as(f64, 940000), try expiryFor(1000000, -60));
+}
+
+test "a finite duration whose expiry is not finite is refused" {
+    // floatMax survives `parseSetRequest`'s finiteness check; the `* 1000.0`
+    // here is what overflows. Letting it through would store `inf` and break
+    // every later `check`.
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        expiryFor(0, std.math.floatMax(f64)),
+    );
+}
+
+test "the enable reply is the Swift dictionary verbatim, expiresAt in milliseconds" {
+    var buf: [768]u8 = undefined;
+    try testing.expectEqualStrings(
+        "{\"enabled\":true,\"duration\":300,\"expiresAt\":1301000}",
+        try enableReply(&buf, 300, 1301000),
+    );
+}
+
+test "a fractional duration is echoed back, not rounded" {
+    var buf: [768]u8 = undefined;
+    const json = try enableReply(&buf, 2.5, 1756480000002.5);
+    try testing.expectEqualStrings(
+        "{\"enabled\":true,\"duration\":2.5,\"expiresAt\":1756480000002.5}",
+        json,
+    );
+
+    // And it is JSON whose numbers survive as numbers.
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expect(parsed.value.object.get("enabled").?.bool);
+    try testing.expectEqual(@as(f64, 2.5), parsed.value.object.get("duration").?.float);
+    try testing.expectEqual(@as(f64, 1756480000002.5), parsed.value.object.get("expiresAt").?.float);
+}
+
+test "a live session answers true and the remainder in seconds" {
+    var buf: [512]u8 = undefined;
+    // The stored expiry and `now` are milliseconds; the reply divides. The
+    // units differ from `expiresAt` on purpose, because they differ in Swift.
+    try testing.expectEqualStrings(
+        "{\"isValid\":true,\"remainingSeconds\":300}",
+        try checkReply(&buf, 1301000, 1001000),
+    );
+    // Sub-second remainders keep their fraction.
+    try testing.expectEqualStrings(
+        "{\"isValid\":true,\"remainingSeconds\":1.5}",
+        try checkReply(&buf, 1001500, 1000000),
+    );
+}
+
+test "no session, an expired session and the exact expiry instant all answer the same" {
+    var buf: [512]u8 = undefined;
+    // Never set.
+    try testing.expectEqualStrings(no_session_reply, try checkReply(&buf, null, 1000000));
+    // Expired: zero, never a negative remainder — Swift's ternary pins that.
+    try testing.expectEqualStrings(no_session_reply, try checkReply(&buf, 999000, 1000000));
+    // Swift's `Date() < expiry` is strict: at the boundary, the session is
+    // already over.
+    try testing.expectEqualStrings(no_session_reply, try checkReply(&buf, 1000000, 1000000));
+}
+
+test "the constant replies are the fields the SDK type declares, and nothing more" {
+    // `craft.d.ts`: disable() -> {enabled}, check() -> {isValid,
+    // remainingSeconds}, clear() -> {cleared}. The field counts matter too:
+    // extra fields would be harmless to today's stringify-only consumers and
+    // a lie to the next one.
+    const disable = try std.json.parseFromSlice(std.json.Value, testing.allocator, disable_reply, .{});
+    defer disable.deinit();
+    try testing.expect(!disable.value.object.get("enabled").?.bool);
+    try testing.expectEqual(@as(usize, 1), disable.value.object.count());
+
+    const none = try std.json.parseFromSlice(std.json.Value, testing.allocator, no_session_reply, .{});
+    defer none.deinit();
+    try testing.expect(!none.value.object.get("isValid").?.bool);
+    try testing.expectEqual(@as(i64, 0), none.value.object.get("remainingSeconds").?.integer);
+    try testing.expectEqual(@as(usize, 2), none.value.object.count());
+
+    const cleared = try std.json.parseFromSlice(std.json.Value, testing.allocator, clear_reply, .{});
+    defer cleared.deinit();
+    try testing.expect(cleared.value.object.get("cleared").?.bool);
+    try testing.expectEqual(@as(usize, 1), cleared.value.object.count());
+}
+
+test "enable stores the expiry the reply names; disable and clear drop it" {
+    session_expiry_ms = null;
+    defer session_expiry_ms = null;
+
+    var bridge = BiometricStoreBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    // The reply itself goes to a webview this process does not have —
+    // `sendResultToJS` swallows that, as `bridge_mobile_device.zig`'s log
+    // test already relies on — so the observable half on a host is the state.
+    const before = compat.milliTimestamp();
+    try bridge.handleMessage(A.set_biometric_persistence, "{\"enabled\":true,\"duration\":300}");
+    const after = compat.milliTimestamp();
+
+    const expiry = session_expiry_ms orelse return error.SessionNotStored;
+    try testing.expect(expiry >= @as(f64, @floatFromInt(before)) + 300000);
+    try testing.expect(expiry <= @as(f64, @floatFromInt(after)) + 300000);
+
+    try bridge.handleMessage(A.set_biometric_persistence, "{\"enabled\":false}");
+    try testing.expect(session_expiry_ms == null);
+
+    try bridge.handleMessage(A.set_biometric_persistence, "{\"enabled\":true}");
+    try testing.expect(session_expiry_ms != null);
+    try bridge.handleMessage(A.clear_biometric_persistence, "{}");
+    try testing.expect(session_expiry_ms == null);
+}
+
+test "a refused set leaves the session exactly as it was" {
+    // The half-applied failure mode: state written before validation. The
+    // page was told InvalidParameter, so nothing may have changed.
+    session_expiry_ms = 123456789;
+    defer session_expiry_ms = null;
+
+    var bridge = BiometricStoreBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        bridge.handleMessage(A.set_biometric_persistence, "{\"enabled\":\"yes\",\"duration\":300}"),
+    );
+    try testing.expectEqual(@as(?f64, 123456789), session_expiry_ms);
+
+    try testing.expectError(
+        bridge_error.BridgeError.MissingData,
+        bridge.handleMessage(A.set_biometric_persistence, "{\"duration\":300}"),
+    );
+    try testing.expectEqual(@as(?f64, 123456789), session_expiry_ms);
+}
+
+test "check reports an expired session without clearing it" {
+    // Swift leaves the stale Date in place; `check` is a reader here too.
+    // Only `clear` and disable remove it, and a later `set` overwrites it.
+    session_expiry_ms = 5; // 1970, long expired
+    defer session_expiry_ms = null;
+
+    var bridge = BiometricStoreBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try bridge.handleMessage(A.check_biometric_persistence, "{}");
+    try testing.expectEqual(@as(?f64, 5), session_expiry_ms);
+}

--- a/packages/zig/src/bridge_mobile_misc.zig
+++ b/packages/zig/src/bridge_mobile_misc.zig
@@ -1,0 +1,454 @@
+//! The `mobile` namespace's flashlight action — and the recorded decision that
+//! the other three actions scoped to this module (`getInitialURL`,
+//! `registerDeepLinkHandler`, `takeScreenshot`) stay *unserved*, so that
+//! `ios_dispatch.route` falls through to the Swift shim that answers them
+//! correctly today. See `deliberately_unserved`.
+//!
+//! ## Why `setFlashlight` is the only arm
+//!
+//! It is the only one of the four with no `CraftConfig` gate in front of it:
+//! the Swift dispatcher calls `setFlashlight(enabled:)` unconditionally, and
+//! the injected capabilities blob hardcodes `flashlight: true`. Every step is
+//! a synchronous AVFoundation call — no completion handler, no `ios_async`
+//! ticket — so the whole exchange happens inside the dispatch frame that holds
+//! the request id, on the main thread WebKit delivered it on.
+//!
+//! The other three founder on one missing channel: their Swift arms are
+//! conditional on `CraftConfig` flags (`enableDeepLinks`,
+//! `enableScreenCapture`) that exist only as Swift properties. Nothing carries
+//! them to Zig — no export, no shared defaults, nothing to grep — so a Zig
+//! handler cannot know whether the app author enabled the feature. Each action
+//! adds its own reason on top:
+//!
+//!  - **`getInitialURL`** cannot be answered from Zig at all. The value lives
+//!    in `DeepLinkManager.shared.initialURL` — a private property of a
+//!    pure-Swift class that derives from nothing and declares no `@objc`, so
+//!    `objc_getClass("DeepLinkManager")` cannot find it and neither `shared`
+//!    nor `getInitialURL()` has an ObjC entry point. It is fed by SwiftUI's
+//!    `.onOpenURL`, which Zig has no path to, and the launch URL is not
+//!    re-derivable afterwards (not in the environment, not in NSUserDefaults).
+//!  - **`registerDeepLinkHandler`** does nothing but acknowledge: Swift
+//!    replies the bare boolean `true` iff `config.enableDeepLinks`; the real
+//!    registration is the page's own `addEventListener('craftDeepLink', …)`.
+//!    An unconditional `true` from Zig would report "registered" in apps where
+//!    the event can never fire. No JS anywhere in the repo posts the action —
+//!    the injected script, `test-bridges.html`, `craft-bridge.js` and the TS
+//!    SDK are all silent — so there is also nothing to migrate *for*.
+//!  - **`takeScreenshot`**'s capture is fully doable from Zig
+//!    (`UIGraphicsBeginImageContextWithOptions` and friends, then
+//!    `UIImagePNGRepresentation`), but `enableScreenCapture` defaults to
+//!    *false* and Swift's arm skips the handler entirely when it is off.
+//!    Serving it unconditionally would switch on a capability the app author
+//!    turned off — fabricated authorization, the exact class of bug this
+//!    migration exists to remove. It stays with the shim until a config
+//!    channel exists.
+//!
+//! ## Why unserved rather than `.unavailable`
+//!
+//! `ios_dispatch.route` hands an action to `CraftSwiftShim` only when every
+//! module answers `UnknownAction`. A declared-`.unavailable` action
+//! *dispatches and refuses* — `bridge_mobile_display.lockOrientation` is the
+//! precedent — so declaring these three would take them away from the shim,
+//! replacing answers that are correct today with rejections. In a Zig-only
+//! build with no shim, the fall-through degrades to an `UnknownAction` error
+//! at the page, which is still the honest outcome: absent the config, craft
+//! does not know whether these features are enabled, and an error a page can
+//! see beats a guess it cannot.
+//!
+//! ## Build note
+//!
+//! A generated app autolinks AVFoundation (`CraftApp.swift` does
+//! `import AVFoundation`). The zig-slice fixture
+//! (`packages/ios/fixtures/zig-slice/build-and-run.sh`) links only
+//! UIKit/WebKit/Foundation/Security, so there `objc_getClass("AVCaptureDevice")`
+//! returns null until `-framework AVFoundation` is added — which the null
+//! check reports as "no flashlight", the same rejection Swift's guard gives a
+//! simulator. Honest either way, but the fixture needs the flag before the
+//! torch can actually light.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const capabilities = @import("capabilities.zig");
+const bridge_error = @import("bridge_error.zig");
+const objc_runtime = @import("objc_runtime.zig");
+
+const objc = objc_runtime.objc;
+const BridgeError = bridge_error.BridgeError;
+
+/// The same type as `objc.id` — `?*anyopaque` — spelled locally.
+///
+/// `objc_runtime.objc` is an empty struct off Darwin, and a `callconv(.c)`
+/// fn-pointer *type* is analysed even when a comptime platform guard makes the
+/// code around it unreachable, so naming `objc.id` there would break the host
+/// build. A single optional pointer, never `?objc.id`: a double optional is
+/// illegal in a `callconv(.c)` signature.
+const Id = ?*anyopaque;
+
+/// `AVCaptureTorchMode`, from `AVCaptureDevice.h`. An `NSInteger`, hence
+/// `c_long` — a narrower type would pass the right bits for 0 and 1 by luck
+/// and break the day a new mode appears.
+const AVCaptureTorchModeOff: c_long = 0;
+const AVCaptureTorchModeOn: c_long = 1;
+
+/// The action name, spelled exactly as the Swift `case` label spells it.
+///
+/// `test/ios_conformance_test.zig` reads this block as "actions Zig serves".
+/// The three unserved actions this module documents must therefore *not*
+/// appear here: listing one would tell the ratchet it migrated while the shim
+/// is still the thing answering it.
+pub const A = struct {
+    pub const set_flashlight = "setFlashlight";
+};
+
+/// The actions this module was scoped to and, on purpose, does not serve.
+///
+/// Recorded as data rather than prose so a test can hold the two properties
+/// the decision rests on: none of them is declared, and each still falls out
+/// of `handleMessage` as `UnknownAction` — the one return `ios_dispatch.route`
+/// converts into a Swift-shim hand-off. Whoever migrates one for real moves
+/// its name from this list into `A` and updates the module comment.
+pub const deliberately_unserved = [_][]const u8{
+    "getInitialURL",
+    "registerDeepLinkHandler",
+    "takeScreenshot",
+};
+
+/// `.result`: every Swift path terminates in `resolveCallback(…, true)` or a
+/// rejection, and the injected `setFlashlight` returns a promise the page can
+/// await. `.live`: the no-torch outcome (simulator, torchless hardware, an
+/// app that dropped AVFoundation) is a per-call rejection — a property of the
+/// device the call found, not of the action.
+pub const capability_actions = [_]capabilities.ActionDecl{
+    .{ .name = A.set_flashlight, .reply = .result },
+};
+
+/// Swift resolves with `resolveCallback(callbackId, result: true)`, serialized
+/// `.fragmentsAllowed`, so the page receives the bare JSON boolean `true` —
+/// not `{"success":true}`. No caller in the repo reads the resolved value
+/// (`craft.d.ts` even types the method `void`), but the shape is the contract
+/// and inventing an object here would change it.
+const success_reply = "true";
+
+pub const MiscBridge = struct {
+    allocator: std.mem.Allocator,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator) Self {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(_: *Self) void {}
+
+    pub fn handleMessage(self: *Self, action: []const u8, data: []const u8) !void {
+        if (std.mem.eql(u8, action, A.set_flashlight)) {
+            try self.setFlashlight(data);
+        } else {
+            // `getInitialURL`, `registerDeepLinkHandler` and `takeScreenshot`
+            // land here on purpose: `UnknownAction` is what routes an action
+            // onward to the Swift shim. See the module comment.
+            return BridgeError.UnknownAction;
+        }
+    }
+
+    /// Turn the torch on or off, and say so with Swift's bare `true`.
+    fn setFlashlight(self: *Self, data: []const u8) !void {
+        var parsed = try parsePayload(self.allocator, data);
+        defer parsed.deinit();
+
+        const enabled = try parseEnabled(parsed.value);
+
+        try setTorch(self.allocator, enabled);
+
+        bridge_error.sendResultToJS(self.allocator, A.set_flashlight, success_reply);
+    }
+};
+
+/// Parse `d`, distinguishing a bad payload from a failed allocation.
+///
+/// `OutOfMemory` propagates as itself: telling the page INVALID_JSON about its
+/// own perfectly good JSON sends whoever debugs it to the wrong side of the
+/// bridge.
+fn parsePayload(allocator: std.mem.Allocator, data: []const u8) !std.json.Parsed(std.json.Value) {
+    return std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => return BridgeError.InvalidJSON,
+    };
+}
+
+/// The `enabled` the page sent, or the reason it cannot be used. Pure, so the
+/// host tests pin every outcome that Swift's `as? Bool` collapsed into one
+/// silent fall-through.
+///
+/// The field name is the one the injected JS posts beside `action` and
+/// `callbackId` — `{action: 'setFlashlight', enabled: enabled, …}` — and the
+/// un-migrated shim reads `body["enabled"]`; both sides of the migration have
+/// to read the same payload.
+///
+/// Swift's arm is `if let enabled = body["enabled"] as? Bool` with no `else`:
+/// a missing or mistyped field replies nothing and the promise hangs for the
+/// full request timeout. That is deliberately not carried across (the storage
+/// module states the family policy); every path here ends in a value or an
+/// error. One divergence rides along: `as? Bool` also lets the NSNumbers 0
+/// and 1 through, so `{"enabled":1}` flips the torch via the shim today and
+/// is `InvalidParameter` here — refused rather than coerced, as this family
+/// refuses everywhere, and the typed surface
+/// (`craft.d.ts: setFlashlight(enabled: boolean)`) never produces it.
+fn parseEnabled(payload: std.json.Value) !bool {
+    const object = switch (payload) {
+        .object => |o| o,
+        else => return BridgeError.InvalidJSON,
+    };
+    const field = object.get("enabled") orelse return BridgeError.MissingData;
+    return switch (field) {
+        .bool => |b| b,
+        else => BridgeError.InvalidParameter,
+    };
+}
+
+/// The raw `AVCaptureTorchMode` for a request. Pure, so the one value that
+/// reaches the hardware is pinned by a host test rather than by reading the
+/// header again — a swap would invert every page's flashlight with no error
+/// anywhere.
+fn torchModeFor(enabled: bool) c_long {
+    return if (enabled) AVCaptureTorchModeOn else AVCaptureTorchModeOff;
+}
+
+/// `AVCaptureDevice.default(for: .video)` → `hasTorch` → lock, set, unlock.
+///
+/// Error mapping is lossy the same way the storage module's OSStatus mapping
+/// is — `sendErrorToJS` carries an enum, not text — so Swift's two rejection
+/// strings become the nearest `BridgeError` and the specifics go to the log:
+/// every flavour of "Flashlight not available" (no framework, no device, no
+/// torch) is `NotFound`, and a refused `lockForConfiguration:` (Swift's
+/// `catch`, rejected with `error.localizedDescription`) is `NativeCallFailed`.
+fn setTorch(allocator: std.mem.Allocator, enabled: bool) !void {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const AVCaptureDevice = objc.objc_getClass("AVCaptureDevice") orelse {
+        // AVFoundation is not in the process — see the module's build note.
+        // No framework, no torch; the same "not available" answer Swift's
+        // guard would give, reached one step earlier.
+        std.log.warn("setFlashlight: AVCaptureDevice class not found; is AVFoundation linked?", .{});
+        return BridgeError.NotFound;
+    };
+
+    // AVMediaTypeVideo is the FourCC string "vide". The literal, not the
+    // extern constant — same trade as `bridge_continuity_camera.zig`: the
+    // constant would put AVFoundation on every consumer's *link* line, and
+    // the value is fixed by decades of QuickTime FourCC compatibility.
+    const media_type = (try objc.createNSString("vide", allocator)) orelse
+        return BridgeError.NativeCallFailed;
+
+    const sel_default = objc.sel_registerName("defaultDeviceWithMediaType:") orelse return error.SelectorNotFound;
+    const device = objc.msgSendId1(AVCaptureDevice, sel_default, media_type) orelse {
+        // The simulator's answer, and a camera-less device's. Swift's guard
+        // takes the same exit: reject, never pretend the torch moved.
+        std.log.info("setFlashlight: no default video capture device (simulator, or no camera)", .{});
+        return BridgeError.NotFound;
+    };
+
+    const sel_has_torch = objc.sel_registerName("hasTorch") orelse return error.SelectorNotFound;
+    if (!objc.msgSendBool(device, sel_has_torch)) {
+        std.log.info("setFlashlight: capture device has no torch", .{});
+        return BridgeError.NotFound;
+    }
+
+    // All three selectors are registered *before* the lock is taken, so no
+    // error path exists between `lockForConfiguration:` and
+    // `unlockForConfiguration` — an early return in that window would leave
+    // the device configuration locked for the rest of the process.
+    const sel_lock = objc.sel_registerName("lockForConfiguration:") orelse return error.SelectorNotFound;
+    const sel_set_mode = objc.sel_registerName("setTorchMode:") orelse return error.SelectorNotFound;
+    const sel_unlock = objc.sel_registerName("unlockForConfiguration") orelse return error.SelectorNotFound;
+
+    // `- (BOOL)lockForConfiguration:(NSError **)outError`, with the out-param
+    // left null: the BOOL already separates locked from not, the NSError
+    // would arrive autoreleased with nothing to do but be logged, and Swift's
+    // `catch` keeps only its message too. The usual cause of a refusal is
+    // another capture session holding the device.
+    const LockFn = *const fn (Id, objc.SEL, ?*Id) callconv(.c) bool;
+    const lock: LockFn = @ptrCast(&objc.objc_msgSend);
+    if (!lock(device, sel_lock, null)) {
+        std.log.warn("setFlashlight: lockForConfiguration: refused", .{});
+        return BridgeError.NativeCallFailed;
+    }
+
+    objc.msgSendVoid1(device, sel_set_mode, torchModeFor(enabled));
+    objc.msgSend(device, sel_unlock);
+}
+
+// =============================================================================
+// Tests
+//
+// Host-only, and there is deliberately no live AVFoundation test. On a Mac
+// with a Continuity Camera iPhone paired, `defaultDeviceWithMediaType:` can
+// return a device whose `hasTorch` is YES — at which point a "test" would
+// fire the torch on somebody's actual phone. Every honest outcome on a host
+// is either environment-dependent (class linked or not, camera present or
+// not) or a side effect on hardware craft does not own, and a test whose pass
+// condition varies by desk is a flake, not a gate. The decisions that fit in
+// a host test — routing, payload validation, the mode values, the reply
+// shape — are pure functions above, and are pinned below.
+// =============================================================================
+
+const testing = std.testing;
+
+test "the declared action is the one the handler serves" {
+    try testing.expectEqual(@as(usize, 1), capability_actions.len);
+    try testing.expectEqualStrings(A.set_flashlight, capability_actions[0].name);
+    try testing.expectEqual(capabilities.Reply.result, capability_actions[0].reply);
+    try testing.expectEqual(capabilities.ActionStatus.live, capability_actions[0].status);
+}
+
+test "the action name matches the Swift case label exactly" {
+    // The conformance ratchet compares this string against the `case "…":`
+    // labels in `CraftApp.swift`, in both directions; a prettier spelling
+    // would register as Zig serving an action the spec does not have.
+    try testing.expectEqualStrings("setFlashlight", A.set_flashlight);
+}
+
+test "every declared action dispatches to something" {
+    // `{}` has no `enabled`, so validation fails *before* any AVFoundation
+    // call — which is what makes this safe on a host with a real camera. What
+    // it rules out is a name in the table `handleMessage` never compares
+    // against.
+    var bridge = MiscBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    for (capability_actions) |decl| {
+        try testing.expectError(
+            BridgeError.MissingData,
+            bridge.handleMessage(decl.name, "{}"),
+        );
+    }
+}
+
+test "the unserved actions stay unserved, which is what routes them to the shim" {
+    var bridge = MiscBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    for (deliberately_unserved) |name| {
+        // `UnknownAction` is the one return `ios_dispatch.route` turns into a
+        // Swift-shim hand-off. Anything else — a result, `.unavailable`'s
+        // refusal, any other error — would take the action away from the arm
+        // that answers it correctly today.
+        try testing.expectError(
+            BridgeError.UnknownAction,
+            bridge.handleMessage(name, "{}"),
+        );
+
+        // And none of them is declared: a capability row for an action the
+        // shim serves would be this module claiming another component's work,
+        // and a name in `A` would tell the conformance ratchet it migrated.
+        for (capability_actions) |decl| {
+            try testing.expect(!std.mem.eql(u8, decl.name, name));
+        }
+    }
+}
+
+test "an action the namespace does not serve is reported, not ignored" {
+    var bridge = MiscBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        BridgeError.UnknownAction,
+        bridge.handleMessage("noSuchAction", "{}"),
+    );
+    // `craft.d.ts` declares `toggleFlashlight` and `test-bridges.html` calls
+    // it, but no injected JS defines it and no dispatcher case answers it — a
+    // pre-existing spec gap, not an action to invent here.
+    try testing.expectError(
+        BridgeError.UnknownAction,
+        bridge.handleMessage("toggleFlashlight", "{\"enabled\":true}"),
+    );
+    // Casing is how a real typo arrives.
+    try testing.expectError(
+        BridgeError.UnknownAction,
+        bridge.handleMessage("setflashlight", "{\"enabled\":true}"),
+    );
+}
+
+test "a malformed payload is reported as bad JSON, not as a missing field" {
+    var bridge = MiscBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        BridgeError.InvalidJSON,
+        bridge.handleMessage(A.set_flashlight, "{not json"),
+    );
+}
+
+/// Parse a literal payload and check the extracted `enabled` — the slices in
+/// a `std.json.Value` point into the `Parsed`, so it stays alive around the
+/// check.
+fn expectEnabled(json: []const u8, expected: bool) !void {
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqual(expected, try parseEnabled(parsed.value));
+}
+
+fn expectEnabledError(json: []const u8, expected: anyerror) !void {
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectError(expected, parseEnabled(parsed.value));
+}
+
+test "the field name the page sends is the field that is read" {
+    try expectEnabled("{\"enabled\":true}", true);
+    try expectEnabled("{\"enabled\":false}", false);
+}
+
+test "a missing enabled is refused rather than defaulted" {
+    // Defaulting to `false` would report "torch off" as the success of a
+    // request that asked for nothing; Swift replies nothing at all and the
+    // promise hangs. Both silent shapes are the ones this family removes.
+    try expectEnabledError("{}", BridgeError.MissingData);
+    // Field names are case-sensitive on the wire; a near-miss is absent.
+    try expectEnabledError("{\"Enabled\":true}", BridgeError.MissingData);
+}
+
+test "a non-boolean enabled is refused, not coerced" {
+    // The one deliberate divergence from Swift, documented at `parseEnabled`:
+    // `as? Bool` lets the NSNumbers 0 and 1 through, so `{"enabled":1}` flips
+    // the torch via the shim today. Coercion is refused everywhere in this
+    // family, and the typed JS surface never produces it.
+    try expectEnabledError("{\"enabled\":1}", BridgeError.InvalidParameter);
+    try expectEnabledError("{\"enabled\":0}", BridgeError.InvalidParameter);
+    try expectEnabledError("{\"enabled\":\"true\"}", BridgeError.InvalidParameter);
+    try expectEnabledError("{\"enabled\":null}", BridgeError.InvalidParameter);
+}
+
+test "a payload that is not an object is bad JSON, not a missing field" {
+    try expectEnabledError("[]", BridgeError.InvalidJSON);
+    try expectEnabledError("true", BridgeError.InvalidJSON);
+}
+
+test "the torch modes are the header's values" {
+    try testing.expectEqual(@as(c_long, 1), torchModeFor(true));
+    try testing.expectEqual(@as(c_long, 0), torchModeFor(false));
+}
+
+test "the success reply is Swift's bare boolean, and it parses" {
+    // `.fragmentsAllowed`: the page's promise resolves with `true` itself,
+    // not an object wrapping it.
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, success_reply, .{});
+    defer parsed.deinit();
+    try testing.expect(parsed.value == .bool);
+    try testing.expect(parsed.value.bool);
+}
+
+test "off Darwin the torch refuses rather than pretending" {
+    // The platform gate, exercised where it actually gates. On Darwin this
+    // same call would reach AVFoundation for real — see the test-section
+    // comment for why that is not done.
+    if (builtin.target.os.tag.isDarwin()) return error.SkipZigTest;
+
+    var bridge = MiscBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        error.UnsupportedPlatform,
+        bridge.handleMessage(A.set_flashlight, "{\"enabled\":true}"),
+    );
+}

--- a/packages/zig/src/bridge_mobile_permissions.zig
+++ b/packages/zig/src/bridge_mobile_permissions.zig
@@ -1,0 +1,973 @@
+//! The permission actions of the `mobile` namespace: `checkPermission` and
+//! `requestPermission`.
+//!
+//! The page-side contract (`craft.permissions` in the injected JS) is one
+//! field in — `{permission: "camera"}` — and a bare JSON fragment out:
+//! `"granted"`, `"denied"`, `"restricted"` or `"undetermined"`. There is no
+//! `"prompt"` anywhere in the vocabulary, and no `{status:…}` wrapper — the
+//! desktop bridge's `craft.permissions` in `craft-bridge.js` (`t='permissions'`,
+//! payload field `name`, reply `{status:…}`) is a different, unrelated contract.
+//! Swift serialises replies with `.fragmentsAllowed`, so the bare quoted string
+//! is the wire value, and `ios_async`'s `"granted"`/`"denied"` completions are
+//! byte-identical to what Swift sends.
+//!
+//! ## What is served, and what deliberately is not
+//!
+//! Dispatch is per *action*, but honesty here is per *permission value*: Zig
+//! can read ten authorization statuses synchronously and can run three request
+//! prompts through `ios_async`'s pooled completion blocks, and it cannot do
+//! the rest without machinery it does not own yet. The split:
+//!
+//!  - `checkPermission` is served for location, locationAlways, camera,
+//!    microphone, photos, contacts, calendar, reminders, motion and
+//!    bluetooth. `notifications` is handed back to the dispatcher as
+//!    `UnknownAction`: the only status API is
+//!    `getNotificationSettingsWithCompletionHandler:`, whose completion takes
+//!    a `UNNotificationSettings *` and whose answer needs three words —
+//!    `ios_async` speaks only BOOL blocks and only two. There is no
+//!    synchronous API to fall back on, and answering without asking is the
+//!    fabricated-reading class this migration exists to remove.
+//!  - `requestPermission` is served for camera, microphone and notifications,
+//!    whose completions are exactly the `void(^)(BOOL)` and
+//!    `void(^)(BOOL, NSError*)` shapes the block pool was built for.
+//!    location/locationAlways (the reply arrives via the app's
+//!    `CLLocationManagerDelegate`, needs its `locationManager` and
+//!    `enableBackgroundLocation` config, and speaks the full four-word
+//!    vocabulary), photos (a status-enum completion with a `.limited`
+//!    special case a BOOL cannot carry) and contacts/calendar/reminders
+//!    (need a store instance kept alive past the dispatch frame, plus an
+//!    iOS 17 availability fork) return `UnknownAction`.
+//!  - `openSettings` is not claimed at all — not in `A`, not in the table.
+//!    Its reply is a bare JSON *boolean* (`UIApplication.open`'s completion
+//!    BOOL, `true`/`false` on the wire), and `ios_async.boolBlock` replies
+//!    the strings `"granted"`/`"denied"`. That mismatch is not cosmetic:
+//!    `false` is falsy and `"denied"` is truthy, so
+//!    `if (await craft.permissions.openSettings())` would take its success
+//!    branch on failure. Hand-building a one-off block here is off the table
+//!    — the repo's last hand-rolled completion block was stack-allocated
+//!    with a doc comment asserting a lifetime async does not honour — so
+//!    claiming this action means first extending `ios_async` with a
+//!    bool-literal reply variant. Until then the Swift shim's answer is
+//!    correct and keeps flowing.
+//!
+//! Returning `UnknownAction` for a payload value is what keeps this honest
+//! without regressing anything: `ios_dispatch.route` treats it as "not mine,
+//! ask the next", finds no other module claiming the action, and hands the
+//! *same* action and payload to `handOffToHost`, where the un-migrated Swift
+//! arm answers exactly as it does today. This is the deliberate opposite of
+//! the `.unavailable` declarations in `bridge_mobile_device`
+//! (`getNetworkStatus`) and `bridge_mobile_display` (`lockOrientation`):
+//! those took actions *away* from the shim because the shim's answers were
+//! fabricated or broken; these shim answers are real, and taking them away
+//! would trade working behaviour for a tidier table. The cost is that the
+//! conformance ratchet keeps counting `openSettings` as not-yet-migrated —
+//! which is the truth.
+//!
+//! ## What is carried across exactly
+//!
+//!  - The status vocabulary and its precedence: restricted beats denied
+//!    beats granted, and everything else — including enum values a future
+//!    iOS adds — is `"undetermined"`. That is Swift's `permissionStatus`
+//!    helper verbatim. Unknown *permission names* also resolve
+//!    `"undetermined"` (Swift's `default` arm); it is a real answer — the
+//!    status of a permission iOS has never heard of is not determined — and
+//!    erroring instead would diverge from both the shim and Android.
+//!  - `requestPermission` for motion and bluetooth resolves
+//!    `"undetermined"`: the Swift request switch has no arm for either, so
+//!    they fall into `default`. iOS prompts for these implicitly at first
+//!    framework use; the spec never requests them explicitly, and neither
+//!    does this module. Resolving locally rather than falling through is
+//!    identical behaviour, minus one Objective-C round trip.
+//!  - `"location"` counts `.authorizedWhenInUse` as granted;
+//!    `"locationAlways"` does not. Same raw status, different verdicts, and
+//!    the check reads the same deprecated
+//!    `+[CLLocationManager authorizationStatus]` the Swift spec calls —
+//!    matching it, not modernising it, because the instance property needs a
+//!    manager this module does not own.
+//!
+//! ## Framework presence, not framework linkage
+//!
+//! Unlike `bridge_mobile_storage`'s Security externs, nothing here is a
+//! link-time symbol: every class is found with `objc_getClass` at call time,
+//! and the one string constant (`AVMediaTypeVideo`) through `dlsym` with the
+//! documented literal value as fallback. A generated app has every class in
+//! the process because `CraftApp.swift` imports AVFoundation, Photos,
+//! Contacts, EventKit, CoreMotion, CoreBluetooth, CoreLocation and
+//! UserNotifications; a process missing one answers `ClassNotFound` →
+//! NATIVE_CALL_FAILED, never a crash and never a guess.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const capabilities = @import("capabilities.zig");
+const bridge_error = @import("bridge_error.zig");
+const objc_runtime = @import("objc_runtime.zig");
+const ios_async = @import("ios_async.zig");
+
+const objc = objc_runtime.objc;
+const is_darwin = builtin.target.os.tag.isDarwin();
+
+/// The same type as `objc.id` — `?*anyopaque` — spelled locally.
+///
+/// `objc_runtime.objc` is an empty struct off Darwin, and a function
+/// *signature* is analysed even when a comptime platform guard makes its body
+/// unreachable, so naming `objc.id` in the signatures below would break the
+/// host build. It stays a single optional pointer, never `?objc.id`, because a
+/// double optional is illegal in a `callconv(.c)` type.
+const Id = ?*anyopaque;
+
+/// The action names, spelled exactly as the Swift `case` labels spell them.
+///
+/// `openSettings` is deliberately absent — see the module comment. Adding it
+/// here without first giving `ios_async` a boolean-literal reply would ship
+/// the truthy-`"denied"` bug, and the conformance scan would count the action
+/// as migrated while the shim was still the only honest server of it.
+pub const A = struct {
+    pub const check_permission = "checkPermission";
+    pub const request_permission = "requestPermission";
+};
+
+/// Both `.result`: every Swift path for these two actions terminates in
+/// exactly one `resolveCallback` or `rejectCallback`, and the injected
+/// `craft.permissions.check`/`request` return promises the page awaits.
+///
+/// Both `.live`, with the caveat the module comment spells out: the manifest
+/// speaks per action, and a handful of payload *values* ride through to the
+/// Swift shim via `UnknownAction`. The page cannot observe the difference —
+/// the same reply arrives either way — so `.live` is the accurate claim.
+pub const capability_actions = [_]capabilities.ActionDecl{
+    .{ .name = A.check_permission, .reply = .result },
+    .{ .name = A.request_permission, .reply = .result },
+};
+
+/// Which handler an action selects, or null for one this namespace does not
+/// serve. Split out from `handleMessage` so the table-versus-dispatch
+/// agreement is assertable on a host that has none of the frameworks.
+const Route = enum { check, request };
+
+fn routeFor(action: []const u8) ?Route {
+    if (std.mem.eql(u8, action, A.check_permission)) return .check;
+    if (std.mem.eql(u8, action, A.request_permission)) return .request;
+    return null;
+}
+
+/// The permission names the Swift switches recognise, plus `.unknown` for
+/// everything else — which is a routed outcome (`"undetermined"`), not an
+/// error, because it is Swift's `default` arm.
+///
+/// Spellings are the Swift `case` labels, compared case-sensitively, exactly
+/// as Swift compares them. The name is only ever *compared* — it never
+/// reaches `createNSString` — so an embedded NUL needs no refusal here: it
+/// fails every comparison and lands in `.unknown`, the same `"undetermined"`
+/// Swift gives it (Swift keeps the NUL and also falls to `default`).
+const Kind = enum {
+    location,
+    location_always,
+    camera,
+    microphone,
+    photos,
+    contacts,
+    calendar,
+    reminders,
+    motion,
+    bluetooth,
+    notifications,
+    unknown,
+};
+
+fn kindFor(name: []const u8) Kind {
+    if (std.mem.eql(u8, name, "location")) return .location;
+    if (std.mem.eql(u8, name, "locationAlways")) return .location_always;
+    if (std.mem.eql(u8, name, "camera")) return .camera;
+    if (std.mem.eql(u8, name, "microphone")) return .microphone;
+    if (std.mem.eql(u8, name, "photos")) return .photos;
+    if (std.mem.eql(u8, name, "contacts")) return .contacts;
+    if (std.mem.eql(u8, name, "calendar")) return .calendar;
+    if (std.mem.eql(u8, name, "reminders")) return .reminders;
+    if (std.mem.eql(u8, name, "motion")) return .motion;
+    if (std.mem.eql(u8, name, "bluetooth")) return .bluetooth;
+    if (std.mem.eql(u8, name, "notifications")) return .notifications;
+    return .unknown;
+}
+
+// =============================================================================
+// The status vocabulary — Swift's `permissionStatus` helper, verbatim.
+// =============================================================================
+
+const granted_json = "\"granted\"";
+const denied_json = "\"denied\"";
+const restricted_json = "\"restricted\"";
+const undetermined_json = "\"undetermined\"";
+
+/// restricted > denied > granted > undetermined, in that order of precedence.
+///
+/// The order is load-bearing and is Swift's: a status that somehow set both
+/// flags must answer `"restricted"`, and `granted == false` with no flag set
+/// is `"undetermined"`, not `"denied"` — notDetermined and every future enum
+/// value both land there, which is the honest word for either.
+fn statusJson(granted: bool, denied: bool, restricted: bool) []const u8 {
+    if (restricted) return restricted_json;
+    if (denied) return denied_json;
+    return if (granted) granted_json else undetermined_json;
+}
+
+/// `CLAuthorizationStatus` (an `Int32`, unlike every other status here):
+/// 0 notDetermined, 1 restricted, 2 denied, 3 authorizedAlways,
+/// 4 authorizedWhenInUse.
+///
+/// `always_only` is the one behavioural fork between the two location
+/// spellings: `"location"` counts whenInUse as granted, `"locationAlways"`
+/// counts only always — so a whenInUse grant checked as `"locationAlways"`
+/// answers `"undetermined"`, which is the spec's answer, odd as it reads.
+fn locationStatusJson(raw: i32, always_only: bool) []const u8 {
+    const granted = raw == 3 or (!always_only and raw == 4);
+    return statusJson(granted, raw == 2, raw == 1);
+}
+
+/// The 0..3 layout that AVFoundation (`AVAuthorizationStatus`), Contacts
+/// (`CNAuthorizationStatus`), CoreMotion (`CMAuthorizationStatus`) and
+/// CoreBluetooth (`CBManagerAuthorization`) all share: 0 notDetermined,
+/// 1 restricted, 2 denied, 3 authorized/allowedAlways.
+///
+/// One mapper for the four on purpose — they are the same numbers, and four
+/// copies would be four places for one transcription slip. Values past 3
+/// (e.g. the `.limited` Contacts gained in iOS 18) fold to `"undetermined"`,
+/// exactly as Swift's `status == .authorized`-only checks do.
+fn simpleAuthStatusJson(raw: c_long) []const u8 {
+    return statusJson(raw == 3, raw == 2, raw == 1);
+}
+
+/// `PHAuthorizationStatus`: as above, plus 4 limited — and limited *is*
+/// granted (`status == .authorized || status == .limited` in Swift). Only
+/// exactly 3 or 4; a future 5 is not presumed to be an access level.
+fn photosStatusJson(raw: c_long) []const u8 {
+    return statusJson(raw == 3 or raw == 4, raw == 2, raw == 1);
+}
+
+/// `EKAuthorizationStatus`: as the simple layout, but granted is
+/// `status == .authorized || status.rawValue >= 4` in Swift — i.e. `raw >= 3`
+/// — because iOS 17 renamed 3 to `.fullAccess` and added 4 `.writeOnly`, and
+/// the spec counts both.
+fn calendarStatusJson(raw: c_long) []const u8 {
+    return statusJson(raw >= 3, raw == 2, raw == 1);
+}
+
+/// The one status that is not a small enum: `AVAudioSessionRecordPermission`
+/// is an `NSUInteger` of four-character codes.
+fn fourCC(comptime s: *const [4]u8) c_ulong {
+    return (@as(c_ulong, s[0]) << 24) | (@as(c_ulong, s[1]) << 16) |
+        (@as(c_ulong, s[2]) << 8) | @as(c_ulong, s[3]);
+}
+
+const record_permission_undetermined: c_ulong = fourCC("undt");
+const record_permission_denied: c_ulong = fourCC("deny");
+const record_permission_granted: c_ulong = fourCC("grnt");
+
+/// Microphone has no restricted case — Swift passes only `granted` and
+/// `denied` to its helper — and anything unrecognised (including `'undt'`)
+/// is `"undetermined"`.
+fn microphoneStatusJson(raw: c_ulong) []const u8 {
+    return statusJson(raw == record_permission_granted, raw == record_permission_denied, false);
+}
+
+// =============================================================================
+// Payload
+// =============================================================================
+
+/// Parse `d`, distinguishing a bad payload from a failed allocation, exactly
+/// as `bridge_mobile_storage` does and for the same reason: telling the page
+/// INVALID_JSON about its own good JSON sends whoever debugs it to the wrong
+/// side of the bridge.
+fn parsePayload(allocator: std.mem.Allocator, data: []const u8) !std.json.Parsed(std.json.Value) {
+    return std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => return bridge_error.BridgeError.InvalidJSON,
+    };
+}
+
+/// The one field the page sends: `permission`, a string. The injected JS
+/// builds the payload as `{permission: permission}` and `_invoke` merges in
+/// `action`/`callbackId`, so extra fields are normal and ignored.
+///
+/// Swift folds missing, `null` and non-string into a single
+/// `"Missing permission"` reject with code `INVALID_ARGUMENT`. This module's
+/// error vocabulary has no such code, so the cases split into the two nearest
+/// words — MISSING_DATA for an absent field, INVALID_PARAMETER for a present
+/// one of the wrong type. Every such case still *rejects* the promise, which
+/// is the part of the contract a page can be written against.
+fn permissionName(payload: std.json.Value) ![]const u8 {
+    const object = switch (payload) {
+        .object => |o| o,
+        else => return bridge_error.BridgeError.InvalidJSON,
+    };
+    const field = object.get("permission") orelse return bridge_error.BridgeError.MissingData;
+    return switch (field) {
+        .string => |s| s,
+        else => bridge_error.BridgeError.InvalidParameter,
+    };
+}
+
+pub const PermissionsBridge = struct {
+    allocator: std.mem.Allocator,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator) Self {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(_: *Self) void {}
+
+    pub fn handleMessage(self: *Self, action: []const u8, data: []const u8) !void {
+        const route = routeFor(action) orelse return bridge_error.BridgeError.UnknownAction;
+        return switch (route) {
+            .check => self.checkPermission(data),
+            .request => self.requestPermission(data),
+        };
+    }
+
+    /// Read one authorization status and answer with the bare status string.
+    ///
+    /// Every served arm is synchronous and prompt-free — reading an
+    /// authorization status never triggers a dialog, including
+    /// `CBManager.authorization`, which unlike instantiating a
+    /// `CBCentralManager` does not start Bluetooth.
+    fn checkPermission(self: *Self, data: []const u8) !void {
+        var parsed = try parsePayload(self.allocator, data);
+        defer parsed.deinit();
+        const name = try permissionName(parsed.value);
+
+        const json: []const u8 = switch (kindFor(name)) {
+            .location => locationStatusJson(try readLocationStatus(), false),
+            .location_always => locationStatusJson(try readLocationStatus(), true),
+            .camera => simpleAuthStatusJson(try readCameraStatus(self.allocator)),
+            .microphone => microphoneStatusJson(try readMicrophonePermission()),
+            .photos => photosStatusJson(try readPhotosStatus()),
+            .contacts => simpleAuthStatusJson(try readContactsStatus()),
+            .calendar => calendarStatusJson(try readEventKitStatus(ek_entity_event)),
+            .reminders => calendarStatusJson(try readEventKitStatus(ek_entity_reminder)),
+            .motion => simpleAuthStatusJson(try readMotionStatus()),
+            .bluetooth => simpleAuthStatusJson(try readBluetoothStatus()),
+            // No sync API exists, and `ios_async` cannot carry a
+            // settings-object completion or a three-way answer. The shim
+            // asks `getNotificationSettingsWithCompletionHandler:` and
+            // resolves from inside it; hand the whole call to it, payload
+            // intact, rather than guess.
+            .notifications => return bridge_error.BridgeError.UnknownAction,
+            // Swift's `default:` — a real answer, see the module comment.
+            .unknown => undetermined_json,
+        };
+        bridge_error.sendResultToJS(self.allocator, A.check_permission, json);
+    }
+
+    /// Run a permission prompt whose completion fits `ios_async`, or hand the
+    /// value to the shim when it does not.
+    ///
+    /// The served arms reply later, from the completion, through the block
+    /// pool: `"granted"` or `"denied"`, byte-identical to Swift's
+    /// `granted ? "granted" : "denied"` under `.fragmentsAllowed`. If the
+    /// status is already determined, the frameworks call the completion
+    /// immediately with the standing answer — same as Swift, no prompt shown.
+    fn requestPermission(self: *Self, data: []const u8) !void {
+        var parsed = try parsePayload(self.allocator, data);
+        defer parsed.deinit();
+        const name = try permissionName(parsed.value);
+
+        switch (kindFor(name)) {
+            .camera => try self.requestCamera(),
+            .microphone => try requestMicrophone(),
+            .notifications => try requestNotifications(),
+            // Delegate replies, status-enum completions, store lifetimes and
+            // an iOS 17 fork — the shim owns all of that today. Same action,
+            // same payload, answered by the Swift arm unchanged.
+            .location, .location_always, .photos, .contacts, .calendar, .reminders => {
+                return bridge_error.BridgeError.UnknownAction;
+            },
+            // The Swift request switch has no motion or bluetooth arm; both
+            // fall into `default` and resolve "undetermined". iOS prompts for
+            // them implicitly at first framework use, never on request.
+            .motion, .bluetooth, .unknown => {
+                bridge_error.sendResultToJS(self.allocator, A.request_permission, undetermined_json);
+            },
+        }
+    }
+
+    /// `+[AVCaptureDevice requestAccessForMediaType:completionHandler:]` with
+    /// a `void(^)(BOOL)` from the pool.
+    ///
+    /// Every fallible step happens *before* `acquire`, so there is no error
+    /// path between the ticket and the framework call and therefore no
+    /// `abandon` site. A future edit that adds a fallible step after
+    /// `acquire` must call `ios_async.abandon(ticket)` on its error path, or
+    /// the slot leaks until the pool answers Busy forever.
+    fn requestCamera(self: *Self) !void {
+        if (!is_darwin) return error.UnsupportedPlatform;
+
+        const AVCaptureDevice = objc.objc_getClass("AVCaptureDevice") orelse return error.ClassNotFound;
+        const sel = objc.sel_registerName("requestAccessForMediaType:completionHandler:") orelse
+            return error.SelectorNotFound;
+        const media = try mediaTypeVideo(self.allocator);
+
+        const ticket = ios_async.acquire(A.request_permission) orelse return poolFull();
+
+        const Fn = *const fn (Id, Id, Id, *anyopaque) callconv(.c) void;
+        const func: Fn = @ptrCast(&objc.objc_msgSend);
+        func(AVCaptureDevice, sel, media, ios_async.boolBlock(ticket));
+    }
+
+    /// `-[AVAudioSession requestRecordPermission:]` on the shared instance —
+    /// the deprecated-but-live API the Swift spec calls; `AVAudioApplication`
+    /// is its replacement and would be a divergence, not a port.
+    fn requestMicrophone() !void {
+        if (!is_darwin) return error.UnsupportedPlatform;
+
+        const session = try audioSession();
+        const sel = objc.sel_registerName("requestRecordPermission:") orelse return error.SelectorNotFound;
+
+        const ticket = ios_async.acquire(A.request_permission) orelse return poolFull();
+
+        const Fn = *const fn (Id, Id, *anyopaque) callconv(.c) void;
+        const func: Fn = @ptrCast(&objc.objc_msgSend);
+        func(session, sel, ios_async.boolBlock(ticket));
+    }
+
+    /// `-[UNUserNotificationCenter requestAuthorizationWithOptions:completionHandler:]`
+    /// with a `void(^)(BOOL, NSError *)` from the pool. The error object is
+    /// discarded by the pool's invoke, exactly as Swift's `{ granted, _ in }`
+    /// discards it — the granted flag is the whole page contract.
+    ///
+    /// `currentNotificationCenter` raises (rather than returning nil) in a
+    /// process with no bundle identifier; that is unreachable from a
+    /// dispatched page message, which only exists inside a bundled app, and
+    /// it is the same exposure the Swift call has.
+    fn requestNotifications() !void {
+        if (!is_darwin) return error.UnsupportedPlatform;
+
+        const UNUserNotificationCenter = objc.objc_getClass("UNUserNotificationCenter") orelse
+            return error.ClassNotFound;
+        const sel_current = objc.sel_registerName("currentNotificationCenter") orelse
+            return error.SelectorNotFound;
+        const center = objc.msgSendId(UNUserNotificationCenter, sel_current) orelse
+            return error.NoNotificationCenter;
+        const sel = objc.sel_registerName("requestAuthorizationWithOptions:completionHandler:") orelse
+            return error.SelectorNotFound;
+
+        const ticket = ios_async.acquire(A.request_permission) orelse return poolFull();
+
+        const Fn = *const fn (Id, Id, c_ulong, *anyopaque) callconv(.c) void;
+        const func: Fn = @ptrCast(&objc.objc_msgSend);
+        func(center, sel, un_options_alert_badge_sound, ios_async.boolErrorBlock(ticket));
+    }
+};
+
+/// The answer for a full block pool. `BridgeError` has no "Busy";
+/// INVALID_PARAMETER is the designated stand-in from the migration notes,
+/// and the point is that the sixteen-plus-first concurrent prompt gets an
+/// explicit rejection instead of a promise that never settles.
+fn poolFull() bridge_error.BridgeError {
+    std.log.warn("permission request refused: all {d} async slots in flight", .{ios_async.max_in_flight});
+    return bridge_error.BridgeError.InvalidParameter;
+}
+
+// =============================================================================
+// Framework constants — transcribed, so pinned by tests below.
+// =============================================================================
+
+/// `EKEntityType`: NSUInteger. event = 0, reminder = 1.
+const ek_entity_event: c_ulong = 0;
+const ek_entity_reminder: c_ulong = 1;
+
+/// `PHAccessLevel.readWrite` = 2 (NSInteger). `.addOnly` is 1; the spec
+/// checks readWrite.
+const ph_access_level_read_write: c_long = 2;
+
+/// `CNEntityType.contacts` = 0 (NSInteger) — the only entity type there is.
+const cn_entity_type_contacts: c_long = 0;
+
+/// `UNAuthorizationOptions`: badge 1<<0 | sound 1<<1 | alert 1<<2 = 7,
+/// matching Swift's `[.alert, .badge, .sound]` exactly — no provisional, no
+/// carPlay, nothing the spec did not ask for.
+const un_options_alert_badge_sound: c_ulong = 7;
+
+// =============================================================================
+// Status readers. Runtime class lookups only — no link-time framework
+// dependency; see the module comment.
+// =============================================================================
+
+/// `+[CLLocationManager authorizationStatus]`. Deprecated since iOS 14 in
+/// favour of the instance property, but it is the exact call the Swift spec
+/// makes, needs no manager instance and no delegate, and reading it never
+/// prompts. `CLAuthorizationStatus` is an `Int32` — the one status here that
+/// is not NSInteger-sized, and a `c_long` cast would read 32 bits of
+/// register garbage above it on a big-endian day; `i32` says what it is.
+fn readLocationStatus() !i32 {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    const CLLocationManager = objc.objc_getClass("CLLocationManager") orelse return error.ClassNotFound;
+    const sel = objc.sel_registerName("authorizationStatus") orelse return error.SelectorNotFound;
+    const Fn = *const fn (Id, Id) callconv(.c) i32;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    return func(CLLocationManager, sel);
+}
+
+/// `+[AVCaptureDevice authorizationStatusForMediaType:]` with
+/// `AVMediaTypeVideo`.
+fn readCameraStatus(allocator: std.mem.Allocator) !c_long {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    const AVCaptureDevice = objc.objc_getClass("AVCaptureDevice") orelse return error.ClassNotFound;
+    const sel = objc.sel_registerName("authorizationStatusForMediaType:") orelse return error.SelectorNotFound;
+    const media = try mediaTypeVideo(allocator);
+    const Fn = *const fn (Id, Id, Id) callconv(.c) c_long;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    return func(AVCaptureDevice, sel, media);
+}
+
+/// `-[AVAudioSession recordPermission]` on the shared instance.
+fn readMicrophonePermission() !c_ulong {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    const session = try audioSession();
+    const sel = objc.sel_registerName("recordPermission") orelse return error.SelectorNotFound;
+    const Fn = *const fn (Id, Id) callconv(.c) c_ulong;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    return func(session, sel);
+}
+
+/// `+[PHPhotoLibrary authorizationStatusForAccessLevel:]` — the level-aware
+/// form the spec calls (`for: .readWrite`), not the level-less deprecated one,
+/// which answers `.authorized` for limited access and would erase the
+/// distinction `photosStatusJson` exists to keep.
+fn readPhotosStatus() !c_long {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    const PHPhotoLibrary = objc.objc_getClass("PHPhotoLibrary") orelse return error.ClassNotFound;
+    const sel = objc.sel_registerName("authorizationStatusForAccessLevel:") orelse return error.SelectorNotFound;
+    const Fn = *const fn (Id, Id, c_long) callconv(.c) c_long;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    return func(PHPhotoLibrary, sel, ph_access_level_read_write);
+}
+
+/// `+[CNContactStore authorizationStatusForEntityType:]`. A class method —
+/// no store instance is needed to *read*, which is what keeps this arm
+/// servable while the request arm is not.
+fn readContactsStatus() !c_long {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    const CNContactStore = objc.objc_getClass("CNContactStore") orelse return error.ClassNotFound;
+    const sel = objc.sel_registerName("authorizationStatusForEntityType:") orelse return error.SelectorNotFound;
+    const Fn = *const fn (Id, Id, c_long) callconv(.c) c_long;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    return func(CNContactStore, sel, cn_entity_type_contacts);
+}
+
+/// `+[EKEventStore authorizationStatusForEntityType:]`, shared by calendar
+/// (event = 0) and reminders (reminder = 1).
+fn readEventKitStatus(entity: c_ulong) !c_long {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    const EKEventStore = objc.objc_getClass("EKEventStore") orelse return error.ClassNotFound;
+    const sel = objc.sel_registerName("authorizationStatusForEntityType:") orelse return error.SelectorNotFound;
+    const Fn = *const fn (Id, Id, c_ulong) callconv(.c) c_long;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    return func(EKEventStore, sel, entity);
+}
+
+/// `+[CMMotionActivityManager authorizationStatus]`.
+fn readMotionStatus() !c_long {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    const CMMotionActivityManager = objc.objc_getClass("CMMotionActivityManager") orelse return error.ClassNotFound;
+    const sel = objc.sel_registerName("authorizationStatus") orelse return error.SelectorNotFound;
+    const Fn = *const fn (Id, Id) callconv(.c) c_long;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    return func(CMMotionActivityManager, sel);
+}
+
+/// `+[CBManager authorization]` — the class property getter, whose selector
+/// is just the property name. Reading it does not start Bluetooth and does
+/// not prompt, unlike instantiating a central manager.
+fn readBluetoothStatus() !c_long {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    const CBManager = objc.objc_getClass("CBManager") orelse return error.ClassNotFound;
+    const sel = objc.sel_registerName("authorization") orelse return error.SelectorNotFound;
+    const Fn = *const fn (Id, Id) callconv(.c) c_long;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    return func(CBManager, sel);
+}
+
+/// `+[AVAudioSession sharedInstance]`, shared by the microphone read and
+/// request arms.
+fn audioSession() !Id {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    const AVAudioSession = objc.objc_getClass("AVAudioSession") orelse return error.ClassNotFound;
+    const sel = objc.sel_registerName("sharedInstance") orelse return error.SelectorNotFound;
+    return objc.msgSendId(AVAudioSession, sel) orelse error.NoAudioSession;
+}
+
+// -----------------------------------------------------------------------------
+// AVMediaTypeVideo
+// -----------------------------------------------------------------------------
+
+extern "c" fn dlsym(handle: ?*anyopaque, symbol: [*:0]const u8) ?*anyopaque;
+
+/// dyld's "search every image" pseudo-handle, (void *)-2 on Darwin.
+const RTLD_DEFAULT: ?*anyopaque = @ptrFromInt(@as(usize, @bitCast(@as(isize, -2))));
+
+/// The `AVMediaTypeVideo` constant, without a link-time AVFoundation
+/// dependency.
+///
+/// Extern-linking the `NSString *const` the way `bridge_mobile_storage` links
+/// `kSec*` would force `-framework AVFoundation` onto every consumer of the
+/// static library — a build-system change no other part of this module needs,
+/// since classes are found at runtime. So: `dlsym` the symbol out of whatever
+/// loaded AVFoundation (if `AVCaptureDevice` resolved, it is loaded and the
+/// symbol is there), and fall back to the documented constant *value*,
+/// `@"vide"`, which AVFoundation compares by content — a media type travels
+/// through dictionaries and `isEqual:`, never pointer identity, which is also
+/// why Swift's bridged strings work.
+fn mediaTypeVideo(allocator: std.mem.Allocator) !Id {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    if (dlsym(RTLD_DEFAULT, "AVMediaTypeVideo")) |sym| {
+        // The symbol is the *variable* — an `NSString *` — so one dereference
+        // yields the object. Guarded: a resolved symbol holding nil would
+        // otherwise put nil into an ObjC argument that must not be.
+        const slot: *Id = @ptrCast(@alignCast(sym));
+        if (slot.*) |ns| return ns;
+    }
+    const ns = try objc.createNSString("vide", allocator);
+    if (ns == null) return error.NSStringCreationFailed;
+    return ns;
+}
+
+// =============================================================================
+// Tests. Host-only by construction: everything that decides what the page
+// sees — routing, name mapping, status mapping, payload validation — is a
+// pure function beside the readers, and no test dispatches a permission kind
+// whose reader would touch a live framework (on a developer's Mac some of
+// these classes exist, and a *request* arm would put a real TCC prompt on
+// someone's screen).
+// =============================================================================
+
+const testing = std.testing;
+
+test "the declared actions are the ones the handler serves" {
+    try testing.expectEqual(@as(usize, 2), capability_actions.len);
+    try testing.expectEqualStrings(A.check_permission, capability_actions[0].name);
+    try testing.expectEqualStrings(A.request_permission, capability_actions[1].name);
+
+    for (capability_actions) |decl| {
+        try testing.expectEqual(capabilities.Reply.result, decl.reply);
+        try testing.expectEqual(capabilities.ActionStatus.live, decl.status);
+    }
+}
+
+test "the action names are the ones the Swift dispatcher answers" {
+    // The wire contract, spelled out. The conformance scan catches a name the
+    // spec lacks; it cannot catch both being renamed in step, which this holds.
+    try testing.expectEqualStrings("checkPermission", A.check_permission);
+    try testing.expectEqualStrings("requestPermission", A.request_permission);
+}
+
+test "every declared action is one the dispatcher routes" {
+    for (capability_actions) |decl| {
+        if (routeFor(decl.name) == null) {
+            std.debug.print("declared action '{s}' does not route\n", .{decl.name});
+            return error.DeclaredActionDoesNotRoute;
+        }
+    }
+}
+
+test "every route the dispatcher has is a declared action" {
+    // Each declaration must claim a distinct route and every route must be
+    // claimed — counting alone would let two rows share one route while
+    // another went undeclared.
+    var claimed = std.mem.zeroes([std.enums.values(Route).len]bool);
+    for (capability_actions) |decl| {
+        const route = routeFor(decl.name) orelse return error.DeclaredActionDoesNotRoute;
+        const slot = @backingInt(route);
+        if (claimed[slot]) return error.TwoDeclarationsShareARoute;
+        claimed[slot] = true;
+    }
+    for (claimed) |taken| {
+        if (!taken) return error.RouteNotDeclared;
+    }
+}
+
+test "openSettings is left to the Swift shim on purpose" {
+    // The pin for the module comment's biggest decision. Its reply is a bare
+    // boolean, `ios_async.boolBlock` replies "granted"/"denied", and "denied"
+    // is truthy — a page's `if (await openSettings())` would take the success
+    // branch on failure. Whoever claims this action deletes this test
+    // *after* giving ios_async a boolean-literal reply, not before.
+    var bridge = PermissionsBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("openSettings", "{}"),
+    );
+    for (capability_actions) |decl| {
+        try testing.expect(!std.mem.eql(u8, decl.name, "openSettings"));
+    }
+}
+
+test "an action the namespace does not serve is reported, not ignored" {
+    var bridge = PermissionsBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("noSuchAction", "{}"),
+    );
+    // Casing is how a real typo arrives.
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("checkpermission", "{}"),
+    );
+    // The Swift helper's name, which is not an action name.
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("permissionStatus", "{}"),
+    );
+    // The desktop namespace's method names, which are a different bridge.
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("check", "{\"permission\":\"camera\"}"),
+    );
+}
+
+test "every declared action dispatches to something" {
+    // `{}` has no `permission`, so both fail validation *before* any
+    // framework call — which is what makes this safe on a host. What it rules
+    // out is a name in the table `handleMessage` does not compare against.
+    var bridge = PermissionsBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    for (capability_actions) |decl| {
+        try testing.expectError(
+            bridge_error.BridgeError.MissingData,
+            bridge.handleMessage(decl.name, "{}"),
+        );
+    }
+}
+
+test "a malformed payload is reported as bad JSON, not as a missing field" {
+    var bridge = PermissionsBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidJSON,
+        bridge.handleMessage(A.check_permission, "{not json"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidJSON,
+        bridge.handleMessage(A.request_permission, "{not json"),
+    );
+}
+
+fn expectPermissionName(json: []const u8, expected: []const u8) !void {
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings(expected, try permissionName(parsed.value));
+}
+
+fn expectPermissionNameError(json: []const u8, expected: anyerror) !void {
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectError(expected, permissionName(parsed.value));
+}
+
+test "the permission field is the one the page sends, extras ignored" {
+    try expectPermissionName("{\"permission\":\"camera\"}", "camera");
+    // `_invoke` merges `action` and `callbackId` into the payload it posts;
+    // their presence must not disturb the read.
+    try expectPermissionName(
+        "{\"permission\":\"microphone\",\"action\":\"checkPermission\",\"callbackId\":\"cb_1\"}",
+        "microphone",
+    );
+}
+
+test "a missing, null, or non-string permission is refused" {
+    // Swift folds all three into one "Missing permission" INVALID_ARGUMENT
+    // reject; the codes here split into the two nearest words, but every case
+    // still rejects — no arm defaults the field or falls through silently.
+    try expectPermissionNameError("{}", bridge_error.BridgeError.MissingData);
+    try expectPermissionNameError("{\"permission\":null}", bridge_error.BridgeError.InvalidParameter);
+    try expectPermissionNameError("{\"permission\":7}", bridge_error.BridgeError.InvalidParameter);
+    try expectPermissionNameError("[]", bridge_error.BridgeError.InvalidJSON);
+    try expectPermissionNameError("\"camera\"", bridge_error.BridgeError.InvalidJSON);
+}
+
+test "the eleven spec spellings map to their kinds" {
+    try testing.expectEqual(Kind.location, kindFor("location"));
+    try testing.expectEqual(Kind.location_always, kindFor("locationAlways"));
+    try testing.expectEqual(Kind.camera, kindFor("camera"));
+    try testing.expectEqual(Kind.microphone, kindFor("microphone"));
+    try testing.expectEqual(Kind.photos, kindFor("photos"));
+    try testing.expectEqual(Kind.contacts, kindFor("contacts"));
+    try testing.expectEqual(Kind.calendar, kindFor("calendar"));
+    try testing.expectEqual(Kind.reminders, kindFor("reminders"));
+    try testing.expectEqual(Kind.motion, kindFor("motion"));
+    try testing.expectEqual(Kind.bluetooth, kindFor("bluetooth"));
+    try testing.expectEqual(Kind.notifications, kindFor("notifications"));
+}
+
+test "an unrecognised permission resolves undetermined, as the spec's default arm" {
+    try testing.expectEqual(Kind.unknown, kindFor("telepathy"));
+    // Case-sensitive, as Swift's switch is.
+    try testing.expectEqual(Kind.unknown, kindFor("Camera"));
+    try testing.expectEqual(Kind.unknown, kindFor(""));
+
+    // End to end: both actions *resolve* for an unknown name — no error, no
+    // shim fall-through — because that is what the Swift default arm does.
+    var bridge = PermissionsBridge.init(testing.allocator);
+    defer bridge.deinit();
+    try bridge.handleMessage(A.check_permission, "{\"permission\":\"telepathy\"}");
+    try bridge.handleMessage(A.request_permission, "{\"permission\":\"telepathy\"}");
+}
+
+test "a NUL-carrying permission lands in unknown rather than being truncated" {
+    // The name is only compared, never handed to `stringWithUTF8String:`, so
+    // there is nothing to truncate and no refusal is needed: "camera\x00x"
+    // is not "camera", fails every comparison, and answers "undetermined" —
+    // the same answer Swift's default arm gives the NUL-keeping original.
+    try testing.expectEqual(Kind.unknown, kindFor("camera\x00x"));
+
+    var bridge = PermissionsBridge.init(testing.allocator);
+    defer bridge.deinit();
+    try bridge.handleMessage(A.check_permission, "{\"permission\":\"camera\\u0000x\"}");
+}
+
+test "restricted outranks denied outranks granted" {
+    // Swift's helper checks in this order, so a status that set two flags
+    // answers the severest one. The spellings must also match ios_async's
+    // hard-coded completion replies byte for byte, or one action would speak
+    // two dialects depending on which arm answered.
+    try testing.expectEqualStrings("\"restricted\"", statusJson(true, true, true));
+    try testing.expectEqualStrings("\"denied\"", statusJson(true, true, false));
+    try testing.expectEqualStrings("\"granted\"", statusJson(true, false, false));
+    try testing.expectEqualStrings("\"undetermined\"", statusJson(false, false, false));
+}
+
+test "location statuses map per the spec, whenInUse counting only for 'location'" {
+    // 0 notDetermined, 1 restricted, 2 denied, 3 always, 4 whenInUse.
+    try testing.expectEqualStrings("\"undetermined\"", locationStatusJson(0, false));
+    try testing.expectEqualStrings("\"restricted\"", locationStatusJson(1, false));
+    try testing.expectEqualStrings("\"denied\"", locationStatusJson(2, false));
+    try testing.expectEqualStrings("\"granted\"", locationStatusJson(3, false));
+    try testing.expectEqualStrings("\"granted\"", locationStatusJson(4, false));
+
+    // The fork: a whenInUse grant checked as "locationAlways" is not granted
+    // — and not denied either. "undetermined" is the spec's answer.
+    try testing.expectEqualStrings("\"granted\"", locationStatusJson(3, true));
+    try testing.expectEqualStrings("\"undetermined\"", locationStatusJson(4, true));
+
+    // A future status value is not guessed at.
+    try testing.expectEqualStrings("\"undetermined\"", locationStatusJson(5, false));
+}
+
+test "the shared 0..3 layout maps for camera, contacts, motion and bluetooth" {
+    try testing.expectEqualStrings("\"undetermined\"", simpleAuthStatusJson(0));
+    try testing.expectEqualStrings("\"restricted\"", simpleAuthStatusJson(1));
+    try testing.expectEqualStrings("\"denied\"", simpleAuthStatusJson(2));
+    try testing.expectEqualStrings("\"granted\"", simpleAuthStatusJson(3));
+    // iOS 18's CNAuthorizationStatus.limited (4) and anything later: Swift's
+    // `status == .authorized` is false for them, so "undetermined" — folded,
+    // not promoted.
+    try testing.expectEqualStrings("\"undetermined\"", simpleAuthStatusJson(4));
+}
+
+test "photos limited counts as granted" {
+    try testing.expectEqualStrings("\"granted\"", photosStatusJson(3));
+    try testing.expectEqualStrings("\"granted\"", photosStatusJson(4));
+    try testing.expectEqualStrings("\"denied\"", photosStatusJson(2));
+    try testing.expectEqualStrings("\"restricted\"", photosStatusJson(1));
+    try testing.expectEqualStrings("\"undetermined\"", photosStatusJson(0));
+    // Unlike EventKit, only exactly limited is promoted; 5 is not presumed to
+    // be an access level.
+    try testing.expectEqualStrings("\"undetermined\"", photosStatusJson(5));
+}
+
+test "calendar fullAccess and writeOnly both count as granted" {
+    // Swift: `status == .authorized || status.rawValue >= 4` — the iOS 17
+    // renames land on 3 (fullAccess) and 4 (writeOnly).
+    try testing.expectEqualStrings("\"granted\"", calendarStatusJson(3));
+    try testing.expectEqualStrings("\"granted\"", calendarStatusJson(4));
+    try testing.expectEqualStrings("\"granted\"", calendarStatusJson(5));
+    try testing.expectEqualStrings("\"denied\"", calendarStatusJson(2));
+    try testing.expectEqualStrings("\"restricted\"", calendarStatusJson(1));
+    try testing.expectEqualStrings("\"undetermined\"", calendarStatusJson(0));
+}
+
+test "the microphone four-char codes are the documented ones" {
+    // AVAudioSessionRecordPermission is the one status that is not a small
+    // enum, and a mistranscribed code would silently reclassify every answer.
+    try testing.expectEqual(@as(c_ulong, 1970168948), record_permission_undetermined);
+    try testing.expectEqual(@as(c_ulong, 1684369017), record_permission_denied);
+    try testing.expectEqual(@as(c_ulong, 1735552628), record_permission_granted);
+
+    try testing.expectEqualStrings("\"granted\"", microphoneStatusJson(record_permission_granted));
+    try testing.expectEqualStrings("\"denied\"", microphoneStatusJson(record_permission_denied));
+    try testing.expectEqualStrings("\"undetermined\"", microphoneStatusJson(record_permission_undetermined));
+    // No restricted case exists for the microphone, and junk is not guessed at.
+    try testing.expectEqualStrings("\"undetermined\"", microphoneStatusJson(0));
+}
+
+test "what Zig cannot answer honestly falls through to the shim, payload intact" {
+    // UnknownAction is the dispatcher's "not mine, ask the next"; the chain
+    // ends at handOffToHost with the same action and the same `d`, and the
+    // un-migrated Swift arm answers as it always has. Any *other* error here
+    // would be final and would take a working reply away from the page.
+    var bridge = PermissionsBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage(A.check_permission, "{\"permission\":\"notifications\"}"),
+    );
+
+    const deferred_requests = [_][]const u8{
+        "{\"permission\":\"location\"}",
+        "{\"permission\":\"locationAlways\"}",
+        "{\"permission\":\"photos\"}",
+        "{\"permission\":\"contacts\"}",
+        "{\"permission\":\"calendar\"}",
+        "{\"permission\":\"reminders\"}",
+    };
+    for (deferred_requests) |payload| {
+        try testing.expectError(
+            bridge_error.BridgeError.UnknownAction,
+            bridge.handleMessage(A.request_permission, payload),
+        );
+    }
+}
+
+test "requesting motion or bluetooth resolves undetermined, as the spec does" {
+    // The Swift request switch has no arm for either — both fall into
+    // `default` and resolve "undetermined" without prompting. Erroring or
+    // falling through would change behaviour the page can already observe.
+    var bridge = PermissionsBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try bridge.handleMessage(A.request_permission, "{\"permission\":\"motion\"}");
+    try bridge.handleMessage(A.request_permission, "{\"permission\":\"bluetooth\"}");
+}
+
+test "the notification options are Swift's [.alert, .badge, .sound]" {
+    // badge 1<<0, sound 1<<1, alert 1<<2. A wrong mask here would not fail —
+    // it would quietly request a different set of capabilities than every
+    // existing app was granted under.
+    try testing.expectEqual(@as(c_ulong, 1 | 2 | 4), un_options_alert_badge_sound);
+}
+
+test "the framework constants that are passed as arguments are the documented ones" {
+    // Each of these rides into objc_msgSend as a raw integer; a wrong value
+    // is not an error but a question about a different entity.
+    try testing.expectEqual(@as(c_ulong, 0), ek_entity_event);
+    try testing.expectEqual(@as(c_ulong, 1), ek_entity_reminder);
+    try testing.expectEqual(@as(c_long, 2), ph_access_level_read_write);
+    try testing.expectEqual(@as(c_long, 0), cn_entity_type_contacts);
+}

--- a/packages/zig/src/bridge_mobile_securestore.zig
+++ b/packages/zig/src/bridge_mobile_securestore.zig
@@ -1,0 +1,884 @@
+//! The secure-storage actions of the `mobile` namespace: `secureSet`,
+//! `secureGet`, `secureRemove`, `secureClear`.
+//!
+//! **Same keychain, same namespace as `bridge_mobile_storage.zig`.** The Swift
+//! helpers (`secureStore`/`secureRetrieve`/`secureRemove`/`secureClear` in
+//! `CraftApp.swift`) identify an item by `kSecClass` + `kSecAttrAccount` and
+//! nothing else — no `kSecAttrService` anywhere in the file, no key prefix, no
+//! access group. That means `secureSet("k")` and `setSharedItem("k")` (group
+//! omitted) read and overwrite the *same item*. Adding a service attribute here
+//! would look like hygiene and would actually make every item the Swift shim
+//! ever wrote unreadable, which is the one thing a partial migration must not
+//! do. The overlap is Swift's design, carried across on purpose.
+//!
+//! Two JS surfaces funnel into these actions: the legacy `craft.secureStore`
+//! object (`set`/`get`/`remove`, promises with **no timeout**) and the modern
+//! `craft.secureStorage` wrapper, which delegates set/get/delete to the legacy
+//! object and reaches `secureClear` through `craft._invoke` (30s timeout). The
+//! no-timeout legacy promises are why every path in this file ends in a reply
+//! or an error — a dropped message parks the page forever.
+//!
+//! ## What is carried across exactly, because it is the observable contract
+//!
+//!  - **Replies are bare JSON fragments**, Swift's `.fragmentsAllowed`:
+//!    `true`/`false` for set/remove/clear, a bare string or `null` for get.
+//!    No object wrapper anywhere, unlike the sharedItems shapes next door.
+//!  - **A keychain failure on set/remove/clear *resolves* `false`** rather than
+//!    rejecting. That is not fabricated success — `false` is the contract's
+//!    failure value, and it is what every existing caller is written against.
+//!    The raw OSStatus goes to the log, which is the only channel a bare
+//!    boolean leaves for it.
+//!  - **`remove` and `clear` treat `errSecItemNotFound` as `true`** — both are
+//!    idempotent and a caller cannot act on the difference.
+//!  - **Accessibility is `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`**, on
+//!    the add only.
+//!  - **`get` answers `null` for a missing key** — the promise resolves, it
+//!    does not reject.
+//!
+//! ## What is deliberately not carried across
+//!
+//! **Swift's silent hang.** The set/get/remove dispatcher arms are `if let`s
+//! with no `else`: a missing `key`, a non-string `value`, or a disabled
+//! `enableSecureStorage` config replies nothing at all, and the legacy promise
+//! never settles. Malformed input errors here instead. The capability gate has
+//! no Zig mirror (`enableSecureStorage` appears nowhere in `packages/zig/src`),
+//! so the actions are served unconditionally. For set/get/remove that grants a
+//! page nothing new: the *ungated* sharedItems actions next door already
+//! read and write the same items (one namespace — see above). The two gated
+//! modules that came before chose differently — clipboard kept its gate
+//! plumbable (`craft_ios_set_clipboard_enabled`, rejecting `PermissionDenied`
+//! when off) and haptics declared its gated action `.unavailable` — and
+//! `secureClear` is where the difference is real: under Swift's default-false
+//! gate a page got CAPABILITY_DISABLED instead of a wipe, and here the wipe is
+//! always live. If that gate is wanted back, clipboard's hook is the pattern;
+//! what must not come back is Swift's silent hang on the other three.
+//!
+//! **`get`'s collapse of every failure into `null`.** Swift returns `nil` for
+//! *any* non-success status, so a page cannot tell "nothing stored" from "the
+//! keychain call failed". Here only `errSecItemNotFound` is `null`; any other
+//! status is an error with the number in the log. Same for stored bytes that
+//! are not UTF-8 (Swift's `String(data:encoding:)` fails and resolves `null`
+//! over a value that *exists*): that is an error here, because `null` is a
+//! claim about the store that nothing verified.
+//!
+//! **A `key` with an embedded NUL.** Swift stores it whole; the route Zig has
+//! to the keychain (`stringWithUTF8String:`) truncates at the NUL and would
+//! file the item under a shorter name than the caller gave, then report success
+//! for a key it did not use. Refused as `InvalidParameter`, exactly as
+//! `bridge_mobile_storage.requireNulFree` does. The *value* keeps its NUL: it
+//! travels as bytes-plus-length through `dataWithBytes:length:` and back out
+//! through `length`/`bytes`, so nothing truncates it, and refusing it would
+//! drop a payload the handler carries perfectly well.
+//!
+//! **Swift's shared delete/add dictionary.** `secureStore` hands the same
+//! dictionary — `kSecValueData` and `kSecAttrAccessible` included — to both
+//! `SecItemDelete` and `SecItemAdd` and discards the delete's status.
+//! `keychainStore` below builds the delete-scoped query first (class + account,
+//! the shape `remove` already uses) and only then adds the value attributes;
+//! `bridge_mobile_storage.zig`'s module comment carries the full argument.
+//!
+//! ## The `secureClear` blast radius, named because it is invisible
+//!
+//! Swift's `secureClear` deletes with a query of `kSecClass` alone: **every
+//! generic-password item the app can see**, including everything
+//! `setSharedItem` wrote (the two namespaces are one namespace — see above).
+//! `keychainClear` is bug-compatible with that, because a narrower clear would
+//! leave items behind that Swift's would have removed and the two
+//! implementations must be interchangeable mid-migration. A page that calls
+//! `craft.secureStorage.clear()` wipes the sharedItems store too, whichever
+//! language answers. This is also why the host tests below never *invoke* the
+//! clear handler: it has no validation step to fail early at, and on a macOS
+//! test runner the query would address the developer's login keychain.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const capabilities = @import("capabilities.zig");
+const bridge_error = @import("bridge_error.zig");
+const objc_runtime = @import("objc_runtime.zig");
+
+const objc = objc_runtime.objc;
+
+/// The same type as `objc.id` — `?*anyopaque` — spelled locally.
+///
+/// `objc_runtime.objc` is an empty struct off Darwin, and a function
+/// *signature* is analysed even when a comptime platform guard makes its body
+/// unreachable, so naming `objc.id` in the `callconv(.c)` types below would
+/// break the host build. It stays a single optional pointer, never `?objc.id`:
+/// a double optional is illegal in a `callconv(.c)` type.
+const Id = ?*anyopaque;
+
+/// Toll-free-bridged CoreFoundation values — the `kSec*` globals — kept
+/// nominally distinct from `Id` in the signatures, as in
+/// `bridge_mobile_storage.zig`.
+const CFTypeRef = ?*anyopaque;
+
+/// `SInt32`, fixed by the ABI; every keychain status of interest is negative.
+const OSStatus = i32;
+
+// Security.framework and CoreFoundation. Duplicated from
+// `bridge_mobile_storage.zig` rather than imported from it: these are
+// file-private there by design, and `extern` declarations are free to repeat.
+// The build note there applies here too — `-framework Security` must reach the
+// app link, which Swift's `import Security` autolinks and the zig-slice fixture
+// passes explicitly.
+extern "c" fn SecItemAdd(attributes: CFTypeRef, result: ?*CFTypeRef) OSStatus;
+extern "c" fn SecItemCopyMatching(query: CFTypeRef, result: ?*CFTypeRef) OSStatus;
+extern "c" fn SecItemDelete(query: CFTypeRef) OSStatus;
+extern "c" fn CFRelease(cf: CFTypeRef) void;
+
+extern "c" const kSecClass: CFTypeRef;
+extern "c" const kSecClassGenericPassword: CFTypeRef;
+extern "c" const kSecAttrAccount: CFTypeRef;
+extern "c" const kSecAttrAccessible: CFTypeRef;
+extern "c" const kSecAttrAccessibleWhenUnlockedThisDeviceOnly: CFTypeRef;
+extern "c" const kSecValueData: CFTypeRef;
+extern "c" const kSecReturnData: CFTypeRef;
+extern "c" const kSecMatchLimit: CFTypeRef;
+extern "c" const kSecMatchLimitOne: CFTypeRef;
+extern "c" const kCFBooleanTrue: CFTypeRef;
+
+/// Only the statuses this file *branches* on. Everything else stays unmapped —
+/// a mis-transcribed constant that reclassifies one failure as another is worse
+/// than a generic one — and reaches the log by its raw number.
+const errSecSuccess: OSStatus = 0;
+const errSecItemNotFound: OSStatus = -25300;
+
+/// The action names, spelled exactly as the Swift `case` labels spell them.
+/// `test/ios_conformance_test.zig` matches the two lists by string in both
+/// directions.
+pub const A = struct {
+    pub const secure_set = "secureSet";
+    pub const secure_get = "secureGet";
+    pub const secure_remove = "secureRemove";
+    pub const secure_clear = "secureClear";
+};
+
+/// All four `.result`: each Swift path resolves or rejects a callback, and
+/// each JS surface returns a promise — the legacy ones without a timeout, so
+/// `.none` here would strand a caller forever, not for thirty seconds.
+///
+/// All four `.live`. Every operation is a plain Security.framework call with
+/// no UI, no completion handler and no entitlement requirement (no access
+/// group is ever named), so nothing needs `.unavailable`.
+pub const capability_actions = [_]capabilities.ActionDecl{
+    .{ .name = A.secure_set, .reply = .result },
+    .{ .name = A.secure_get, .reply = .result },
+    .{ .name = A.secure_remove, .reply = .result },
+    .{ .name = A.secure_clear, .reply = .result },
+};
+
+/// Which handler an action selects, split out from `handleMessage` so the
+/// table-versus-dispatch agreement is assertable on a host. That split is
+/// load-bearing for exactly one action here: `secureClear` has no payload and
+/// therefore no validation step, so a test that *called* it to prove routing
+/// would issue a class-wide `SecItemDelete` against the machine running the
+/// tests.
+const Route = enum { set, get, remove, clear };
+
+fn routeFor(action: []const u8) ?Route {
+    if (std.mem.eql(u8, action, A.secure_set)) return .set;
+    if (std.mem.eql(u8, action, A.secure_get)) return .get;
+    if (std.mem.eql(u8, action, A.secure_remove)) return .remove;
+    if (std.mem.eql(u8, action, A.secure_clear)) return .clear;
+    return null;
+}
+
+pub const SecureStoreBridge = struct {
+    allocator: std.mem.Allocator,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator) Self {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(_: *Self) void {}
+
+    pub fn handleMessage(self: *Self, action: []const u8, data: []const u8) !void {
+        const route = routeFor(action) orelse return bridge_error.BridgeError.UnknownAction;
+        // Exhaustive, so a `Route` without a handler is a compile error.
+        return switch (route) {
+            .set => self.secureSet(data),
+            .get => self.secureGet(data),
+            .remove => self.secureRemove(data),
+            .clear => self.secureClear(),
+        };
+    }
+
+    /// Store `value` under `key`, replacing whatever was there. Resolves
+    /// `true`/`false`, Swift's `resolveCallback(callbackId, result: success)`.
+    fn secureSet(self: *Self, data: []const u8) !void {
+        var parsed = try parsePayload(self.allocator, data);
+        defer parsed.deinit();
+
+        const request = try parseSetRequest(parsed.value);
+        const stored = try keychainStore(self.allocator, request.key, request.value);
+        bridge_error.sendResultToJS(self.allocator, A.secure_set, boolFragment(stored));
+    }
+
+    /// Read `key`. A missing item resolves `null`; a found one resolves the
+    /// bare string. Both are fragments, not objects — `test-bridges.html` does
+    /// `'Stored and retrieved: ' + value` with the reply directly.
+    fn secureGet(self: *Self, data: []const u8) !void {
+        var parsed = try parsePayload(self.allocator, data);
+        defer parsed.deinit();
+
+        const key = try parseKey(parsed.value);
+        const found = try keychainRetrieve(self.allocator, key);
+        defer if (found) |bytes| self.allocator.free(bytes);
+
+        const json = try valueFragment(self.allocator, found);
+        defer self.allocator.free(json);
+        bridge_error.sendResultToJS(self.allocator, A.secure_get, json);
+    }
+
+    /// Delete `key`. Absent resolves `true`, as in Swift — idempotent.
+    fn secureRemove(self: *Self, data: []const u8) !void {
+        var parsed = try parsePayload(self.allocator, data);
+        defer parsed.deinit();
+
+        const key = try parseKey(parsed.value);
+        const removed = try keychainDelete(self.allocator, key);
+        bridge_error.sendResultToJS(self.allocator, A.secure_remove, boolFragment(removed));
+    }
+
+    /// Delete every generic-password item — see the module comment for what
+    /// that includes. The payload is ignored, as Swift ignores the body: the
+    /// only caller is `craft._invoke('secureClear')`, which sends none, and
+    /// `ios_dispatch.payloadOf` hands this `"{}"` for an absent `d`.
+    fn secureClear(self: *Self) !void {
+        const cleared = try keychainClear();
+        bridge_error.sendResultToJS(self.allocator, A.secure_clear, boolFragment(cleared));
+    }
+};
+
+/// Parse `d`, distinguishing a bad payload from a failed allocation — telling
+/// the page INVALID_JSON about its own good JSON sends whoever debugs it to
+/// the wrong side of the bridge.
+fn parsePayload(allocator: std.mem.Allocator, data: []const u8) !std.json.Parsed(std.json.Value) {
+    return std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => return bridge_error.BridgeError.InvalidJSON,
+    };
+}
+
+/// The set payload after validation. Field names are the ones the injected JS
+/// posts (`{action:'secureSet', key: key, value: value, callbackId: id}`) and
+/// the un-migrated shim reads (`body["key"]`, `body["value"]`) — pinned on
+/// both sides of the migration.
+const SetRequest = struct {
+    key: []const u8,
+    value: []const u8,
+};
+
+/// The `key` field, or the reason it cannot be used. Pure, so the host tests
+/// can pin every outcome Swift's `as? String` collapsed into a silent hang.
+fn parseKey(payload: std.json.Value) ![]const u8 {
+    const object = switch (payload) {
+        .object => |o| o,
+        else => return bridge_error.BridgeError.InvalidJSON,
+    };
+    const key_field = object.get("key") orelse return bridge_error.BridgeError.MissingData;
+    const key = switch (key_field) {
+        .string => |s| s,
+        else => return bridge_error.BridgeError.InvalidParameter,
+    };
+    try requireNulFree(key);
+    return key;
+}
+
+fn parseSetRequest(payload: std.json.Value) !SetRequest {
+    const key = try parseKey(payload);
+
+    const object = payload.object; // parseKey proved it is an object
+    const value_field = object.get("value") orelse return bridge_error.BridgeError.MissingData;
+    const value = switch (value_field) {
+        .string => |s| s,
+        // Swift's `as? String` fails here and replies nothing at all. A
+        // coercion would be worse: it would overwrite a real secret with a
+        // stringified something and report success.
+        else => return bridge_error.BridgeError.InvalidParameter,
+    };
+
+    return .{ .key = key, .value = value };
+}
+
+/// Refuse a `key` carrying the one byte it cannot survive. `\u0000` is a legal
+/// JSON escape and `std.json` decodes it to the byte, so a page can reach
+/// this; `createNSString` (`stringWithUTF8String:`) would then truncate and
+/// the item would be filed under a name the caller did not give. The value
+/// needs no equivalent — `makeData` passes bytes and a length, and the NSData
+/// round-trip test below pins that a NUL survives it.
+fn requireNulFree(s: []const u8) !void {
+    if (std.mem.indexOfScalar(u8, s, 0) != null) return bridge_error.BridgeError.InvalidParameter;
+}
+
+/// The bare boolean fragments Swift's `.fragmentsAllowed` produces from
+/// `resolveCallback(callbackId, result: success)`. Static, so the boolean
+/// replies allocate nothing.
+fn boolFragment(ok: bool) []const u8 {
+    return if (ok) "true" else "false";
+}
+
+/// The get reply: a bare JSON string, or the literal `null` for a missing key.
+///
+/// Escaped with `appendJsonEscaped` because the value is page-controlled and
+/// is replayed into JavaScript that `evaluateJavaScript:` parses as source — a
+/// `"` or `\` in a stored secret would otherwise break the page's promise
+/// resolution. `null` and `""` are different answers and stay different: a
+/// stored empty string must read back as `""`.
+fn valueFragment(allocator: std.mem.Allocator, value: ?[]const u8) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    if (value) |v| {
+        try out.append(allocator, '"');
+        try bridge_error.appendJsonEscaped(allocator, &out, v);
+        try out.append(allocator, '"');
+    } else {
+        try out.appendSlice(allocator, "null");
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+/// Log a keychain failure with the one thing a bare-boolean reply cannot
+/// carry: the raw OSStatus. The `key` names the failing call; the **value is
+/// never logged**, here or anywhere in this file — it is the secret the caller
+/// chose the keychain for.
+fn logStatus(op: []const u8, key: []const u8, status: OSStatus) void {
+    std.log.warn("secure store {s} failed for key '{s}': OSStatus {d}", .{ op, key, status });
+}
+
+/// The query every operation starts from: class + account. No service, no
+/// access group, matching the Swift exactly — see the module comment for why
+/// adding either would strand Swift-written data.
+///
+/// The dictionary is an autoreleased `NSMutableDictionary`, alive for the
+/// run-loop turn the `WKScriptMessageHandler` callback runs inside, handed to
+/// `SecItem*` via toll-free bridging.
+fn newQuery(allocator: std.mem.Allocator, key: []const u8) !Id {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const NSMutableDictionary = objc.objc_getClass("NSMutableDictionary") orelse return error.ClassNotFound;
+    const sel_dictionary = objc.sel_registerName("dictionary") orelse return error.SelectorNotFound;
+    const query = objc.msgSendId(NSMutableDictionary, sel_dictionary);
+    if (query == null) return error.QueryAllocationFailed;
+
+    try setQueryValue(query, kSecClass, kSecClassGenericPassword);
+
+    // `createNSString` can hand back nil (its `stringWithUTF8String:` returns
+    // nil for bytes it rejects). `std.json` already validated UTF-8 and the
+    // NUL check ran, so this should not fire — but an unchecked nil into
+    // `setObject:forKey:` is an uncatchable NSInvalidArgumentException, so it
+    // is named rather than assumed away.
+    const account = try objc.createNSString(key, allocator);
+    if (account == null) return error.StringCreationFailed;
+    try setQueryValue(query, kSecAttrAccount, account);
+
+    return query;
+}
+
+/// `-[NSMutableDictionary setObject:forKey:]` with the nil checks that keep a
+/// missing Security.framework constant a named error instead of an
+/// uncatchable ObjC exception.
+fn setQueryValue(dict: Id, cf_key: CFTypeRef, value: Id) !void {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    if (cf_key == null or value == null) return error.MissingKeychainConstant;
+
+    const sel_set = objc.sel_registerName("setObject:forKey:") orelse return error.SelectorNotFound;
+    objc.msgSendVoid2(dict, sel_set, value, cf_key);
+}
+
+/// `+[NSData dataWithBytes:length:]`, autoreleased. The value's bytes as-is:
+/// `std.json` validated them as UTF-8 already, so there is no conversion step
+/// and nothing that can fail the way Swift's `value.data(using: .utf8)!`
+/// force-unwrap could.
+fn makeData(bytes: []const u8) !Id {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const NSData = objc.objc_getClass("NSData") orelse return error.ClassNotFound;
+    const sel_data = objc.sel_registerName("dataWithBytes:length:") orelse return error.SelectorNotFound;
+
+    // The length must be an explicit `c_ulong` (`NSUInteger`): the variadic
+    // msgSend cast takes the argument type from what is passed.
+    const data = objc.msgSendId2(NSData, sel_data, bytes.ptr, @as(c_ulong, @intCast(bytes.len)));
+    if (data == null) return error.NSDataCreationFailed;
+    return data;
+}
+
+/// Store `value` under `key`, replacing any existing item; `false` means the
+/// add failed and the status is in the log.
+///
+/// Delete-then-add as in Swift, but the delete gets the *scoped* query (class
+/// + account) before the value attributes go in — see the module comment. The
+/// delete's status is discarded exactly as Swift discards it: "nothing to
+/// replace" is the common case. The add's status is never discarded.
+fn keychainStore(allocator: std.mem.Allocator, key: []const u8, value: []const u8) !bool {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const query = try newQuery(allocator, key);
+
+    _ = SecItemDelete(query);
+
+    try setQueryValue(query, kSecValueData, try makeData(value));
+    // Device-local, never iCloud-synced, unreadable while locked. On the add
+    // only — in a delete or match query it would filter rather than set.
+    try setQueryValue(query, kSecAttrAccessible, kSecAttrAccessibleWhenUnlockedThisDeviceOnly);
+
+    const status = SecItemAdd(query, null);
+    if (status == errSecSuccess) return true;
+    logStatus("set", key, status);
+    return false;
+}
+
+/// Read `key`, returning an owned copy of its bytes, or null when absent.
+///
+/// Copied out because `SecItemCopyMatching`'s result arrives **+1 retained**
+/// — ARC released it for Swift, Zig must not forget to — and the copy lets the
+/// `CFRelease` sit next to the read on every path.
+///
+/// Divergence from Swift, on purpose: Swift folds *every* non-success status
+/// and every non-UTF-8 value into `nil` → the page sees `null`, a claim that
+/// nothing is stored. Only `errSecItemNotFound` earns `null` here; a failed
+/// call or an undecodable item is an error with the diagnostic in the log.
+fn keychainRetrieve(allocator: std.mem.Allocator, key: []const u8) !?[]u8 {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const query = try newQuery(allocator, key);
+    // `kCFBooleanTrue`, not an NSNumber built here — Swift's `true` bridges to
+    // the `__NSCFBoolean` singleton.
+    try setQueryValue(query, kSecReturnData, kCFBooleanTrue);
+    try setQueryValue(query, kSecMatchLimit, kSecMatchLimitOne);
+
+    var result: CFTypeRef = null;
+    const status = SecItemCopyMatching(query, &result);
+
+    if (status == errSecItemNotFound) return null;
+    if (status != errSecSuccess) {
+        logStatus("get", key, status);
+        return bridge_error.BridgeError.NativeCallFailed;
+    }
+
+    const data = result orelse {
+        // errSecSuccess with no object should be impossible; if it happens it
+        // is not "nothing stored" and must not be answered as `null`.
+        std.log.warn("secure store get for key '{s}' returned errSecSuccess with no data", .{key});
+        return bridge_error.BridgeError.NativeCallFailed;
+    };
+    defer CFRelease(data);
+
+    // Swift's `result as? Data`: one message send to be sure this is not
+    // something else read as raw bytes.
+    if (!try isData(data)) {
+        std.log.warn("secure store get for key '{s}' returned a non-CFData result", .{key});
+        return bridge_error.BridgeError.NativeCallFailed;
+    }
+
+    const len = try dataLength(data);
+    const bytes: []const u8 = if (len == 0)
+        // `-bytes` is documented to return nil for empty data.
+        &[_]u8{}
+    else
+        (try dataBytes(data) orelse {
+            std.log.warn("secure store get for key '{s}' returned {d} bytes at a nil pointer", .{ key, len });
+            return bridge_error.BridgeError.NativeCallFailed;
+        })[0..len];
+
+    if (!std.unicode.utf8ValidateSlice(bytes)) {
+        // The item exists; only its bytes cannot ride a string-valued API.
+        // Swift resolves `null` here, indistinguishable from "not stored".
+        std.log.warn("secure store item for key '{s}' is not valid UTF-8; this API only returns strings", .{key});
+        return bridge_error.BridgeError.InvalidParameter;
+    }
+
+    return try allocator.dupe(u8, bytes);
+}
+
+/// Delete `key`; absent is `true`, any other failure is `false` with the
+/// status logged — Swift's `status == errSecSuccess || status ==
+/// errSecItemNotFound`, verbatim.
+fn keychainDelete(allocator: std.mem.Allocator, key: []const u8) !bool {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const query = try newQuery(allocator, key);
+    const status = SecItemDelete(query);
+    if (status == errSecSuccess or status == errSecItemNotFound) return true;
+    logStatus("remove", key, status);
+    return false;
+}
+
+/// Delete every generic-password item the app can see — the class-only query
+/// is the entire scope, and the module comment names what that includes. An
+/// already-empty store is `true`, as in Swift.
+fn keychainClear() !bool {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const NSMutableDictionary = objc.objc_getClass("NSMutableDictionary") orelse return error.ClassNotFound;
+    const sel_dictionary = objc.sel_registerName("dictionary") orelse return error.SelectorNotFound;
+    const query = objc.msgSendId(NSMutableDictionary, sel_dictionary);
+    if (query == null) return error.QueryAllocationFailed;
+
+    try setQueryValue(query, kSecClass, kSecClassGenericPassword);
+
+    const status = SecItemDelete(query);
+    if (status == errSecSuccess or status == errSecItemNotFound) return true;
+    logStatus("clear", "*", status);
+    return false;
+}
+
+/// `-[NSObject isKindOfClass:[NSData class]]`; true for the toll-free-bridged
+/// `CFDataRef` the keychain hands back.
+fn isData(obj: Id) !bool {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const NSData = objc.objc_getClass("NSData") orelse return error.ClassNotFound;
+    const sel_kind = objc.sel_registerName("isKindOfClass:") orelse return error.SelectorNotFound;
+    const Fn = *const fn (Id, Id, Id) callconv(.c) bool;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    return func(obj, sel_kind, NSData);
+}
+
+/// `-[NSData length]`. `NSUInteger`, hence `c_ulong`.
+fn dataLength(data: Id) !usize {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const sel_length = objc.sel_registerName("length") orelse return error.SelectorNotFound;
+    const Fn = *const fn (Id, Id) callconv(.c) c_ulong;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    return @intCast(func(data, sel_length));
+}
+
+/// `-[NSData bytes]` — not `-UTF8String`, which a `CFDataRef` does not answer;
+/// that typo would be a runtime crash, not a compile error. The pointer is
+/// valid until the data is released, which the caller does after copying.
+fn dataBytes(data: Id) !?[*]const u8 {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const sel_bytes = objc.sel_registerName("bytes") orelse return error.SelectorNotFound;
+    const Fn = *const fn (Id, Id) callconv(.c) ?[*]const u8;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    return func(data, sel_bytes);
+}
+
+// =============================================================================
+// Tests — host-only. Everything that decides what the page sees (routing,
+// parsing, fragment shaping) is a pure function beside the Security calls, and
+// the Security calls themselves are never made from here: three of the four
+// handlers fail validation before reaching them, and `secureClear`, which has
+// no validation to fail at, is pinned through `routeFor` alone (invoking it
+// would address the login keychain of whatever machine runs the tests).
+// =============================================================================
+
+const testing = std.testing;
+
+test "the declared actions are the ones the handler serves" {
+    try testing.expectEqual(@as(usize, 4), capability_actions.len);
+    try testing.expectEqualStrings(A.secure_set, capability_actions[0].name);
+    try testing.expectEqualStrings(A.secure_get, capability_actions[1].name);
+    try testing.expectEqualStrings(A.secure_remove, capability_actions[2].name);
+    try testing.expectEqualStrings(A.secure_clear, capability_actions[3].name);
+
+    for (capability_actions) |decl| {
+        try testing.expectEqual(capabilities.Reply.result, decl.reply);
+        try testing.expectEqual(capabilities.ActionStatus.live, decl.status);
+    }
+}
+
+test "the action names match the Swift case labels exactly" {
+    // The conformance ratchet compares these against the `case "…":` labels in
+    // `CraftApp.swift` in both directions; a prettier spelling would read as
+    // Zig serving an action the spec does not have.
+    try testing.expectEqualStrings("secureSet", A.secure_set);
+    try testing.expectEqualStrings("secureGet", A.secure_get);
+    try testing.expectEqualStrings("secureRemove", A.secure_remove);
+    try testing.expectEqualStrings("secureClear", A.secure_clear);
+}
+
+test "every declared action is one the dispatcher routes" {
+    for (capability_actions) |decl| {
+        if (routeFor(decl.name) == null) {
+            std.debug.print("declared action '{s}' does not route\n", .{decl.name});
+            return error.DeclaredActionDoesNotRoute;
+        }
+    }
+}
+
+test "every route the dispatcher has is a declared action" {
+    // The other direction: a route with a handler and no declaration is an
+    // action the page can call and the manifest denies exists. Each
+    // declaration must claim a *distinct* route — counting alone would let two
+    // rows share one route while another went undeclared.
+    var claimed = std.mem.zeroes([std.enums.values(Route).len]bool);
+    for (capability_actions) |decl| {
+        const route = routeFor(decl.name) orelse return error.DeclaredActionDoesNotRoute;
+        const slot = @backingInt(route);
+        if (claimed[slot]) {
+            std.debug.print("two declarations route to {s}\n", .{@tagName(route)});
+            return error.TwoDeclarationsShareARoute;
+        }
+        claimed[slot] = true;
+    }
+    for (claimed, 0..) |taken, slot| {
+        if (!taken) {
+            std.debug.print(
+                "route {s} has a handler but no capability_actions row\n",
+                .{@tagName(@as(Route, @fromBackingInt(@intCast(slot))))},
+            );
+            return error.RouteNotDeclared;
+        }
+    }
+}
+
+test "the payload-taking actions fail validation before any Security call" {
+    // `{}` has no `key`, so set/get/remove error out before the keychain is
+    // touched — which is what makes this safe on a developer's machine, and
+    // what rules out a routed name whose handler ignores its payload contract.
+    // `secureClear` is deliberately absent: it has no payload and no
+    // validation gate, so invoking it here would be a real class-wide delete.
+    var bridge = SecureStoreBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    const payload_actions = [_][]const u8{ A.secure_set, A.secure_get, A.secure_remove };
+    for (payload_actions) |name| {
+        try testing.expectError(
+            bridge_error.BridgeError.MissingData,
+            bridge.handleMessage(name, "{}"),
+        );
+    }
+}
+
+test "an action the namespace does not serve is reported, not ignored" {
+    var bridge = SecureStoreBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("noSuchAction", "{}"),
+    );
+    // Near misses — casing is how a real typo arrives.
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("secureset", "{}"),
+    );
+    // The JS surface names, which are not action names.
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("secureStore", "{}"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("secureStorage", "{}"),
+    );
+    // The sharedItems namespace next door shares the *keychain* with this
+    // module but must not share the dispatch: two modules claiming one action
+    // would make `ios_dispatch`'s first-match routing order-dependent.
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("setSharedItem", "{\"key\":\"k\",\"value\":\"v\"}"),
+    );
+}
+
+test "a malformed payload is reported as bad JSON, not as a missing field" {
+    var bridge = SecureStoreBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidJSON,
+        bridge.handleMessage(A.secure_get, "{not json"),
+    );
+}
+
+fn expectKeyError(json: []const u8, expected: anyerror) !void {
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectError(expected, parseKey(parsed.value));
+}
+
+fn expectSetError(json: []const u8, expected: anyerror) !void {
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectError(expected, parseSetRequest(parsed.value));
+}
+
+test "the field names the page sends are the ones that are read" {
+    // `{action:'secureSet', key: key, value: value, callbackId: id}` in the
+    // injected JS; the shim reads `body["key"]` / `body["value"]`. A rename on
+    // either side of the migration would make the two handlers read different
+    // payloads.
+    var parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        testing.allocator,
+        "{\"key\":\"token\",\"value\":\"abc123\"}",
+        .{},
+    );
+    defer parsed.deinit();
+
+    const request = try parseSetRequest(parsed.value);
+    try testing.expectEqualStrings("token", request.key);
+    try testing.expectEqualStrings("abc123", request.value);
+    try testing.expectEqualStrings("token", try parseKey(parsed.value));
+}
+
+test "an absent key is refused rather than defaulted" {
+    try expectKeyError("{}", bridge_error.BridgeError.MissingData);
+    try expectSetError("{\"value\":\"v\"}", bridge_error.BridgeError.MissingData);
+}
+
+test "an absent value is refused rather than stored as empty" {
+    // Swift's `if let value = body["value"] as? String` fails here and replies
+    // nothing at all — the legacy promise has no timeout, so that is a hang. A
+    // default of `""` would be worse: it would overwrite a real secret and
+    // resolve `true`.
+    try expectSetError("{\"key\":\"k\"}", bridge_error.BridgeError.MissingData);
+}
+
+test "a non-string key or value is refused, not coerced" {
+    try expectKeyError("{\"key\":7}", bridge_error.BridgeError.InvalidParameter);
+    try expectKeyError("{\"key\":null}", bridge_error.BridgeError.InvalidParameter);
+    try expectSetError("{\"key\":\"k\",\"value\":7}", bridge_error.BridgeError.InvalidParameter);
+    try expectSetError("{\"key\":\"k\",\"value\":null}", bridge_error.BridgeError.InvalidParameter);
+}
+
+test "an explicitly empty value is a value, and is stored" {
+    var parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        testing.allocator,
+        "{\"key\":\"k\",\"value\":\"\"}",
+        .{},
+    );
+    defer parsed.deinit();
+    const request = try parseSetRequest(parsed.value);
+    try testing.expectEqualStrings("", request.value);
+}
+
+test "a key with an embedded NUL is refused, not truncated" {
+    // `stringWithUTF8String:` stops at the first NUL, so an unchecked
+    // "a\u0000b" would address the item named "a" while the reply reported on
+    // the full key — and `secureGet("a")` would then hand back a secret filed
+    // under a different page key.
+    try expectKeyError("{\"key\":\"a\\u0000b\"}", bridge_error.BridgeError.InvalidParameter);
+    try expectSetError(
+        "{\"key\":\"a\\u0000b\",\"value\":\"v\"}",
+        bridge_error.BridgeError.InvalidParameter,
+    );
+
+    // The *value* keeps its NUL: `makeData` passes bytes and a length, so
+    // nothing truncates, and the NSData round-trip test below proves it.
+    // Refusing it would drop a payload the handler carries fine — and Swift
+    // stores it whole too, so this is the compatible answer, not the lenient
+    // one.
+    var parsed = try std.json.parseFromSlice(
+        std.json.Value,
+        testing.allocator,
+        "{\"key\":\"k\",\"value\":\"a\\u0000b\"}",
+        .{},
+    );
+    defer parsed.deinit();
+    const request = try parseSetRequest(parsed.value);
+    try testing.expectEqualSlices(u8, &[_]u8{ 'a', 0, 'b' }, request.value);
+}
+
+test "a payload that is not an object is bad JSON, not a missing field" {
+    try expectKeyError("[]", bridge_error.BridgeError.InvalidJSON);
+    try expectKeyError("\"key\"", bridge_error.BridgeError.InvalidJSON);
+}
+
+test "the boolean replies are the two bare fragments and nothing else" {
+    // Swift resolves with `.fragmentsAllowed`, so the page receives the JSON
+    // fragment `true` or `false` — not `{"success":true}`, which is the shape
+    // next door in sharedItems and would break `craft.secureStore.set`'s
+    // boolean contract.
+    try testing.expectEqualStrings("true", boolFragment(true));
+    try testing.expectEqualStrings("false", boolFragment(false));
+}
+
+test "a found value and a missing one are different fragments" {
+    const found = try valueFragment(testing.allocator, "abc123");
+    defer testing.allocator.free(found);
+    try testing.expectEqualStrings("\"abc123\"", found);
+
+    // A nil String? cast `as Any` bridges to NSNull, which serializes as the
+    // fragment `null` — the promise *resolves* with null, it does not reject.
+    const missing = try valueFragment(testing.allocator, null);
+    defer testing.allocator.free(missing);
+    try testing.expectEqualStrings("null", missing);
+
+    // A stored empty string is not a missing item.
+    const empty = try valueFragment(testing.allocator, "");
+    defer testing.allocator.free(empty);
+    try testing.expectEqualStrings("\"\"", empty);
+}
+
+test "a page-controlled value cannot break the reply" {
+    // The fragment is replayed into JavaScript that `evaluateJavaScript:`
+    // parses as source; an unescaped quote in a stored secret would be a
+    // syntax error in the page. The NUL matters too: a value stored with one
+    // must survive the round trip through the JSON escape.
+    const json = try valueFragment(testing.allocator, "we\"ird\\secret\nwith\x00nul");
+    defer testing.allocator.free(json);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("we\"ird\\secret\nwith\x00nul", parsed.value.string);
+}
+
+test "the constants that are branched on are the documented ones" {
+    // `errSecItemNotFound` is the difference between `null`/`true` and a
+    // failure on three of the four actions; a wrong `errSecSuccess` would make
+    // every call look failed.
+    try testing.expectEqual(@as(OSStatus, 0), errSecSuccess);
+    try testing.expectEqual(@as(OSStatus, -25300), errSecItemNotFound);
+}
+
+// The remaining tests exercise the Objective-C half against the live runtime —
+// libobjc and Foundation only, no keychain, skipped off Darwin. They exist
+// because a wrong selector string is a runtime crash or a silent no-op, never
+// a compile error, and these are this file's own copies of the selectors.
+
+test "the NSData selectors round-trip bytes, embedded NUL included" {
+    if (!builtin.target.os.tag.isDarwin()) return error.SkipZigTest;
+
+    // The NUL is the point: `length`/`bytes` rather than `UTF8String`, which
+    // would truncate a stored secret at the first zero byte and report the
+    // truncation as the value.
+    const payload = "se\x00cret";
+    const data = try makeData(payload);
+    try testing.expect(try isData(data));
+
+    const len = try dataLength(data);
+    try testing.expectEqual(@as(usize, payload.len), len);
+
+    const bytes = (try dataBytes(data)).?;
+    try testing.expectEqualSlices(u8, payload, bytes[0..len]);
+}
+
+test "an empty value is empty data, and is never dereferenced" {
+    if (!builtin.target.os.tag.isDarwin()) return error.SkipZigTest;
+
+    const data = try makeData("");
+    try testing.expect(try isData(data));
+    try testing.expectEqual(@as(usize, 0), try dataLength(data));
+}
+
+test "the CFData type check rejects something that is not data" {
+    if (!builtin.target.os.tag.isDarwin()) return error.SkipZigTest;
+
+    // Stands in for "the keychain returned something else" — the case that
+    // must not be read as raw bytes and handed to the page as a secret.
+    const ns = try objc.createNSString("not data", testing.allocator);
+    try testing.expect(!try isData(ns));
+}
+
+test "the query builder produces a dictionary the runtime accepts" {
+    if (!builtin.target.os.tag.isDarwin()) return error.SkipZigTest;
+
+    // Proves the `kSec*` globals resolve, `NSMutableDictionary` allocates, and
+    // `setObject:forKey:`'s selector is spelled right — without a single
+    // `SecItem*` call, so the host keychain is never touched. A headless CI
+    // runner may have no login keychain at all, and a test depending on one is
+    // a flake, not a gate; the write/read/delete round trip needs the
+    // simulator fixture.
+    const query = try newQuery(testing.allocator, "conformance-probe");
+    try testing.expect(query != null);
+}

--- a/packages/zig/src/bridge_mobile_shortcuts.zig
+++ b/packages/zig/src/bridge_mobile_shortcuts.zig
@@ -1,0 +1,949 @@
+//! The home-screen quick-action pair of the `mobile` namespace:
+//! `setShortcuts`, `clearShortcuts`.
+//!
+//! These are `UIApplication.shortcutItems` — the long-press menu on the app
+//! icon — not the desktop hotkeys of `bridge_shortcuts.zig`, which shares
+//! nothing with this file but a word. Both actions are one property write on
+//! the shared application, done synchronously: the Swift helpers wrap the
+//! write in `DispatchQueue.main.async`, but the Zig dispatcher is already
+//! inside the `WKScriptMessageHandler` callback on the main thread, so the
+//! hop would only move the reply away from the frame that holds this call's
+//! id. No completion handler exists anywhere on either path, hence no
+//! `ios_async` ticket.
+//!
+//! ## What is carried across exactly, because it is the observable contract
+//!
+//!  - **`setShortcuts` resolves with the object `{"count":N}`** — the Swift
+//!    dictionary literal — and `clearShortcuts` resolves with the **bare JSON
+//!    fragment `true`** (Swift serialises with `.fragmentsAllowed`, and
+//!    `test-bridges.html` renders `'Shortcuts cleared: ' + result`, so the
+//!    bare boolean is load-bearing).
+//!  - **An empty `shortcuts` array is a valid request**: it installs an empty
+//!    list and replies `{"count":0}`, exactly as Swift does. It is not folded
+//!    into `clearShortcuts`.
+//!  - **A JSON `null` `subtitle`/`iconName`/`userInfo` means "none"**, the
+//!    same answer as omitting the field — Swift's `as? String` turns `NSNull`
+//!    into `nil`, and `JSON.stringify` keeps an explicit null where it drops
+//!    an undefined.
+//!
+//! ## What is deliberately not carried across
+//!
+//! **Swift's silent hang.** The dispatcher arm is `if let shortcuts = ... as?
+//! [[String: Any]]` with no `else`: a missing or non-array `shortcuts` replies
+//! nothing and the page's promise never settles. Every path here ends in a
+//! reply or an error, per the precedent `bridge_mobile_storage.zig` set.
+//!
+//! **Swift's silent element skip.** An element missing `type` or `title` is
+//! `continue`d and the reply reports a smaller `count`. Skipping is dropping a
+//! payload element under a success, so a malformed element refuses the whole
+//! batch with `InvalidParameter` instead — which also means `count` always
+//! equals the length of the array the page sent, never a quiet subset. The
+//! same goes for a `subtitle`/`iconName`/`userInfo` of the wrong type, which
+//! Swift's `as?` casts would drop while installing the rest of the shortcut.
+//!
+//! **A NUL byte in `type`, `title`, `subtitle` or `iconName`.** All four reach
+//! UIKit through `stringWithUTF8String:`, which stops at the first NUL, and
+//! `type` in particular is the identity the app would match on activation — a
+//! truncated one is a different shortcut than the page named, reported as
+//! installed. Refused with `InvalidParameter`; see `requireNulFree`.
+//! `userInfo` string values are exempt: they travel as escaped JSON bytes
+//! through `NSJSONSerialization` and keep their NULs whole.
+//!
+//! ## `userInfo` is carried, not dropped
+//!
+//! Nothing in the repo sends it, but the injected JS contract permits it and
+//! Swift stores it, so silently discarding it here would be the exact
+//! dropped-field bug this migration exists to remove. The element's sub-JSON
+//! is re-serialised and handed to `NSJSONSerialization`, which yields the same
+//! Foundation types (`NSString`/`NSNumber`/`NSArray`/`NSDictionary`/`NSNull`)
+//! that Swift's `as? [String: NSSecureCoding]` cast admits.
+//!
+//! ## The gap that is real and is not this file's to close
+//!
+//! Installing shortcuts is honest — they appear in the long-press menu — but
+//! **tapping one never reaches the page**: the injected JS registers
+//! `craftShortcut` listeners, and no template implements
+//! `application(_:performActionFor:completionHandler:)` or any scene-delegate
+//! equivalent, so nothing ever dispatches that event. Tapping launches or
+//! foregrounds the app and stops there. Pre-existing, identical under the
+//! Swift shim, and outside these two actions' scope.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const capabilities = @import("capabilities.zig");
+const bridge_error = @import("bridge_error.zig");
+const objc_runtime = @import("objc_runtime.zig");
+
+const objc = objc_runtime.objc;
+
+/// The same type as `objc.id` — `?*anyopaque` — spelled locally.
+///
+/// `objc_runtime.objc` is an empty struct off Darwin, and a function
+/// *signature* is analysed even when a comptime platform guard makes its body
+/// unreachable, so naming `objc.id` in module-level signatures would break the
+/// host build. It stays a single optional pointer, never `?objc.id`: a double
+/// optional is illegal in a `callconv(.c)` type.
+const Id = ?*anyopaque;
+
+/// The action names, spelled exactly as the Swift `case` labels spell them.
+/// The conformance ratchet matches the two lists by string in both directions.
+pub const A = struct {
+    pub const set_shortcuts = "setShortcuts";
+    pub const clear_shortcuts = "clearShortcuts";
+};
+
+/// Both `.result`: each Swift path terminates in exactly one
+/// `resolveCallback`, and both injected JS methods return promises the page
+/// awaits. `clearShortcuts` resolving with a bare fragment is still a result —
+/// `.none` would tell an app the action is fire-and-forget and strand the
+/// caller for the whole request timeout.
+///
+/// Both `.live`: everything each action does is one main-thread property
+/// write, fully reachable from Zig.
+pub const capability_actions = [_]capabilities.ActionDecl{
+    .{ .name = A.set_shortcuts, .reply = .result },
+    .{ .name = A.clear_shortcuts, .reply = .result },
+};
+
+/// One shortcut, after validation. Slices borrow from the parsed payload,
+/// which outlives every use — the whole handler runs inside one dispatch.
+///
+/// The field is `@"type"` and not something prettier because the wire name is
+/// the contract: the injected JS posts `type`, the Swift shim reads
+/// `shortcut["type"]`, and a rename here is exactly the field-name drift that
+/// broke `craft.fs.writeFile`.
+const Shortcut = struct {
+    type: []const u8,
+    title: []const u8,
+    subtitle: ?[]const u8 = null,
+    icon_name: ?[]const u8 = null,
+    /// Kept as the parsed JSON value; converted to Foundation objects only on
+    /// Darwin, at install time. Always `.object` when non-null.
+    user_info: ?std.json.Value = null,
+};
+
+/// Which handler an action selects, or null for one this namespace does not
+/// serve. Split out from `handleMessage` so the table-versus-dispatch
+/// agreement can be asserted on a host, where `UIApplication` does not exist.
+const Route = enum { set_shortcuts, clear_shortcuts };
+
+fn routeFor(action: []const u8) ?Route {
+    if (std.mem.eql(u8, action, A.set_shortcuts)) return .set_shortcuts;
+    if (std.mem.eql(u8, action, A.clear_shortcuts)) return .clear_shortcuts;
+    return null;
+}
+
+pub const ShortcutsBridge = struct {
+    allocator: std.mem.Allocator,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator) Self {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(_: *Self) void {}
+
+    pub fn handleMessage(self: *Self, action: []const u8, data: []const u8) !void {
+        const route = routeFor(action) orelse return bridge_error.BridgeError.UnknownAction;
+        // Exhaustive, so a `Route` without a handler is a compile error.
+        return switch (route) {
+            .set_shortcuts => self.setShortcuts(data),
+            .clear_shortcuts => self.clearShortcuts(),
+        };
+    }
+
+    /// Replace the app's quick actions with the batch the page sent.
+    fn setShortcuts(self: *Self, data: []const u8) !void {
+        var parsed = try parsePayload(self.allocator, data);
+        defer parsed.deinit();
+
+        const shortcuts = try parseShortcuts(self.allocator, parsed.value);
+        defer self.allocator.free(shortcuts);
+
+        try installShortcuts(self.allocator, shortcuts);
+
+        // Counted from what Zig validated and installed, never read back from
+        // `shortcutItems` — Swift counts its own local array the same way. The
+        // whole batch installs or nothing does, so this is always the length
+        // the page sent.
+        var buf: [40]u8 = undefined;
+        const json = try countReply(&buf, shortcuts.len);
+        bridge_error.sendResultToJS(self.allocator, A.set_shortcuts, json);
+    }
+
+    /// Remove all quick actions.
+    ///
+    /// `data` is deliberately not parsed: the injected JS posts no payload
+    /// (`ios_dispatch.payloadOf` normalises the absent `d` to `"{}"`), Swift
+    /// dispatches unconditionally, and there is no field whose absence or
+    /// shape could change what "clear" means.
+    fn clearShortcuts(self: *Self) !void {
+        try uninstallShortcuts();
+        bridge_error.sendResultToJS(self.allocator, A.clear_shortcuts, clear_reply);
+    }
+};
+
+/// The `clearShortcuts` resolution: Swift's `resolveCallback(_, result: true)`
+/// under `.fragmentsAllowed` — a bare boolean, not `{"success":true}`. The
+/// page string-concatenates the resolved value, so the fragment is the shape.
+const clear_reply = "true";
+
+/// Parse `d`, distinguishing a bad payload from a failed allocation —
+/// `OutOfMemory` propagates as itself so nobody debugs their own good JSON.
+fn parsePayload(allocator: std.mem.Allocator, data: []const u8) !std.json.Parsed(std.json.Value) {
+    return std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch |err| switch (err) {
+        error.OutOfMemory => return err,
+        else => return bridge_error.BridgeError.InvalidJSON,
+    };
+}
+
+/// The validated batch, or the reason it cannot be installed. Pure, so the
+/// host tests can pin every outcome Swift collapsed into a silent hang, a
+/// silent skip, or a silent `as?`-cast drop.
+///
+/// A missing `shortcuts` is `MissingData` (the required field is absent), a
+/// present-but-wrong one — including JSON `null` — is `InvalidParameter`,
+/// matching `bridge_mobile_storage.zig`'s split. Swift replies *nothing* in
+/// both cases and the page hangs; the divergence is the module's headline.
+fn parseShortcuts(allocator: std.mem.Allocator, payload: std.json.Value) ![]Shortcut {
+    const object = switch (payload) {
+        .object => |o| o,
+        else => return bridge_error.BridgeError.InvalidJSON,
+    };
+
+    const field = object.get("shortcuts") orelse return bridge_error.BridgeError.MissingData;
+    const array = switch (field) {
+        .array => |a| a,
+        else => return bridge_error.BridgeError.InvalidParameter,
+    };
+
+    var out: std.ArrayListUnmanaged(Shortcut) = .empty;
+    errdefer out.deinit(allocator);
+    for (array.items) |element| {
+        try out.append(allocator, try parseShortcut(element));
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+/// One element. Everything wrong with it is `InvalidParameter` — the
+/// malformed thing is an entry inside the `shortcuts` argument, not a missing
+/// top-level field — and it refuses the batch rather than being skipped; the
+/// module comment carries the argument.
+fn parseShortcut(element: std.json.Value) !Shortcut {
+    const object = switch (element) {
+        .object => |o| o,
+        else => return bridge_error.BridgeError.InvalidParameter,
+    };
+
+    var shortcut = Shortcut{
+        .type = try requiredString(object, "type"),
+        .title = try requiredString(object, "title"),
+    };
+    shortcut.subtitle = try optionalString(object, "subtitle");
+    shortcut.icon_name = try optionalString(object, "iconName");
+
+    if (object.get("userInfo")) |info| {
+        shortcut.user_info = switch (info) {
+            .null => null,
+            // Kept whole; strings inside may carry NULs, which the
+            // NSJSONSerialization route preserves — no `requireNulFree` here.
+            .object => info,
+            // Swift's `as? [String: NSSecureCoding]` turns anything else into
+            // nil and installs the shortcut without it, reported as success.
+            else => return bridge_error.BridgeError.InvalidParameter,
+        };
+    }
+
+    return shortcut;
+}
+
+/// A field Swift `guard`s on: present and a string, or the batch is refused.
+fn requiredString(object: std.json.ObjectMap, name: []const u8) ![]const u8 {
+    const field = object.get(name) orelse return bridge_error.BridgeError.InvalidParameter;
+    const s = switch (field) {
+        .string => |v| v,
+        else => return bridge_error.BridgeError.InvalidParameter,
+    };
+    try requireNulFree(s);
+    return s;
+}
+
+/// A field Swift reads with `as? String`: absent and JSON `null` both mean
+/// "none"; any other non-string is refused rather than dropped.
+fn optionalString(object: std.json.ObjectMap, name: []const u8) !?[]const u8 {
+    const field = object.get(name) orelse return null;
+    return switch (field) {
+        .null => null,
+        .string => |v| blk: {
+            try requireNulFree(v);
+            break :blk v;
+        },
+        else => bridge_error.BridgeError.InvalidParameter,
+    };
+}
+
+/// Refuse a string carrying the one byte `stringWithUTF8String:` cannot
+/// survive. `\u0000` is a legal JSON escape and `std.json` decodes it to the
+/// byte, so a page can reach this. Without the check, a `type` of
+/// `"open\u0000debug"` would install the shortcut whose activation identity is
+/// `"open"` and reply `{"count":1}` as if the asked-for one existed.
+fn requireNulFree(s: []const u8) !void {
+    if (std.mem.indexOfScalar(u8, s, 0) != null) return bridge_error.BridgeError.InvalidParameter;
+}
+
+/// `{"count":N}` — the Swift dictionary literal, verbatim. `bufPrint` is safe
+/// here where storage needed escaping: nothing page-controlled is echoed.
+fn countReply(buf: []u8, count: usize) ![]const u8 {
+    return std.fmt.bufPrint(buf, "{{\"count\":{d}}}", .{count});
+}
+
+/// Re-serialise a parsed value to JSON bytes for `NSJSONSerialization`.
+///
+/// `std.json.Value` does not remember its source span, so this walk exists.
+/// Strings and keys go through `bridge_error.appendJsonEscaped`, which escapes
+/// every control byte — `bridge_handoff.zig`'s older copy of this walk misses
+/// NUL, and an unescaped control byte makes the bytes invalid JSON that
+/// Foundation would refuse, turning a legal payload into a refusal.
+///
+/// A non-finite float is refused *here*, purely and testably: `{d}` would
+/// render `inf`, which is not JSON, and the failure would otherwise surface as
+/// an opaque nil from Foundation.
+fn serializeJsonValue(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    value: std.json.Value,
+) !void {
+    switch (value) {
+        .null => try out.appendSlice(allocator, "null"),
+        .bool => |b| try out.appendSlice(allocator, if (b) "true" else "false"),
+        .integer => |i| {
+            var buf: [24]u8 = undefined;
+            try out.appendSlice(allocator, try std.fmt.bufPrint(&buf, "{d}", .{i}));
+        },
+        .float => |f| {
+            if (!std.math.isFinite(f)) return bridge_error.BridgeError.InvalidParameter;
+            // `{d}` renders decimal notation, never scientific, and a finite
+            // f64 can need up to `bufferSize(.decimal, f64)` (347) bytes —
+            // 1e300 alone is 301 digits. A smaller buffer turns that legal
+            // JSON number into a NoSpaceLeft refusal.
+            var buf: [std.fmt.float.bufferSize(.decimal, f64)]u8 = undefined;
+            try out.appendSlice(allocator, try std.fmt.bufPrint(&buf, "{d}", .{f}));
+        },
+        // Only produced under parse options this module does not use, but
+        // carrying it costs one line and dropping it would be a silent hole.
+        .number_string => |s| try out.appendSlice(allocator, s),
+        .string => |s| {
+            try out.append(allocator, '"');
+            try bridge_error.appendJsonEscaped(allocator, out, s);
+            try out.append(allocator, '"');
+        },
+        .array => |items| {
+            try out.append(allocator, '[');
+            for (items.items, 0..) |item, i| {
+                if (i > 0) try out.append(allocator, ',');
+                try serializeJsonValue(allocator, out, item);
+            }
+            try out.append(allocator, ']');
+        },
+        .object => |obj| {
+            try out.append(allocator, '{');
+            var it = obj.iterator();
+            var first = true;
+            while (it.next()) |entry| {
+                if (!first) try out.append(allocator, ',');
+                first = false;
+                try out.append(allocator, '"');
+                try bridge_error.appendJsonEscaped(allocator, out, entry.key_ptr.*);
+                try out.appendSlice(allocator, "\":");
+                try serializeJsonValue(allocator, out, entry.value_ptr.*);
+            }
+            try out.append(allocator, '}');
+        },
+    }
+}
+
+// =============================================================================
+// The Objective-C half. Main thread throughout — see the module comment.
+// =============================================================================
+
+/// `[UIApplication sharedApplication]`, non-nil or an error.
+///
+/// Resolved before anything is built so a process with no shared application —
+/// an app extension, or one that has not reached `UIApplicationMain` — fails
+/// early instead of assembling items nothing can install.
+fn sharedApplication() !*anyopaque {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const UIApplication = objc.objc_getClass("UIApplication") orelse return error.ClassNotFound;
+    const sel_shared = objc.sel_registerName("sharedApplication") orelse return error.SelectorNotFound;
+    return objc.msgSendId(UIApplication, sel_shared) orelse error.NoSharedApplication;
+}
+
+/// Build the item array and assign it. All-or-nothing: any element that fails
+/// aborts before `setShortcutItems:` is reached, leaving the previous set
+/// installed — never a partial batch reported whole.
+fn installShortcuts(allocator: std.mem.Allocator, shortcuts: []const Shortcut) !void {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const app = try sharedApplication();
+
+    const NSMutableArray = objc.objc_getClass("NSMutableArray") orelse return error.ClassNotFound;
+    const sel_array = objc.sel_registerName("array") orelse return error.SelectorNotFound;
+    const sel_add = objc.sel_registerName("addObject:") orelse return error.SelectorNotFound;
+    // Autoreleased; on the error paths below the pool drains it, items and
+    // all, at the end of this run-loop turn.
+    const items = objc.msgSendId(NSMutableArray, sel_array);
+    if (items == null) return error.NativeCallFailed;
+
+    for (shortcuts) |shortcut| {
+        // Non-null by construction — `addObject:` raises an uncatchable
+        // NSInvalidArgumentException on nil, which is why `makeShortcutItem`
+        // returns `*anyopaque` and not `Id`.
+        const item = try makeShortcutItem(allocator, shortcut);
+        objc.msgSendVoid1(items, sel_add, item);
+        // `alloc`/`init` handed it over at +1; the array's retain is now the
+        // one keeping it alive. Without this, one item leaks per shortcut per
+        // call.
+        objc.release(item);
+    }
+
+    const sel_set = objc.sel_registerName("setShortcutItems:") orelse return error.SelectorNotFound;
+    objc.msgSendVoid1(app, sel_set, items);
+}
+
+/// `UIApplication.shared.shortcutItems = nil`, which is how "no shortcuts" is
+/// spelled — distinct from assigning an empty array, though UIKit renders both
+/// as an empty menu.
+fn uninstallShortcuts() !void {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const app = try sharedApplication();
+    const sel_set = objc.sel_registerName("setShortcutItems:") orelse return error.SelectorNotFound;
+    objc.msgSendVoid1(app, sel_set, @as(Id, null));
+}
+
+/// One `UIApplicationShortcutItem`, at +1 and never nil.
+///
+/// `initWithType:localizedTitle:...` declares `type` and `localizedTitle`
+/// nonnull and raises on a nil — so the `createNSString` results are checked
+/// even though `std.json` has already validated the bytes as UTF-8, because a
+/// nil into that initialiser is an uncatchable crash, not an error.
+fn makeShortcutItem(allocator: std.mem.Allocator, shortcut: Shortcut) !*anyopaque {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const ns_type = try objc.createNSString(shortcut.type, allocator);
+    if (ns_type == null) return bridge_error.BridgeError.InvalidParameter;
+    const ns_title = try objc.createNSString(shortcut.title, allocator);
+    if (ns_title == null) return bridge_error.BridgeError.InvalidParameter;
+
+    var ns_subtitle: Id = null;
+    if (shortcut.subtitle) |subtitle| {
+        ns_subtitle = try objc.createNSString(subtitle, allocator);
+        if (ns_subtitle == null) return bridge_error.BridgeError.InvalidParameter;
+    }
+
+    var icon: Id = null;
+    if (shortcut.icon_name) |name| icon = try makeIcon(allocator, name);
+
+    var user_info: Id = null;
+    if (shortcut.user_info) |info| user_info = try toFoundationObject(allocator, info);
+
+    const UIApplicationShortcutItem = objc.objc_getClass("UIApplicationShortcutItem") orelse
+        return error.ClassNotFound;
+    // Registered before `alloc` so a failed lookup cannot leak the +1 object.
+    const sel_init = objc.sel_registerName("initWithType:localizedTitle:localizedSubtitle:icon:userInfo:") orelse
+        return error.SelectorNotFound;
+
+    const allocated = try objc.alloc(UIApplicationShortcutItem);
+    if (allocated == null) return error.NativeCallFailed;
+
+    // subtitle, icon and userInfo are declared nullable — nil is the "none"
+    // the page asked for, not a missing argument.
+    const InitFn = *const fn (Id, objc.SEL, Id, Id, Id, Id, Id) callconv(.c) Id;
+    const init_fn: InitFn = @ptrCast(&objc.objc_msgSend);
+    const item = init_fn(allocated, sel_init, ns_type, ns_title, ns_subtitle, icon, user_info);
+    // A nil from init means init consumed the allocation (the ObjC
+    // convention), so there is nothing to release here.
+    return item orelse error.NativeCallFailed;
+}
+
+/// `+[UIApplicationShortcutIcon iconWithSystemImageName:]` (iOS 13+),
+/// autoreleased.
+///
+/// The honesty limit: UIKit returns a real icon object even for a bogus SF
+/// Symbols name — it just renders blank — and exposes no validation API, so a
+/// typo'd `iconName` cannot be caught here by anyone. The nil check guards the
+/// call convention, not the name.
+fn makeIcon(allocator: std.mem.Allocator, name: []const u8) !*anyopaque {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const UIApplicationShortcutIcon = objc.objc_getClass("UIApplicationShortcutIcon") orelse
+        return error.ClassNotFound;
+    const sel_icon = objc.sel_registerName("iconWithSystemImageName:") orelse return error.SelectorNotFound;
+
+    const ns_name = try objc.createNSString(name, allocator);
+    if (ns_name == null) return bridge_error.BridgeError.InvalidParameter;
+
+    return objc.msgSendId1(UIApplicationShortcutIcon, sel_icon, ns_name) orelse error.NativeCallFailed;
+}
+
+/// A parsed JSON object as the Foundation containers Swift's
+/// `as? [String: NSSecureCoding]` admits, via
+/// `+[NSJSONSerialization JSONObjectWithData:options:error:]` (autoreleased).
+///
+/// The round trip through bytes is the honest route: NSString keys and values
+/// built this way keep embedded NULs that `stringWithUTF8String:` would
+/// truncate, and every Foundation type it can produce conforms to
+/// NSSecureCoding. A nil back is `InvalidParameter` — the caller's `userInfo`
+/// holds something JSON cannot carry — with the log naming the field, since
+/// the error code alone cannot.
+fn toFoundationObject(allocator: std.mem.Allocator, value: std.json.Value) !*anyopaque {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    var bytes: std.ArrayListUnmanaged(u8) = .empty;
+    defer bytes.deinit(allocator);
+    try serializeJsonValue(allocator, &bytes, value);
+
+    const NSData = objc.objc_getClass("NSData") orelse return error.ClassNotFound;
+    const sel_data = objc.sel_registerName("dataWithBytes:length:") orelse return error.SelectorNotFound;
+    const data = objc.msgSendId2(NSData, sel_data, bytes.items.ptr, @as(c_ulong, @intCast(bytes.items.len)));
+    if (data == null) return error.NativeCallFailed;
+
+    const NSJSONSerialization = objc.objc_getClass("NSJSONSerialization") orelse return error.ClassNotFound;
+    const sel_parse = objc.sel_registerName("JSONObjectWithData:options:error:") orelse
+        return error.SelectorNotFound;
+    const ParseFn = *const fn (Id, objc.SEL, Id, c_ulong, Id) callconv(.c) Id;
+    const parse_fn: ParseFn = @ptrCast(&objc.objc_msgSend);
+    return parse_fn(NSJSONSerialization, sel_parse, data, 0, null) orelse {
+        std.log.warn("a shortcut's userInfo did not survive NSJSONSerialization; refusing the batch", .{});
+        return bridge_error.BridgeError.InvalidParameter;
+    };
+}
+
+// =============================================================================
+// Tests. Host-only by construction: everything that decides what the page
+// sees — routing, validation, reply shaping, the userInfo byte walk — is a
+// pure function beside the two UIKit writes.
+// =============================================================================
+
+const testing = std.testing;
+
+test "every declared action is one the dispatcher routes" {
+    for (capability_actions) |decl| {
+        if (routeFor(decl.name) == null) {
+            std.debug.print("declared action '{s}' does not route\n", .{decl.name});
+            return error.DeclaredActionDoesNotRoute;
+        }
+    }
+}
+
+test "every route the dispatcher has is a declared action" {
+    // Each declaration must claim a distinct route and every route must be
+    // claimed — counting alone would let two rows share one route while
+    // another went undeclared.
+    var claimed = std.mem.zeroes([std.enums.values(Route).len]bool);
+    for (capability_actions) |decl| {
+        const route = routeFor(decl.name) orelse return error.DeclaredActionDoesNotRoute;
+        const slot = @backingInt(route);
+        if (claimed[slot]) return error.TwoDeclarationsShareARoute;
+        claimed[slot] = true;
+    }
+    for (claimed) |taken| {
+        if (!taken) return error.RouteNotDeclared;
+    }
+}
+
+test "both actions reply with a result the page awaits" {
+    for (capability_actions) |decl| {
+        try testing.expectEqual(capabilities.Reply.result, decl.reply);
+        try testing.expectEqual(capabilities.ActionStatus.live, decl.status);
+    }
+}
+
+test "the action names are the ones the Swift dispatcher answers" {
+    // The wire contract, spelled out: the conformance scan compares `A`
+    // against `CraftApp.swift`'s case labels and catches one drifting, but not
+    // both renamed in step.
+    try testing.expectEqualStrings("setShortcuts", A.set_shortcuts);
+    try testing.expectEqualStrings("clearShortcuts", A.clear_shortcuts);
+}
+
+test "an action the namespace does not serve is reported, not ignored" {
+    var bridge = ShortcutsBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("noSuchAction", "{}"),
+    );
+    // The Swift *helper* names, which are not action names — accepting one
+    // would serve an action the spec's dispatcher does not have.
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("setAppShortcuts", "{\"shortcuts\":[]}"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("clearAppShortcuts", "{}"),
+    );
+    // Casing is how a real typo arrives.
+    try testing.expectError(
+        bridge_error.BridgeError.UnknownAction,
+        bridge.handleMessage("setshortcuts", "{}"),
+    );
+}
+
+test "a malformed payload is reported as bad JSON, not as a missing field" {
+    var bridge = ShortcutsBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidJSON,
+        bridge.handleMessage(A.set_shortcuts, "{not json"),
+    );
+}
+
+test "a missing shortcuts field is an answer on every platform, not a hang" {
+    // The headline divergence: Swift's `if let ... as? [[String: Any]]` has no
+    // `else`, so this exact payload leaves the page's promise unsettled
+    // forever. Validation also runs before any platform gate, so the page gets
+    // the specific error rather than UnsupportedPlatform wherever this runs.
+    var bridge = ShortcutsBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.MissingData,
+        bridge.handleMessage(A.set_shortcuts, "{}"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        bridge.handleMessage(A.set_shortcuts, "{\"shortcuts\":null}"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        bridge.handleMessage(A.set_shortcuts, "{\"shortcuts\":\"new-message\"}"),
+    );
+}
+
+fn expectParseError(json: []const u8, expected: anyerror) !void {
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectError(expected, parseShortcuts(testing.allocator, parsed.value));
+}
+
+test "the fields the injected JS sends are the fields that are read" {
+    // test-bridges.html's exact batch, plus a userInfo the contract permits.
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator,
+        \\{"shortcuts":[
+        \\  {"type":"new-message","title":"New Message","subtitle":"Start composing","iconName":"square.and.pencil"},
+        \\  {"type":"search","title":"Search","iconName":"magnifyingglass"},
+        \\  {"type":"settings","title":"Settings","iconName":"gear","userInfo":{"tab":"general"}}
+        \\]}
+    , .{});
+    defer parsed.deinit();
+
+    const shortcuts = try parseShortcuts(testing.allocator, parsed.value);
+    defer testing.allocator.free(shortcuts);
+
+    try testing.expectEqual(@as(usize, 3), shortcuts.len);
+    try testing.expectEqualStrings("new-message", shortcuts[0].type);
+    try testing.expectEqualStrings("New Message", shortcuts[0].title);
+    try testing.expectEqualStrings("Start composing", shortcuts[0].subtitle.?);
+    try testing.expectEqualStrings("square.and.pencil", shortcuts[0].icon_name.?);
+    try testing.expect(shortcuts[0].user_info == null);
+    // The second element sends no subtitle, which must be "none", not "".
+    try testing.expect(shortcuts[1].subtitle == null);
+    try testing.expectEqualStrings("magnifyingglass", shortcuts[1].icon_name.?);
+    // userInfo rides along whole rather than being dropped.
+    const info = shortcuts[2].user_info orelse return error.UserInfoDropped;
+    try testing.expectEqualStrings("general", info.object.get("tab").?.string);
+}
+
+test "an empty batch is a valid request, not an error and not a clear" {
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, "{\"shortcuts\":[]}", .{});
+    defer parsed.deinit();
+
+    const shortcuts = try parseShortcuts(testing.allocator, parsed.value);
+    defer testing.allocator.free(shortcuts);
+    try testing.expectEqual(@as(usize, 0), shortcuts.len);
+}
+
+test "a malformed element refuses the batch instead of being skipped" {
+    // Swift `continue`s these and reports a smaller count — an element
+    // silently dropped under a success. The whole batch is refused so `count`
+    // can never quietly disagree with what the page sent.
+    try expectParseError(
+        "{\"shortcuts\":[{\"title\":\"No Type\"}]}",
+        bridge_error.BridgeError.InvalidParameter,
+    );
+    try expectParseError(
+        "{\"shortcuts\":[{\"type\":\"no-title\"}]}",
+        bridge_error.BridgeError.InvalidParameter,
+    );
+    // A good element does not buy a bad one a pass.
+    try expectParseError(
+        "{\"shortcuts\":[{\"type\":\"ok\",\"title\":\"Ok\"},42]}",
+        bridge_error.BridgeError.InvalidParameter,
+    );
+}
+
+test "a required field of the wrong type is refused, not coerced" {
+    try expectParseError(
+        "{\"shortcuts\":[{\"type\":7,\"title\":\"T\"}]}",
+        bridge_error.BridgeError.InvalidParameter,
+    );
+    try expectParseError(
+        "{\"shortcuts\":[{\"type\":\"t\",\"title\":null}]}",
+        bridge_error.BridgeError.InvalidParameter,
+    );
+}
+
+test "null and absent optionals both mean none; wrong types are refused" {
+    // Swift's `as? String` folds NSNull and a number to nil alike — the first
+    // is the page saying "none", the second is a field silently dropped while
+    // the shortcut installs anyway.
+    var parsed = try std.json.parseFromSlice(testing_value_type, testing.allocator, "{\"shortcuts\":[{\"type\":\"t\",\"title\":\"T\",\"subtitle\":null,\"iconName\":null,\"userInfo\":null}]}", .{});
+    defer parsed.deinit();
+
+    const shortcuts = try parseShortcuts(testing.allocator, parsed.value);
+    defer testing.allocator.free(shortcuts);
+    try testing.expect(shortcuts[0].subtitle == null);
+    try testing.expect(shortcuts[0].icon_name == null);
+    try testing.expect(shortcuts[0].user_info == null);
+
+    try expectParseError(
+        "{\"shortcuts\":[{\"type\":\"t\",\"title\":\"T\",\"subtitle\":3}]}",
+        bridge_error.BridgeError.InvalidParameter,
+    );
+    try expectParseError(
+        "{\"shortcuts\":[{\"type\":\"t\",\"title\":\"T\",\"iconName\":[]}]}",
+        bridge_error.BridgeError.InvalidParameter,
+    );
+    try expectParseError(
+        "{\"shortcuts\":[{\"type\":\"t\",\"title\":\"T\",\"userInfo\":\"not an object\"}]}",
+        bridge_error.BridgeError.InvalidParameter,
+    );
+}
+
+// Spelled once: `std.json.Value` as a type argument inside a string-heavy test.
+const testing_value_type = std.json.Value;
+
+test "a NUL in any UIKit-bound string is refused, not truncated" {
+    // All four reach UIKit via `stringWithUTF8String:`, which stops at the
+    // first NUL; `type` is the identity a future activation handler would
+    // match on, so a truncated one is a different shortcut reported installed.
+    try expectParseError(
+        "{\"shortcuts\":[{\"type\":\"a\\u0000b\",\"title\":\"T\"}]}",
+        bridge_error.BridgeError.InvalidParameter,
+    );
+    try expectParseError(
+        "{\"shortcuts\":[{\"type\":\"t\",\"title\":\"a\\u0000b\"}]}",
+        bridge_error.BridgeError.InvalidParameter,
+    );
+    try expectParseError(
+        "{\"shortcuts\":[{\"type\":\"t\",\"title\":\"T\",\"subtitle\":\"a\\u0000b\"}]}",
+        bridge_error.BridgeError.InvalidParameter,
+    );
+    try expectParseError(
+        "{\"shortcuts\":[{\"type\":\"t\",\"title\":\"T\",\"iconName\":\"a\\u0000b\"}]}",
+        bridge_error.BridgeError.InvalidParameter,
+    );
+
+    // A NUL inside userInfo is *kept*: that path never crosses a C string, so
+    // refusing it would drop a value the handler can carry perfectly well.
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, "{\"shortcuts\":[{\"type\":\"t\",\"title\":\"T\",\"userInfo\":{\"k\":\"a\\u0000b\"}}]}", .{});
+    defer parsed.deinit();
+    const shortcuts = try parseShortcuts(testing.allocator, parsed.value);
+    defer testing.allocator.free(shortcuts);
+    const info = shortcuts[0].user_info orelse return error.UserInfoDropped;
+    try testing.expectEqualSlices(u8, &[_]u8{ 'a', 0, 'b' }, info.object.get("k").?.string);
+}
+
+test "a payload that is not an object is bad JSON, not a missing field" {
+    try expectParseError("[]", bridge_error.BridgeError.InvalidJSON);
+    try expectParseError("\"shortcuts\"", bridge_error.BridgeError.InvalidJSON);
+}
+
+test "the count reply is the Swift dictionary verbatim, and is JSON" {
+    var buf: [40]u8 = undefined;
+    try testing.expectEqualStrings("{\"count\":0}", try countReply(&buf, 0));
+    try testing.expectEqualStrings("{\"count\":3}", try countReply(&buf, 3));
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, try countReply(&buf, 3), .{});
+    defer parsed.deinit();
+    try testing.expectEqual(@as(i64, 3), parsed.value.object.get("count").?.integer);
+}
+
+test "the clear reply is the bare fragment true, not an object" {
+    // Swift resolves with `.fragmentsAllowed`, and the page renders
+    // 'Shortcuts cleared: ' + result — wrapping this in {"success":true} would
+    // "fix" it into displaying [object Object].
+    try testing.expectEqualStrings("true", clear_reply);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, clear_reply, .{});
+    defer parsed.deinit();
+    try testing.expect(parsed.value == .bool);
+    try testing.expect(parsed.value.bool);
+}
+
+test "the userInfo byte walk survives a std.json round trip" {
+    const source =
+        \\{"s":"quo\"te\\slash","n":-7,"f":1.5,"b":true,"z":null,"a":[1,"two",{"deep":false}]}
+    ;
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, source, .{});
+    defer parsed.deinit();
+
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    try serializeJsonValue(testing.allocator, &out, parsed.value);
+
+    var round = try std.json.parseFromSlice(std.json.Value, testing.allocator, out.items, .{});
+    defer round.deinit();
+    const obj = round.value.object;
+    try testing.expectEqualStrings("quo\"te\\slash", obj.get("s").?.string);
+    try testing.expectEqual(@as(i64, -7), obj.get("n").?.integer);
+    try testing.expectEqual(@as(f64, 1.5), obj.get("f").?.float);
+    try testing.expect(obj.get("b").?.bool);
+    try testing.expect(obj.get("z").? == .null);
+    try testing.expectEqualStrings("two", obj.get("a").?.array.items[1].string);
+    try testing.expect(!obj.get("a").?.array.items[2].object.get("deep").?.bool);
+}
+
+test "the byte walk escapes control bytes Foundation would refuse raw" {
+    // The exact miss in bridge_handoff.zig's older walk: a NUL emitted as the
+    // raw byte is invalid JSON, so NSJSONSerialization would answer nil and a
+    // legal userInfo would be refused. \u0000 in, \u0000 out.
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, "{\"k\":\"a\\u0000b\"}", .{});
+    defer parsed.deinit();
+
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    try serializeJsonValue(testing.allocator, &out, parsed.value);
+
+    try testing.expect(std.mem.indexOf(u8, out.items, "\\u0000") != null);
+    try testing.expect(std.mem.indexOfScalar(u8, out.items, 0) == null);
+}
+
+test "a float of extreme magnitude is rendered whole, not refused" {
+    // 1e300 is 301 decimal digits under `{d}` and 5e-324 — the smallest
+    // subnormal — is 326; both are legal JSON that std.json parses to
+    // `.float`. The 64-byte buffer this pins against answered them
+    // NoSpaceLeft, which reached the page as NativeCallFailed for a lawful
+    // userInfo.
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, "{\"big\":1e300,\"tiny\":5e-324}", .{});
+    defer parsed.deinit();
+
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    try serializeJsonValue(testing.allocator, &out, parsed.value);
+
+    // Still JSON after the digits stretch. The 301-digit rendering of 1e300
+    // is integer-shaped and too wide for i64, so std.json re-reads it as
+    // `.number_string` — its spelling for a number wider than its scalars;
+    // Foundation's parser has no such split and reads it as one number.
+    var round = try std.json.parseFromSlice(std.json.Value, testing.allocator, out.items, .{});
+    defer round.deinit();
+    const big = round.value.object.get("big").?.number_string;
+    try testing.expectEqual(@as(usize, 301), big.len);
+    try testing.expectEqual(@as(u8, '1'), big[0]);
+    // The subnormal renders as 0.00…05, floats on the re-parse, and Ryu's
+    // shortest digits make the value exact.
+    try testing.expectEqual(@as(f64, 5e-324), round.value.object.get("tiny").?.float);
+}
+
+test "a non-finite float is refused before Foundation sees it" {
+    // std.json parses 1e999 to inf; `{d}` would render it as `inf`, which is
+    // not JSON, and the failure would surface as an opaque nil three calls
+    // later. Refusing here keeps the diagnosis one frame deep.
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        serializeJsonValue(testing.allocator, &out, .{ .float = std.math.inf(f64) }),
+    );
+}
+
+// The remaining tests exercise the Objective-C half against the live runtime —
+// libobjc and Foundation on a macOS host, no UIKit and no device required.
+
+test "userInfo becomes a Foundation dictionary with its NUL intact" {
+    if (!builtin.target.os.tag.isDarwin()) return error.SkipZigTest;
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, "{\"route\":\"a\\u0000b\",\"depth\":3}", .{});
+    defer parsed.deinit();
+
+    const dict = try toFoundationObject(testing.allocator, parsed.value);
+    try testing.expect(try isKindOf(dict, "NSDictionary"));
+
+    // The value under "route" must be an NSString of *three* characters —
+    // proving the JSON-bytes route carries what `stringWithUTF8String:`
+    // truncates, which is the whole reason userInfo takes it.
+    const route = try dictValueForKey(testing.allocator, dict, "route");
+    try testing.expect(route != null);
+    try testing.expect(try isKindOf(route, "NSString"));
+    try testing.expectEqual(@as(usize, 3), try nsStringLength(route));
+}
+
+test "a missing UIApplication is reported rather than read past" {
+    // macOS links no UIKit, which is the same shape as an app extension or a
+    // pre-UIApplicationMain process on a device: `objc_getClass` answers null
+    // and the handler must error, not install into nothing or fabricate
+    // `true`. Pinned to macOS — on iOS the class exists and the right answer
+    // is a real install.
+    if (builtin.target.os.tag != .macos) return error.SkipZigTest;
+
+    var bridge = ShortcutsBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(error.ClassNotFound, bridge.handleMessage(A.clear_shortcuts, "{}"));
+    try testing.expectError(
+        error.ClassNotFound,
+        bridge.handleMessage(A.set_shortcuts, "{\"shortcuts\":[{\"type\":\"t\",\"title\":\"T\"}]}"),
+    );
+}
+
+test "off Darwin the platform gate answers instead of crashing" {
+    if (builtin.target.os.tag.isDarwin()) return error.SkipZigTest;
+
+    var bridge = ShortcutsBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        error.UnsupportedPlatform,
+        bridge.handleMessage(A.set_shortcuts, "{\"shortcuts\":[{\"type\":\"t\",\"title\":\"T\"}]}"),
+    );
+    try testing.expectError(error.UnsupportedPlatform, bridge.handleMessage(A.clear_shortcuts, "{}"));
+}
+
+/// `-[NSObject isKindOfClass:]` for the host tests above.
+fn isKindOf(obj: Id, class_name: [*:0]const u8) !bool {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const cls = objc.objc_getClass(class_name) orelse return error.ClassNotFound;
+    const sel_kind = objc.sel_registerName("isKindOfClass:") orelse return error.SelectorNotFound;
+    const Fn = *const fn (Id, objc.SEL, Id) callconv(.c) bool;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    return func(obj, sel_kind, cls);
+}
+
+/// `-[NSDictionary objectForKey:]` for the host tests above.
+fn dictValueForKey(allocator: std.mem.Allocator, dict: Id, key: []const u8) !Id {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const ns_key = try objc.createNSString(key, allocator);
+    if (ns_key == null) return error.NativeCallFailed;
+    const sel_obj = objc.sel_registerName("objectForKey:") orelse return error.SelectorNotFound;
+    return objc.msgSendId1(dict, sel_obj, ns_key);
+}
+
+/// `-[NSString length]` — UTF-16 code units, which is what makes it the right
+/// probe for "did the NUL survive": "a\x00b" is three either way.
+fn nsStringLength(ns: Id) !usize {
+    if (!builtin.target.os.tag.isDarwin()) return error.UnsupportedPlatform;
+
+    const sel_length = objc.sel_registerName("length") orelse return error.SelectorNotFound;
+    const Fn = *const fn (Id, objc.SEL) callconv(.c) c_ulong;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    return @intCast(func(ns, sel_length));
+}

--- a/packages/zig/src/ios_async.zig
+++ b/packages/zig/src/ios_async.zig
@@ -1,0 +1,295 @@
+//! The machinery an asynchronous reply needs, built once.
+//!
+//! Everything served so far answers from inside the dispatch: the request id
+//! is on `request_context`'s stack, the reply reads it, done. A completion
+//! handler breaks both halves of that at once — it fires after the dispatch
+//! frame is gone (so the id is no longer anywhere), and it fires on whatever
+//! queue the framework felt like (so `evaluateJavaScript`, which is
+//! main-thread-only, cannot be called from it directly).
+//!
+//! Getting this wrong is not hypothetical; it is the repo's inheritance.
+//! `request_context.current()` returning null in a late reply silently drops
+//! correlation to action-name matching, which hands caller B's answer to
+//! caller A whenever two calls of one action are in flight. And the previous
+//! block implementation was built on the stack and handed to an async API,
+//! with its own doc comment asserting a lifetime ("valid for duration of
+//! call") that async precisely does not honour.
+//!
+//! Three pieces, each chosen for being checkable:
+//!
+//!   - a slot pool that captures {request id, action} at dispatch time, with
+//!     generation counters so a stale or double-firing completion cannot
+//!     resolve a slot that has been reused;
+//!   - completion blocks that are module-level and flagged BLOCK_IS_GLOBAL,
+//!     because `Block_copy` on a global block returns the same pointer —
+//!     no heap copy, no descriptor lifetime, no copy/dispose helpers. Each
+//!     pool slot has its own pre-built block with the slot index baked in,
+//!     which is how a non-capturing block knows who it is;
+//!   - delivery hopped to the main queue with `dispatch_async_f` — the
+//!     function-pointer variant, so the hop itself needs no block at all.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const objc_runtime = @import("objc_runtime.zig");
+const request_context = @import("request_context.zig");
+const bridge_error = @import("bridge_error.zig");
+const compat_mutex = @import("compat_mutex.zig");
+
+const objc = objc_runtime.objc;
+const is_darwin = builtin.target.os.tag.isDarwin();
+
+/// How many async calls may be in flight at once. A page that exceeds this
+/// gets an explicit Busy error, which is an answer — the alternative was a
+/// silently dropped reply.
+pub const max_in_flight = 16;
+
+const Slot = struct {
+    /// Incremented on every acquire and release. A completion carrying a
+    /// stale generation is a late or duplicate fire for a call that has
+    /// already been answered; it must do nothing rather than resolve
+    /// whoever owns the slot now.
+    generation: u32 = 0,
+    in_use: bool = false,
+    /// The id the reply names. -1 for a call the page sent without one.
+    request_id: i64 = -1,
+    /// The action, copied into fixed storage: the dispatch frame's slices are
+    /// dead by the time the completion fires.
+    action_buf: [64]u8 = undefined,
+    action_len: usize = 0,
+    /// What the completion resolved. Written on the firing thread, read on
+    /// the main thread after the dispatch_async_f hop.
+    granted: bool = false,
+};
+
+var slots: [max_in_flight]Slot = @splat(.{});
+var slots_mutex: compat_mutex.Mutex = .{};
+
+/// A slot ticket: which slot, and which lease of it.
+pub const Ticket = struct {
+    index: u5,
+    generation: u32,
+};
+
+/// Capture the current request's identity for a reply that will arrive after
+/// the dispatch is gone. Called from inside the dispatch, which is the only
+/// place `request_context.current()` still means this call.
+///
+/// Null means the pool is full. The caller must answer Busy — returning
+/// silence here would reproduce the exact bug this file exists to prevent.
+pub fn acquire(action: []const u8) ?Ticket {
+    if (action.len > 64) return null;
+
+    slots_mutex.lock();
+    defer slots_mutex.unlock();
+
+    for (&slots, 0..) |*slot, i| {
+        if (slot.in_use) continue;
+        slot.in_use = true;
+        slot.generation +%= 1;
+        slot.request_id = if (request_context.current()) |id| @intCast(id) else -1;
+        @memcpy(slot.action_buf[0..action.len], action);
+        slot.action_len = action.len;
+        return .{ .index = @intCast(i), .generation = slot.generation };
+    }
+    return null;
+}
+
+/// Release without replying — for the error path between acquire and the
+/// framework call, where the caller is about to answer synchronously itself.
+pub fn abandon(ticket: Ticket) void {
+    slots_mutex.lock();
+    defer slots_mutex.unlock();
+    const slot = &slots[ticket.index];
+    if (slot.generation != ticket.generation or !slot.in_use) return;
+    slot.in_use = false;
+    slot.generation +%= 1;
+}
+
+// ---------------------------------------------------------------------------
+// The block pool: one pre-built BOOL-completion block per slot.
+// ---------------------------------------------------------------------------
+
+const BlockDescriptor = extern struct {
+    reserved: c_ulong = 0,
+    size: c_ulong,
+};
+
+/// void (^)(BOOL) — the shape of `requestAccessForMediaType:completionHandler:`
+/// and, with the error parameter ignored by the invoke, close enough to
+/// `requestAuthorizationWithOptions:` that each gets its own invoke below.
+const BoolBlock = extern struct {
+    isa: ?*anyopaque,
+    flags: c_int,
+    reserved: c_int = 0,
+    invoke: *const anyopaque,
+    descriptor: *const BlockDescriptor,
+};
+
+/// 1 << 28. A global block is never copied: `Block_copy` returns the same
+/// pointer. That is the entire trick — no heap block, no copy/dispose pair,
+/// no descriptor lifetime, and the pool's blocks are safely handed to any
+/// API that escapes them.
+const BLOCK_IS_GLOBAL: c_int = 1 << 28;
+
+const bool_block_descriptor = BlockDescriptor{ .size = @sizeOf(BoolBlock) };
+
+extern var _NSConcreteGlobalBlock: anyopaque;
+
+/// The per-slot invokes. Comptime-generated so each block knows its slot
+/// without capturing anything: the index is baked into the function, and the
+/// function is baked into the block.
+fn makeBoolInvoke(comptime index: u5) *const anyopaque {
+    const S = struct {
+        fn invoke(_: *const BoolBlock, granted: bool) callconv(.c) void {
+            completionFired(index, granted);
+        }
+    };
+    return @ptrCast(&S.invoke);
+}
+
+/// void (^)(BOOL, NSError *) — `requestAuthorizationWithOptions:` and friends.
+/// The error object is deliberately unused: the granted flag is the answer
+/// the page's contract carries, and Swift discarded the error here too.
+fn makeBoolErrorInvoke(comptime index: u5) *const anyopaque {
+    const S = struct {
+        fn invoke(_: *const BoolBlock, granted: bool, _: objc.id) callconv(.c) void {
+            completionFired(index, granted);
+        }
+    };
+    return @ptrCast(&S.invoke);
+}
+
+fn makeBlocks(comptime maker: fn (comptime u5) *const anyopaque) [max_in_flight]BoolBlock {
+    var out: [max_in_flight]BoolBlock = undefined;
+    for (&out, 0..) |*b, i| {
+        b.* = .{
+            .isa = &_NSConcreteGlobalBlock,
+            .flags = BLOCK_IS_GLOBAL,
+            .invoke = maker(@intCast(i)),
+            .descriptor = &bool_block_descriptor,
+        };
+    }
+    return out;
+}
+
+var bool_blocks: [max_in_flight]BoolBlock = if (is_darwin) makeBlocks(makeBoolInvoke) else undefined;
+var bool_error_blocks: [max_in_flight]BoolBlock = if (is_darwin) makeBlocks(makeBoolErrorInvoke) else undefined;
+
+/// The block to pass as a `void (^)(BOOL)` completion handler for the call
+/// this ticket was acquired for.
+pub fn boolBlock(ticket: Ticket) *anyopaque {
+    return @ptrCast(&bool_blocks[ticket.index]);
+}
+
+/// The block to pass as a `void (^)(BOOL, NSError *)` completion handler.
+pub fn boolErrorBlock(ticket: Ticket) *anyopaque {
+    return @ptrCast(&bool_error_blocks[ticket.index]);
+}
+
+// ---------------------------------------------------------------------------
+// Firing: any thread → main queue → reply.
+// ---------------------------------------------------------------------------
+
+const dispatch_function_t = *const fn (?*anyopaque) callconv(.c) void;
+extern "c" fn dispatch_async_f(queue: *anyopaque, context: ?*anyopaque, work: dispatch_function_t) void;
+/// `dispatch_get_main_queue()` is a macro over this global.
+extern var _dispatch_main_q: anyopaque;
+
+fn completionFired(index: u5, granted: bool) void {
+    // Record the outcome under the lock, but deliver from the main queue:
+    // the reply ends in `evaluateJavaScript`, which is main-thread-only, and
+    // this may be running on whatever queue the framework chose.
+    {
+        slots_mutex.lock();
+        defer slots_mutex.unlock();
+        const slot = &slots[index];
+        if (!slot.in_use) return; // stale fire for an abandoned slot
+        slot.granted = granted;
+    }
+
+    // The context pointer carries only the slot index; everything else stays
+    // in the slot, guarded by its generation.
+    dispatch_async_f(&_dispatch_main_q, @ptrFromInt(@as(usize, index) + 1), deliverOnMain);
+}
+
+fn deliverOnMain(context: ?*anyopaque) callconv(.c) void {
+    const index: usize = @intFromPtr(context orelse return) - 1;
+
+    var action_buf: [64]u8 = undefined;
+    var action_len: usize = 0;
+    var request_id: i64 = -1;
+    var granted = false;
+    {
+        slots_mutex.lock();
+        defer slots_mutex.unlock();
+        const slot = &slots[index];
+        if (!slot.in_use) return;
+        action_len = slot.action_len;
+        @memcpy(action_buf[0..action_len], slot.action_buf[0..action_len]);
+        request_id = slot.request_id;
+        granted = slot.granted;
+        slot.in_use = false;
+        slot.generation +%= 1;
+    }
+
+    const action = action_buf[0..action_len];
+
+    // Restore the identity captured at dispatch, so the reply names the call
+    // that is actually waiting — the whole point of this file.
+    request_context.push(if (request_id < 0) null else @intCast(request_id));
+    defer request_context.pop();
+
+    bridge_error.sendResultToJS(
+        std.heap.c_allocator,
+        action,
+        if (granted) "\"granted\"" else "\"denied\"",
+    );
+}
+
+const testing = std.testing;
+
+test "acquire captures the current request id, release makes the slot reusable" {
+    request_context.push(42);
+    defer request_context.pop();
+
+    const ticket = acquire("requestPermission") orelse return error.PoolUnexpectedlyFull;
+    try testing.expectEqual(@as(i64, 42), slots[ticket.index].request_id);
+    try testing.expectEqualStrings("requestPermission", slots[ticket.index].action_buf[0..slots[ticket.index].action_len]);
+
+    abandon(ticket);
+    try testing.expect(!slots[ticket.index].in_use);
+}
+
+test "a stale ticket cannot abandon a slot that was re-leased" {
+    const first = acquire("a") orelse return error.PoolUnexpectedlyFull;
+    abandon(first);
+
+    // Re-lease the same slot; the old ticket's generation is now stale.
+    const second = acquire("b") orelse return error.PoolUnexpectedlyFull;
+    defer abandon(second);
+
+    abandon(first); // must be a no-op
+    try testing.expect(slots[second.index].in_use);
+}
+
+test "the pool exhausts loudly rather than silently" {
+    var tickets: [max_in_flight]Ticket = undefined;
+    var n: usize = 0;
+    defer for (tickets[0..n]) |t| abandon(t);
+
+    while (n < max_in_flight) : (n += 1) {
+        tickets[n] = acquire("x") orelse break;
+    }
+    // Whatever other tests leased, the pool must end by refusing with null —
+    // never by handing out a slot it does not have.
+    try testing.expect(acquire("one-too-many") == null);
+}
+
+test "an action longer than the slot's storage is refused at acquire" {
+    // Truncating it instead would make the eventual reply name a different
+    // action than the page called — correlation by wrong name, reported as
+    // success.
+    // (`**` no longer lexes as one operator in this Zig; @splat says the same.)
+    const long: [65]u8 = @splat('a');
+    try testing.expect(acquire(&long) == null);
+}

--- a/packages/zig/src/ios_dispatch.zig
+++ b/packages/zig/src/ios_dispatch.zig
@@ -11,6 +11,11 @@ const bridge_mobile_device = @import("bridge_mobile_device.zig");
 const bridge_mobile_system = @import("bridge_mobile_system.zig");
 const bridge_mobile_display = @import("bridge_mobile_display.zig");
 const bridge_mobile_storage = @import("bridge_mobile_storage.zig");
+const bridge_mobile_misc = @import("bridge_mobile_misc.zig");
+const bridge_mobile_shortcuts = @import("bridge_mobile_shortcuts.zig");
+const bridge_mobile_securestore = @import("bridge_mobile_securestore.zig");
+const bridge_mobile_biometric = @import("bridge_mobile_biometric.zig");
+const bridge_mobile_permissions = @import("bridge_mobile_permissions.zig");
 
 const objc = objc_runtime.objc;
 
@@ -203,6 +208,11 @@ const mobile_bridges = .{
     bridge_mobile_system.SystemBridge,
     bridge_mobile_display.DisplayBridge,
     bridge_mobile_storage.StorageBridge,
+    bridge_mobile_misc.MiscBridge,
+    bridge_mobile_shortcuts.ShortcutsBridge,
+    bridge_mobile_securestore.SecureStoreBridge,
+    bridge_mobile_biometric.BiometricStoreBridge,
+    bridge_mobile_permissions.PermissionsBridge,
 };
 
 /// Narrow an arbitrary handler error to one the page's error codes can express.

--- a/packages/zig/src/ios_dispatch.zig
+++ b/packages/zig/src/ios_dispatch.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 const objc_runtime = @import("objc_runtime.zig");
 const request_context = @import("request_context.zig");
 const bridge_error = @import("bridge_error.zig");
+pub const ios_async = @import("ios_async.zig");
 const bridge_mobile = @import("bridge_mobile.zig");
 const bridge_mobile_clipboard = @import("bridge_mobile_clipboard.zig");
 const bridge_mobile_haptics = @import("bridge_mobile_haptics.zig");
@@ -353,6 +354,10 @@ fn buildShimError(
         try out.print(allocator, "{d}", .{request_id});
     }
     try out.append(allocator, '}');
+}
+
+test {
+    _ = ios_async;
 }
 
 const testing = std.testing;

--- a/packages/zig/test/ios_conformance_test.zig
+++ b/packages/zig/test/ios_conformance_test.zig
@@ -31,6 +31,11 @@ const zig_sources = [_][]const u8{
     @embedFile("src/bridge_mobile_system.zig"),
     @embedFile("src/bridge_mobile_display.zig"),
     @embedFile("src/bridge_mobile_storage.zig"),
+    @embedFile("src/bridge_mobile_misc.zig"),
+    @embedFile("src/bridge_mobile_shortcuts.zig"),
+    @embedFile("src/bridge_mobile_securestore.zig"),
+    @embedFile("src/bridge_mobile_biometric.zig"),
+    @embedFile("src/bridge_mobile_permissions.zig"),
 };
 
 /// The action list lives in the `switch action` block, and nowhere else.
@@ -54,8 +59,10 @@ const dispatch_end = "func webView(";
 /// exists to force.
 ///
 /// History: 105 after the vertical slice (getDeviceInfo); 86 after Tier 0
-/// landed clipboard, haptics, device, system, display, and storage.
-const max_not_yet_migrated: usize = 86;
+/// landed clipboard, haptics, device, system, display, and storage; 74 after
+/// the secure tier landed flashlight, shortcuts, the Keychain secure store,
+/// biometric persistence, and permissions — including the first async reply.
+const max_not_yet_migrated: usize = 74;
 
 fn dispatcherRegion() []const u8 {
     const begin = std.mem.indexOf(u8, swift_spec, dispatch_begin) orelse return "";


### PR DESCRIPTION
Follow-on to #85. Twelve more actions cross into Zig, including the **first asynchronous reply**, and the fixture now round-trips a secret through the real Keychain.

## The async foundation (`ios_async.zig`)

The plan flagged async replies as the highest-risk item after Phase 1: a completion handler fires after the dispatch frame is gone (the request id is no longer anywhere) and on whatever queue the framework chose (`evaluateJavaScript` is main-thread-only). Losing the id silently drops correlation to action-name matching — caller B's answer handed to caller A whenever two calls of one action are in flight.

Three pieces, each checkable:
- a **slot pool** capturing `{request id, action}` at dispatch time, with generation counters so a stale or double-firing completion cannot resolve a reused slot;
- completion blocks that are **`BLOCK_IS_GLOBAL`** — `Block_copy` on a global block returns the same pointer, so no heap copy, no descriptor lifetime, no copy/dispose. Each slot has its own comptime-generated invoke with the index baked in: how a non-capturing block knows who it is;
- delivery hopped to the main queue with **`dispatch_async_f`** — the function-pointer variant, so the hop itself needs no block.

The pool exhausts loudly (`acquire` → null obliges a Busy reply), and an action longer than slot storage is refused rather than truncated — a truncated name would make the reply name a different action than the page called.

## Five modules, 12 actions

| module | actions |
|---|---|
| misc | setFlashlight |
| shortcuts | setShortcuts, clearShortcuts |
| securestore | secureSet, secureGet, secureRemove, secureClear |
| biometric | setBiometricPersistence, checkBiometricPersistence, clearBiometricPersistence |
| permissions | checkPermission, **requestPermission** (async, on ios_async) |

**Deliberately not served:** getInitialURL, registerDeepLinkHandler, takeScreenshot, openSettings stay with the Swift shim. Their Swift arms are config-gated (`enableDeepLinks`, `enableScreenCapture`) and no config channel into Zig exists yet — declaring them `.unavailable` would make Zig dispatch-and-refuse, *stealing* them from the shim that serves them correctly today. Falling through is the honest routing.

The adversarial review pass caught another lawful-payload refusal before it shipped: floats rendered with `{d}` into a `[64]u8` buffer, when `{d}` on f64 needs up to **347 bytes** — `{"x":1e300}` failed as `NativeCallFailed`. Sized by `std.fmt.float.bufferSize` now, pinned by a test.

## The Keychain on a simulator, reverse-engineered

The fixture's tenth assertion round-trips a secret containing a quote and a backslash through real `SecItemAdd`/`SecItemCopyMatching`, byte-identical. Getting it to run surfaced a mechanism worth recording:

- unsigned app → `SecItemAdd` fails with `errSecMissingEntitlement` (-34018)
- signing `application-identifier` entitlements **in** → the launch itself is denied (POSIX 163 from RunningBoard; bisected — the same signature without them launches)
- the simulator's actual mechanism, which Xcode uses: identity entitlements live in a **`__TEXT,__entitlements` Mach-O section**, not the signature

The harness now embeds the identity via `-sectcreate` and signs ad-hoc — matching what a real simulator build carries.

## Verification

All ten fixture assertions on an iPhone 17 Pro simulator (iOS 26.5):

```
ok: page -> native … ok: error route closed with escaping intact
ok: Tier-0 action served by Zig with a live UIKit value
ok: secureSet/secureGet round-tripped a secret through the Keychain
PASS
```

Plus `zig build test` / `test:ios` / desktop / `build-ios` / `build-ios-simulator` / `build-android`, `zig fmt --check`, `verify:cimports`, `pickier`. The conformance ratchet is at **74** and only goes down.