### PR TITLE
iOS Phase 9: calendar and contacts — ratchet 53 → 48

### DIFF
--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -467,6 +467,15 @@ pub fn build(b: *std.Build) void {
     ios_conformance_tests.root_module.addAnonymousImport("src/bridge_mobile_contactpicker.zig", .{
         .root_source_file = b.path("src/bridge_mobile_contactpicker.zig"),
     });
+    ios_conformance_tests.root_module.addAnonymousImport("src/bridge_mobile_calendar.zig", .{
+        .root_source_file = b.path("src/bridge_mobile_calendar.zig"),
+    });
+    ios_conformance_tests.root_module.addAnonymousImport("src/bridge_mobile_contacts.zig", .{
+        .root_source_file = b.path("src/bridge_mobile_contacts.zig"),
+    });
+    ios_conformance_tests.root_module.addAnonymousImport("src/bridge_mobile_speech.zig", .{
+        .root_source_file = b.path("src/bridge_mobile_speech.zig"),
+    });
 
     const menubar_tests = b.addTest(.{
         .root_module = b.createModule(.{

--- a/packages/zig/src/bridge_mobile_calendar.zig
+++ b/packages/zig/src/bridge_mobile_calendar.zig
@@ -1,0 +1,2392 @@
+//! `getCalendarEvents`, `createCalendarEvent`, `deleteCalendarEvent` — EventKit,
+//! ported from `CraftApp.swift:716-731` (dispatch) and `3289-3361` (the three
+//! implementations). Every claim below is measured against those lines.
+//!
+//! Three actions, three different reply shapes, and one of them is not even
+//! asynchronous. Nothing here emits: there is no `sendToWeb(` anywhere in
+//! `CraftApp.swift:3289-3361`, no calendar member in `ios_events.Event`, and no
+//! `craftCalendar*` event name on the iOS side at all — the one
+//! `_craftCalendarResolve` the repo does contain is the *Android* template's
+//! promise holder (`packages/android/templates/CraftBridge.kt.template:397`),
+//! not something `dispatchEvent` ever carries. So `ios_events` is deliberately
+//! not imported. There is no runtime delegate either — EventKit answers through a
+//! completion block, not a protocol — so `ios_delegate` is not imported.
+//!
+//! ## The payloads, field by field, from the injected JS
+//!
+//! The only page surface is `window.craft.calendar.*` (`CraftApp.swift:1783-1808`).
+//! There are no flat aliases; `packages/ios/README.md:329-341`,
+//! `packages/typescript/types/craft.d.ts:282-295` and both
+//! `templates/test-bridges.html:831,842` document and call a
+//! `window.craft.getCalendarEvents(...)` that has never existed. Those harness
+//! tests throw `TypeError` inside their own `try` and never reach the bridge, so
+//! the harness gives **zero** evidence about anything here. The contract below
+//! comes from `resolveCallback`/`rejectCallback` and `.fragmentsAllowed`, which
+//! is what actually runs.
+//!
+//!   - `getCalendarEvents` posts `{startDate, endDate}` **top-level**, read as
+//!     `body["startDate"] as? Double`. They are **milliseconds**: Swift divides
+//!     by 1000 to make an `NSTimeInterval` (3297-3298).
+//!   - `createCalendarEvent` posts `{event: {...}}` — a **nested object**, whose
+//!     keys are `title`, `location`, `notes`, `startDate`, `endDate`, `isAllDay`.
+//!   - `deleteCalendarEvent` posts `{eventId}` top-level, a string.
+//!
+//! `callbackId` is the shim's own correlation and never reaches a Zig module;
+//! `ios_async` owns the request id here.
+//!
+//! **None of these promises has a timeout.** All three are hand-built
+//! `new Promise` (1788, 1796, 1804) rather than going through `_createCallback`
+//! (1196-1210, the only thing carrying the 30-second `setTimeout`). An
+//! unanswered call parks the page forever, which is why every path in this file
+//! ends in a reply or an error.
+//!
+//! ## One rule for wrong-typed fields, applied everywhere
+//!
+//! Swift reads every field through `as? T`, which yields nil for the wrong type
+//! and then falls back to a default — `?? ""`, `?? false`, `Date()`, or "leave
+//! the property unset". That means `craft.calendar.getEvents('2024-01-01')`
+//! silently returns events from **now to now + 1 month**, and the page cannot
+//! tell. So:
+//!
+//!   - **Absent, or JSON `null`** → Swift's documented default, reproduced
+//!     exactly. That is the real contract and it is honoured.
+//!   - **Present and of a type `as? T` accepts** → accepted identically,
+//!     including the `NSNumber`-as-`Bool` rule where only `0` and `1` are
+//!     booleans (the same rule `bridge_mobile_contactpicker.zig:448-460` spells
+//!     out for `multiple`).
+//!   - **Present and of a type `as? T` rejects** → `INVALID_PARAMETER`, naming
+//!     the field, rather than the shim's silent default. This is a divergence
+//!     and it is deliberate: a range the page did not ask for, answered as
+//!     success, is the wrong-answer-reported-as-success class this migration
+//!     exists to remove. `bridge_mobile_motion.zig:760-775` made the same call
+//!     for `interval`.
+//!
+//! One case is not a preference but a limit: `true as? Double` on a
+//! `__NSCFBoolean` is a genuine wart whose answer differs between Foundation
+//! versions and is not settled here. `{"startDate":true}` is refused rather than
+//! guessed at in either direction; it is nonsense on any reading.
+//!
+//! A string containing an embedded NUL is also refused. `stringWithUTF8String:`
+//! stops at the NUL, so carrying it across would silently create an event with a
+//! truncated title, where Swift's `as? String` preserves the whole thing.
+//!
+//! The same refusal applies in the *outbound* direction, and it is coarser
+//! there: `readString` compares `UTF8String`'s NUL-terminated bytes against
+//! `lengthOfBytesUsingEncoding:`, so an existing calendar event whose title
+//! contains U+0000 fails the whole `getCalendarEvents` call rather than one row.
+//! Swift's `JSONSerialization` would have carried it. Reporting a prefix as the
+//! whole title is the one thing worse than failing, and a partial list is the
+//! other; this is the same call `bridge_mobile_notifications.zig` and
+//! `bridge_mobile_contactpicker.zig` already made.
+//!
+//! ## The three reply shapes, from `resolveCallback` + `.fragmentsAllowed`
+//!
+//!   - **`getCalendarEvents` resolves a bare JSON array of objects** (3303-3315),
+//!     seven keys each, **always all seven present**: `id`, `title`, `location`,
+//!     `notes`, `startDate`, `endDate`, `isAllDay`. `location` and `notes` are
+//!     `""` when the event has none — never omitted and never `null`, whatever
+//!     `craft.d.ts:1174-1183` says with its `location?: string`. The runtime is
+//!     the contract. `startDate`/`endDate` are **fractional milliseconds**.
+//!     Swift's `[String: Any]` has no key order at all, so one is fixed here to
+//!     make the bytes testable — the same call `shapeFix` makes in
+//!     `bridge_mobile_location.zig:611`. An empty result is `[]` and **resolves**.
+//!   - **`createCalendarEvent` resolves a bare JSON string** — the new
+//!     `eventIdentifier` (3342) — **or bare `null`**. `EKEvent.eventIdentifier`
+//!     is `String!`, and a nil implicitly-unwrapped optional coerced to `Any`
+//!     becomes `Optional<String>.none`, which `.fragmentsAllowed` renders as
+//!     `null`. Same path `bridge_mobile_securestore.zig:23-24` documents for
+//!     `secureGet`.
+//!   - **`deleteCalendarEvent` resolves bare `true`** (3357), not `undefined`.
+//!     `craft.d.ts:295` declares `Promise<void>`; the wire value is `true`.
+//!
+//! ### The `payload || {}` hazard, which bites exactly one value
+//!
+//! Zig replies through `bridge_error.sendResultToJS` →
+//! `window.__craftBridgeResult`, and `js/craft-bridge.js:80` resolves
+//! `payload || {}`. Through **this** route a falsy fragment is coerced:
+//! `null → {}`. Swift's own `window.craft._resolveCallback` route does not do
+//! that. So a `createCalendarEvent` whose save succeeded but whose
+//! `eventIdentifier` came back nil hands the page `{}` rather than `null`.
+//!
+//! `null` is still sent, deliberately. The alternatives are worse: rejecting
+//! would tell the page the event was **not** created when it **was** — the
+//! mirror image of fabricated success — and substituting `""` is swallowed by
+//! `|| {}` just the same while also being a lie about the identifier. A
+//! synthetic id would be a lie the page could act on. This is written down
+//! rather than papered over.
+//!
+//! ## What each action actually does, and where it diverges
+//!
+//! **Both read paths request access with the deprecated
+//! `requestAccessToEntityType:completion:`**, matching Swift 3291/3320, which has
+//! **no `if #available` fork** — unlike `requestPermission`
+//! (`CraftApp.swift:2852-2867`, which does fork to
+//! `requestFullAccessToEvents`). Matching is not laziness: `packages/ios/src/index.ts:190`
+//! writes **only** `NSCalendarsUsageDescription`, and
+//! `requestFullAccessToEventsWithCompletion:` requires
+//! `NSCalendarsFullAccessUsageDescription`, which nothing in this repo ever
+//! writes. Calling the iOS 17 API would terminate the app. (Swift's own
+//! `requestPermission("calendar")` arm has that latent crash; it is not
+//! replicated here.)
+//!
+//! **The Info.plist key is a hard precondition for the two async actions, not
+//! merely evidence of a config flag.** `requestAccessToEntityType:` in a process
+//! whose Info.plist lacks the usage description raises
+//! `NSInternalInconsistencyException`, which from Zig is an uncatchable SIGABRT.
+//! So the gate runs **before** the store is ever touched. This is where the
+//! wording deliberately differs from `bridge_mobile_contactpicker.zig`, whose
+//! `CNContactPickerViewController` genuinely needs no authorization. For
+//! `deleteCalendarEvent` — which requests nothing (3350) — the key is only
+//! evidence of `config.enableCalendar`, and it is checked for that reason.
+//!
+//! **`config.enableCalendar` has no Zig mirror**, the same gap
+//! `bridge_mobile_contactpicker.zig` records for `enableContacts`. The plist key
+//! `packages/ios/src/index.ts:190` writes iff that flag is the stand-in, and the
+//! mapping is exact — nothing else writes or shares it.
+//!
+//! **Behaviour changes on every disabled or malformed path, in Zig's favour.**
+//! Swift's three cases have no `else` (717-731): an app with
+//! `enableCalendar: false`, a `createCalendarEvent` with no `event` object, and a
+//! `deleteCalendarEvent` with no `eventId` string all answer the page with
+//! **nothing**, on a promise with no timeout — a hang for the life of the page.
+//! Here they are `PERMISSION_DENIED`, `MISSING_DATA` and `MISSING_DATA`.
+//! Everybody settles, which is strictly better, and it is observable.
+//!
+//! **A permission denial rejects `PERMISSION_DENIED`, not `NATIVE_CALL_FAILED`.**
+//! `ios_async.deliverErrorCode` exists for exactly this. The message is
+//! byte-identical to `createCalendarEvent`'s (3322) and to `getCalendarEvents`'
+//! fallback (3293); the code changes from Swift's default `CRAFT_ERROR`, which is
+//! the accurate cause rather than the historical one.
+//! `getCalendarEvents`' other variant — `error?.localizedDescription`, a
+//! localised EventKit string — is **not** reproducible through `BridgeError` and
+//! is not claimed: it goes to the log instead.
+//!
+//! **`deleteCalendarEvent` requests no permission, and that is reproduced
+//! faithfully even though it is misleading.** `eventWithIdentifier:` returns nil
+//! both for an absent event and for an unauthorized store, so on a fresh install
+//! every delete says "Event not found" (`NOT_FOUND` here). Adding a permission
+//! request would show the user a prompt at a moment the shim never shows one.
+//!
+//! **A save that fails is refused with the reason logged, never pre-empted.**
+//! `defaultCalendarForNewEvents` can be nil on a freshly-erased simulator or a
+//! device with no writable calendar; Swift assigns it unconditionally (3338) and
+//! lets `saveEvent:span:error:` fail with "No calendar has been set". The same
+//! happens for a missing start or end date, which is why absent nested dates are
+//! **not** given a default here. In every case the `NSError` goes to the log and
+//! the page gets `NATIVE_CALL_FAILED`; there is no fallback to "the first
+//! writable calendar", which would write the event somewhere the shim would not.
+//!
+//! **A fetched event with a nil `startDate` or `endDate` rejects rather than
+//! crashing.** Swift's `event.startDate.timeIntervalSince1970` force-unwraps an
+//! implicitly-unwrapped optional. Zig cannot fabricate a `0` there — that would
+//! be an event dated 1970 reported as real — so the whole reply is refused with
+//! the event's id in the log.
+//!
+//! `CraftApp.swift:3301` also force-unwraps `predicate!` inside a `[weak self]`
+//! closure, which crashes if the coordinator died first. Zig has no `self` and
+//! no such hazard; the nil is checked instead of translated.
+//!
+//! ## Concurrency: a side table, not a single slot
+//!
+//! The completion block is global (`BLOCK_IS_GLOBAL`, so `Block_copy` is the
+//! identity and escaping it to EventKit costs no heap lifetime), which means it
+//! captures nothing and knows only the slot index baked into its comptime
+//! invoke. Two things therefore live in a per-slot side table: the ticket, and
+//! the request parameters the completion still needs — the millisecond range for
+//! a fetch, or the parsed event for a save. That is
+//! `bridge_mobile_notifications.zig:481-533`'s pattern exactly.
+//!
+//! A *single* pending slot, as `bridge_mobile_contactpicker.zig` uses, would be
+//! wrong here: there is no on-screen picker making concurrency impossible, and
+//! two `getCalendarEvents` in flight is an ordinary page. The table is one entry
+//! per `ios_async` slot, mutex-guarded, and a full pool is an explicit refusal
+//! rather than silence.
+//!
+//! The strings a pending `createCalendarEvent` owns are allocated from
+//! `std.heap.c_allocator` at dispatch and freed by the completion, because the
+//! dispatcher's allocator is not guaranteed to outlive the frame and the
+//! completion runs long after it is gone.
+//!
+//! No reply is ever sent from the completion directly. `ios_async` is the only
+//! channel, and its main-queue hop is not merely thread safety: it restores the
+//! `request_context` captured at dispatch, so the reply names the call that is
+//! waiting instead of falling back to action-name matching.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const capabilities = @import("capabilities.zig");
+const bridge_error = @import("bridge_error.zig");
+const objc_runtime = @import("objc_runtime.zig");
+const ios_async = @import("ios_async.zig");
+const compat_mutex = @import("compat_mutex.zig");
+const memory = @import("memory.zig");
+
+const objc = objc_runtime.objc;
+const is_darwin = builtin.target.os.tag.isDarwin();
+
+/// The same type as `objc.id` — `?*anyopaque` — spelled locally, per the
+/// location/notifications/contactpicker precedent: `objc_runtime.objc` is an
+/// empty struct off Darwin and a function *signature* is analysed even when a
+/// comptime platform guard prunes the body, so naming `objc.id` in the
+/// `callconv(.c)` types below would break the host build. A single optional
+/// pointer, never `?objc.id` — a double optional is illegal in `callconv(.c)`.
+const Id = ?*anyopaque;
+
+/// The action names, spelled exactly as the Swift `case` labels spell them.
+/// `test/ios_conformance_test.zig` matches this block against those labels in
+/// both directions, and fails the build if two modules declare one name.
+pub const A = struct {
+    pub const get_calendar_events = "getCalendarEvents";
+    pub const create_calendar_event = "createCalendarEvent";
+    pub const delete_calendar_event = "deleteCalendarEvent";
+};
+
+/// All three are `.result`: every Swift path out of every one of them ends in
+/// exactly one `resolveCallback` or one `rejectCallback`. `.none` would be a
+/// claim that nothing answers, and on these particular promises — hand-built, no
+/// `setTimeout` — that is a page parked forever rather than for thirty seconds.
+///
+/// All three are `.live`, not `.unavailable`: in an app built with
+/// `enableCalendar` all three work. A refusal here is always a specific
+/// condition (calendar not configured, EventKit not linked, permission denied,
+/// the async pool full), never the normal answer. `.unavailable` would make Zig
+/// dispatch and then refuse an action the shim serves.
+pub const capability_actions = [_]capabilities.ActionDecl{
+    .{ .name = A.get_calendar_events, .reply = .result },
+    .{ .name = A.create_calendar_event, .reply = .result },
+    .{ .name = A.delete_calendar_event, .reply = .result },
+};
+
+/// Which handler an action selects, split out from `handleMessage` so the
+/// table-versus-dispatch agreement is assertable on a host without touching
+/// EventKit.
+const Route = enum { get_events, create_event, delete_event };
+
+fn routeFor(action: []const u8) ?Route {
+    if (std.mem.eql(u8, action, A.get_calendar_events)) return .get_events;
+    if (std.mem.eql(u8, action, A.create_calendar_event)) return .create_event;
+    if (std.mem.eql(u8, action, A.delete_calendar_event)) return .delete_event;
+    return null;
+}
+
+pub const CalendarBridge = struct {
+    allocator: std.mem.Allocator,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator) Self {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(_: *Self) void {}
+
+    pub fn handleMessage(self: *Self, action: []const u8, data: []const u8) !void {
+        const route = routeFor(action) orelse return bridge_error.BridgeError.UnknownAction;
+        // Exhaustive, so a `Route` without a handler is a compile error.
+        return switch (route) {
+            .get_events => self.getCalendarEvents(data),
+            .create_event => self.createCalendarEvent(data),
+            .delete_event => self.deleteCalendarEvent(data),
+        };
+    }
+
+    /// `eventStore.requestAccess(to: .event) { … predicateForEvents … }`.
+    ///
+    /// Ordering is load-bearing. The payload is parsed **first**, so a malformed
+    /// body is reported the same on any platform and before any framework is
+    /// consulted. Then the Info.plist precondition, then every class and
+    /// selector the completion will need — all of it **before**
+    /// `ios_async.acquire`, because a completion has no way to report a failed
+    /// `sel_registerName` as anything but a log line. After the lease there are
+    /// exactly two statements, both infallible: publish the side-table entry
+    /// (which the completion reads), then make the framework call. A lease that
+    /// escaped without either would narrow the pool for the life of the process.
+    ///
+    /// The two `NSDate`s are built **inside** the completion rather than here,
+    /// which is where Swift builds them (3297-3298). It matters: the user may
+    /// spend seconds on the permission sheet, and "now" means now-when-granted
+    /// in the shim.
+    fn getCalendarEvents(self: *Self, data: []const u8) !void {
+        const range = try parseRange(self.allocator, data);
+
+        if (!is_darwin) return error.UnsupportedPlatform;
+
+        try requireCalendarConfigured(A.get_calendar_events);
+
+        const sels = try Sels.resolve(A.get_calendar_events);
+        const store = try ensureStore(A.get_calendar_events);
+
+        const ticket = ios_async.acquire(A.get_calendar_events) orelse
+            return poolFull(A.get_calendar_events);
+
+        // Published *before* the framework call, never after:
+        // `requestAccessToEntityType:` may invoke its completion synchronously
+        // when access is already granted, and a completion that found an empty
+        // entry would have no ticket to reply with.
+        publishPendingCall(ticket, sels, store, .{ .fetch = range });
+
+        requestAccess(store, sels, ticket);
+    }
+
+    /// `eventStore.requestAccess(to: .event) { … EKEvent … save … }`.
+    ///
+    /// Same ordering discipline as the fetch, plus one ownership rule: the
+    /// parsed event's strings are allocated from `std.heap.c_allocator` — the
+    /// allocator the completion frees them with — and the `errdefer` releases
+    /// them on every path that leaves before the side table takes ownership.
+    ///
+    /// That is also why `self.allocator` goes unused here, unlike in the other
+    /// two handlers: the dispatcher's allocator is not promised to outlive this
+    /// frame, and the completion runs long after it is gone.
+    fn createCalendarEvent(_: *Self, data: []const u8) !void {
+        // Not `self.allocator`: this outlives the dispatch frame, and
+        // `ios_async` delivers on `std.heap.c_allocator` too.
+        const owner = std.heap.c_allocator;
+        const new_event = try parseNewEvent(owner, data);
+        errdefer new_event.deinit(owner);
+
+        if (!is_darwin) return error.UnsupportedPlatform;
+
+        try requireCalendarConfigured(A.create_calendar_event);
+
+        const sels = try Sels.resolve(A.create_calendar_event);
+        const store = try ensureStore(A.create_calendar_event);
+
+        const ticket = ios_async.acquire(A.create_calendar_event) orelse
+            return poolFull(A.create_calendar_event);
+
+        // Ownership of `new_event`'s strings moves into the side table here.
+        publishPendingCall(ticket, sels, store, .{ .create = new_event });
+
+        requestAccess(store, sels, ticket);
+    }
+
+    /// `eventStore.event(withIdentifier:)` then `remove(_:span:)`.
+    ///
+    /// Fully synchronous — Swift requests no access here (3350) — so there is no
+    /// ticket, no block and no side table. The reply goes out on this frame,
+    /// where `request_context` still names the call, exactly as
+    /// `bridge_mobile_clipboard.zig` replies.
+    fn deleteCalendarEvent(self: *Self, data: []const u8) !void {
+        const event_id = try parseEventId(self.allocator, data);
+        defer self.allocator.free(event_id);
+
+        if (!is_darwin) return error.UnsupportedPlatform;
+
+        try requireCalendarConfigured(A.delete_calendar_event);
+
+        const sels = try Sels.resolve(A.delete_calendar_event);
+        const store = try ensureStore(A.delete_calendar_event);
+
+        const ns_id = try makeString(sels, self.allocator, event_id);
+
+        const FindFn = *const fn (Id, Id, Id) callconv(.c) Id;
+        const find: FindFn = @ptrCast(&objc.objc_msgSend);
+        const event = find(store, sels.event_with_identifier, ns_id) orelse {
+            // Also what an *unauthorized* store answers, because this path never
+            // requests access. Misleading, and the shim's exact behaviour; see
+            // the module comment for why a prompt is not added here.
+            std.log.info(
+                "deleteCalendarEvent: no event with that identifier (an unauthorized " ++
+                    "store answers the same way, since this action requests no access)",
+                .{},
+            );
+            return bridge_error.BridgeError.NotFound;
+        };
+
+        var ns_error: Id = null;
+        const RemoveFn = *const fn (Id, Id, Id, c_long, ?*Id) callconv(.c) bool;
+        const remove: RemoveFn = @ptrCast(&objc.objc_msgSend);
+        if (!remove(store, sels.remove_event, event, ek_span_this_event, &ns_error)) {
+            logNativeError("deleteCalendarEvent: removeEvent:span:error: failed", ns_error, sels);
+            return bridge_error.BridgeError.NativeCallFailed;
+        }
+
+        bridge_error.sendResultToJS(self.allocator, A.delete_calendar_event, true_fragment);
+    }
+};
+
+/// `-[EKEventStore requestAccessToEntityType:completion:]` with this ticket's
+/// pre-built global block. Infallible by construction: the store, the selector
+/// and the block all exist by the time this is reached.
+fn requestAccess(store: Id, sels: Sels, ticket: ios_async.Ticket) void {
+    if (!is_darwin) return;
+
+    const RequestFn = *const fn (Id, Id, c_ulong, ?*anyopaque) callconv(.c) void;
+    const request: RequestFn = @ptrCast(&objc.objc_msgSend);
+    request(store, sels.request_access, ek_entity_type_event, accessBlock(ticket));
+}
+
+/// The answer for a full block pool, copied from `bridge_mobile_location`:
+/// `BridgeError` has no "Busy", `INVALID_PARAMETER` is the migration notes'
+/// designated stand-in, and the point is that the caller gets an explicit
+/// rejection instead of a promise that never settles.
+fn poolFull(action: []const u8) bridge_error.BridgeError {
+    std.log.warn(
+        "{s} refused: all {d} async slots are in flight",
+        .{ action, ios_async.max_in_flight },
+    );
+    return bridge_error.BridgeError.InvalidParameter;
+}
+
+// =============================================================================
+// Payload parsing. Pure — no Objective-C — so the exact coercions Swift performs
+// are pinned by host tests on every platform.
+// =============================================================================
+
+/// `getCalendarEvents`' two top-level fields, still in **milliseconds**.
+///
+/// Kept as milliseconds rather than converted here because the division by 1000
+/// is Swift's (3297-3298) and belongs next to the `NSDate` it feeds; a struct
+/// holding "seconds" that was filled from a millisecond wire value is exactly
+/// the kind of unit slip nothing catches.
+const Range = struct {
+    start_ms: ?f64 = null,
+    end_ms: ?f64 = null,
+};
+
+/// The nested `event` object, with every string owned by the caller's allocator.
+///
+/// The optionals are three-state on the wire and two-state here: absent and
+/// JSON `null` both become `null`, which is what Swift's `as? String` produces
+/// and what sets the `EKEvent` property to nil. A *wrongly typed* value never
+/// reaches this struct — `parseNewEvent` refuses it.
+const NewEvent = struct {
+    /// `data["title"] as? String ?? ""` — never null.
+    title: []const u8,
+    location: ?[]const u8,
+    notes: ?[]const u8,
+    /// Absent stays absent. Swift's `if let` leaves `EKEvent.startDate` nil and
+    /// `saveEvent:span:error:` then fails with "No start date has been set";
+    /// inventing a default here would create an event the shim refuses to.
+    start_ms: ?f64,
+    end_ms: ?f64,
+    all_day: bool,
+
+    fn deinit(self: NewEvent, allocator: std.mem.Allocator) void {
+        allocator.free(self.title);
+        if (self.location) |s| allocator.free(s);
+        if (self.notes) |s| allocator.free(s);
+    }
+};
+
+/// A malformed or non-object `d` is `InvalidJSON` rather than a silent default.
+/// It is a Zig-only failure mode — `WKScriptMessage.body` is always a dictionary,
+/// so Swift never meets it — but guessing for a body that could not be read
+/// would be acting on values the page did not send.
+fn parseRange(allocator: std.mem.Allocator, data: []const u8) !Range {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch
+        return bridge_error.BridgeError.InvalidJSON;
+    defer parsed.deinit();
+
+    const root = switch (parsed.value) {
+        .object => |obj| obj,
+        else => return bridge_error.BridgeError.InvalidJSON,
+    };
+
+    return .{
+        .start_ms = try millisecondsFrom(root.get("startDate"), "startDate"),
+        .end_ms = try millisecondsFrom(root.get("endDate"), "endDate"),
+    };
+}
+
+fn parseNewEvent(allocator: std.mem.Allocator, data: []const u8) !NewEvent {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch
+        return bridge_error.BridgeError.InvalidJSON;
+    defer parsed.deinit();
+
+    const root = switch (parsed.value) {
+        .object => |obj| obj,
+        else => return bridge_error.BridgeError.InvalidJSON,
+    };
+
+    // `body["event"] as? [String: Any]` failing makes Swift's whole `case` body
+    // not run, which answers the page with nothing on an untimed promise. Two
+    // distinct causes, reported distinctly rather than collapsed.
+    const event_value = root.get("event") orelse {
+        std.log.warn("createCalendarEvent refused: the message carried no 'event' object", .{});
+        return bridge_error.BridgeError.MissingData;
+    };
+    const event = switch (event_value) {
+        .object => |obj| obj,
+        .null => {
+            std.log.warn("createCalendarEvent refused: 'event' was null", .{});
+            return bridge_error.BridgeError.MissingData;
+        },
+        else => {
+            std.log.warn("createCalendarEvent refused: 'event' is not an object", .{});
+            return bridge_error.BridgeError.InvalidParameter;
+        },
+    };
+
+    // Built field by field with an errdefer per owned string, so a refusal in a
+    // later field does not leak an earlier one.
+    const title = (try ownedStringFrom(allocator, event.get("title"), "event.title")) orelse
+        try allocator.dupe(u8, "");
+    errdefer allocator.free(title);
+
+    const location = try ownedStringFrom(allocator, event.get("location"), "event.location");
+    errdefer if (location) |s| allocator.free(s);
+
+    const notes = try ownedStringFrom(allocator, event.get("notes"), "event.notes");
+    errdefer if (notes) |s| allocator.free(s);
+
+    return .{
+        .title = title,
+        .location = location,
+        .notes = notes,
+        .start_ms = try millisecondsFrom(event.get("startDate"), "event.startDate"),
+        .end_ms = try millisecondsFrom(event.get("endDate"), "event.endDate"),
+        .all_day = try allDayFrom(event.get("isAllDay")),
+    };
+}
+
+/// `body["eventId"] as? String`, owned by the caller.
+///
+/// An empty string is *accepted*: Swift passes it to `event(withIdentifier: "")`,
+/// which answers nil, which is "Event not found". Refusing it here would answer a
+/// different question than the shim answers.
+fn parseEventId(allocator: std.mem.Allocator, data: []const u8) ![]u8 {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch
+        return bridge_error.BridgeError.InvalidJSON;
+    defer parsed.deinit();
+
+    const root = switch (parsed.value) {
+        .object => |obj| obj,
+        else => return bridge_error.BridgeError.InvalidJSON,
+    };
+
+    const value = root.get("eventId") orelse {
+        std.log.warn("deleteCalendarEvent refused: the message carried no 'eventId'", .{});
+        return bridge_error.BridgeError.MissingData;
+    };
+
+    return switch (value) {
+        .null => {
+            std.log.warn("deleteCalendarEvent refused: 'eventId' was null", .{});
+            return bridge_error.BridgeError.MissingData;
+        },
+        .string => |s| blk: {
+            if (std.mem.indexOfScalar(u8, s, 0) != null) {
+                std.log.warn(
+                    "deleteCalendarEvent refused: 'eventId' contains an embedded NUL, which " ++
+                        "stringWithUTF8String: would silently truncate",
+                    .{},
+                );
+                return bridge_error.BridgeError.InvalidParameter;
+            }
+            break :blk try allocator.dupe(u8, s);
+        },
+        else => {
+            std.log.warn("deleteCalendarEvent refused: 'eventId' is not a string", .{});
+            return bridge_error.BridgeError.InvalidParameter;
+        },
+    };
+}
+
+/// `as? Double`, as a partial function: null for absent, an error for a value
+/// `as? Double` would reject.
+///
+/// `std.json` parks a literal that overflows `i64`, or one written in a form it
+/// keeps verbatim, in `.number_string` with scanner-validated source bytes. It is
+/// still a number the page sent, so it is read rather than refused for its
+/// spelling — the same call `bridge_mobile_motion.zig:785` makes.
+///
+/// Non-finite is refused: `1e400` parses to `inf`, and an infinite
+/// `NSTimeInterval` is not a date. `.bool` is refused too — see the module
+/// comment on the `__NSCFBoolean` wart.
+fn millisecondsFrom(value: ?std.json.Value, comptime field: []const u8) !?f64 {
+    const v = value orelse return null;
+
+    const ms: f64 = switch (v) {
+        .null => return null,
+        .integer => |i| @floatFromInt(i),
+        .float => |f| f,
+        .number_string => |s| std.fmt.parseFloat(f64, s) catch {
+            std.log.warn(
+                "calendar refused: '" ++ field ++ "' is a number craft cannot read",
+                .{},
+            );
+            return bridge_error.BridgeError.InvalidParameter;
+        },
+        else => {
+            std.log.warn(
+                "calendar refused: '" ++ field ++ "' is not a number; Swift would silently " ++
+                    "use its default instead, which the page cannot see",
+                .{},
+            );
+            return bridge_error.BridgeError.InvalidParameter;
+        },
+    };
+
+    if (!std.math.isFinite(ms)) {
+        std.log.warn("calendar refused: '" ++ field ++ "' is not a finite number", .{});
+        return bridge_error.BridgeError.InvalidParameter;
+    }
+    return ms;
+}
+
+/// `as? String`, copied into caller-owned memory. Null for absent or JSON null.
+fn ownedStringFrom(
+    allocator: std.mem.Allocator,
+    value: ?std.json.Value,
+    comptime field: []const u8,
+) !?[]const u8 {
+    const v = value orelse return null;
+
+    return switch (v) {
+        .null => null,
+        .string => |s| blk: {
+            if (std.mem.indexOfScalar(u8, s, 0) != null) {
+                std.log.warn(
+                    "createCalendarEvent refused: '" ++ field ++ "' contains an embedded NUL, " ++
+                        "which stringWithUTF8String: would silently truncate",
+                    .{},
+                );
+                return bridge_error.BridgeError.InvalidParameter;
+            }
+            break :blk try allocator.dupe(u8, s);
+        },
+        else => {
+            std.log.warn(
+                "createCalendarEvent refused: '" ++ field ++ "' is not a string; Swift would " ++
+                    "silently use its default instead",
+                .{},
+            );
+            return bridge_error.BridgeError.InvalidParameter;
+        },
+    };
+}
+
+/// `data["isAllDay"] as? Bool ?? false`.
+///
+/// The accepted set is exactly what a bridged `NSNumber as? Bool` accepts — a
+/// real boolean, or the numbers `0` and `1`, the rule
+/// `bridge_mobile_contactpicker.zig:448-460` spells out. `2` is truthy in
+/// JavaScript and is *not* a Bool to Foundation; Swift turns it into `false`,
+/// and here it is refused rather than silently creating a timed event for a page
+/// that asked for an all-day one.
+fn allDayFrom(value: ?std.json.Value) !bool {
+    const v = value orelse return false;
+
+    return switch (v) {
+        .null => false,
+        .bool => |b| b,
+        .integer => |i| switch (i) {
+            0 => false,
+            1 => true,
+            else => return allDayRefused(),
+        },
+        .float => |f| if (f == 0.0) false else if (f == 1.0) true else return allDayRefused(),
+        else => return allDayRefused(),
+    };
+}
+
+/// Always an error. Split out so the four refusing arms above say the same
+/// thing once, and so each arm stays an expression.
+fn allDayRefused() bridge_error.BridgeError {
+    std.log.warn(
+        "createCalendarEvent refused: 'event.isAllDay' is not a boolean Foundation would " ++
+            "accept (only true/false and the numbers 0 and 1 are); Swift would silently use " ++
+            "false instead",
+        .{},
+    );
+    return bridge_error.BridgeError.InvalidParameter;
+}
+
+// =============================================================================
+// Reply shaping. Pure — no Objective-C — so the exact bytes the page receives
+// are pinned by host tests.
+// =============================================================================
+
+/// `resolveCallback(callbackId, result: true)` under `.fragmentsAllowed`.
+/// Static, so the delete reply allocates nothing.
+const true_fragment = "true";
+
+/// One `EKEvent` as Swift's `eventData` map reads it (3304-3312).
+///
+/// The four strings are already `?? ""`-collapsed: nil `location` is `""` on the
+/// wire, not a missing key and not `null`, whichever way `craft.d.ts` declares
+/// it. The strings borrow whatever buffer they were read from — on the native
+/// path an `NSString`'s internal UTF-8, valid for the completion's autorelease
+/// pool — and every one is copied into the JSON before that returns.
+const CalEvent = struct {
+    id: []const u8,
+    title: []const u8,
+    location: []const u8,
+    notes: []const u8,
+    /// `timeIntervalSince1970 * 1000` — fractional milliseconds, not an integer.
+    start_ms: f64,
+    end_ms: f64,
+    all_day: bool,
+};
+
+fn appendJsonString(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    s: []const u8,
+) !void {
+    try out.append(allocator, '"');
+    // Titles, locations and notes are user data and will contain `"` and `\` in
+    // the wild. This reply is replayed into the source `evaluateJavaScript:`
+    // parses, so an unescaped quote is a syntax error in the page rather than a
+    // wrong field.
+    try bridge_error.appendJsonEscaped(allocator, out, s);
+    try out.append(allocator, '"');
+}
+
+/// One `f64` as a JSON number.
+///
+/// `{d}` renders decimal notation, never scientific, and a finite `f64` can need
+/// up to `std.fmt.float.bufferSize(.decimal, f64)` (347) bytes. Non-finite is
+/// refused rather than printed: `inf` and `nan` are not JSON, Swift's own
+/// `JSONSerialization` refuses them too, and printing them would produce a
+/// syntax error inside the reply script with nothing to point at.
+///
+/// A benign divergence, stated rather than hidden: Zig's shortest-round-trip
+/// `{d}` and `JSONSerialization`'s renderer can print different digit strings
+/// for the same `f64`. Both parse back to the same JavaScript number.
+fn appendNumber(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    value: f64,
+) !void {
+    if (!std.math.isFinite(value)) return bridge_error.BridgeError.InvalidParameter;
+    var buf: [std.fmt.float.bufferSize(.decimal, f64)]u8 = undefined;
+    try out.appendSlice(allocator, try std.fmt.bufPrint(&buf, "{d}", .{value}));
+}
+
+/// The `getCalendarEvents` reply: a bare array of seven-key objects.
+///
+/// Key order is fixed at id, title, location, notes, startDate, endDate,
+/// isAllDay — Swift's literal order, which as a `Dictionary` it does not
+/// actually preserve. A caller cannot depend on order, but a *test* can only pin
+/// bytes that are deterministic.
+///
+/// An empty list is `[]` and **resolves**. `events.map` over nothing is `[]` in
+/// Swift, so turning "no events in that range" into an error would break a path
+/// the shim answers successfully.
+fn shapeEvents(allocator: std.mem.Allocator, events: []const CalEvent) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.append(allocator, '[');
+    for (events, 0..) |event, i| {
+        if (i != 0) try out.append(allocator, ',');
+        try out.appendSlice(allocator, "{\"id\":");
+        try appendJsonString(allocator, &out, event.id);
+        try out.appendSlice(allocator, ",\"title\":");
+        try appendJsonString(allocator, &out, event.title);
+        try out.appendSlice(allocator, ",\"location\":");
+        try appendJsonString(allocator, &out, event.location);
+        try out.appendSlice(allocator, ",\"notes\":");
+        try appendJsonString(allocator, &out, event.notes);
+        try out.appendSlice(allocator, ",\"startDate\":");
+        try appendNumber(allocator, &out, event.start_ms);
+        try out.appendSlice(allocator, ",\"endDate\":");
+        try appendNumber(allocator, &out, event.end_ms);
+        try out.appendSlice(allocator, ",\"isAllDay\":");
+        try out.appendSlice(allocator, if (event.all_day) "true" else "false");
+        try out.append(allocator, '}');
+    }
+    try out.append(allocator, ']');
+
+    return out.toOwnedSlice(allocator);
+}
+
+/// The `createCalendarEvent` reply: a bare JSON string, or bare `null`.
+///
+/// `null` is what a nil `eventIdentifier` reaches the page as through Swift, and
+/// it is what is sent here — even though `craft-bridge.js:80`'s `payload || {}`
+/// turns it into `{}` on the Zig route. See the module comment: rejecting a save
+/// that succeeded would be the worse lie, and `""` is swallowed by `|| {}` just
+/// the same while additionally being false about the identifier.
+fn shapeCreatedId(allocator: std.mem.Allocator, identifier: ?[]const u8) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    if (identifier) |id| {
+        try appendJsonString(allocator, &out, id);
+    } else {
+        try out.appendSlice(allocator, "null");
+    }
+
+    return out.toOwnedSlice(allocator);
+}
+
+/// Swift's `startDate! / 1000` — the wire carries milliseconds and
+/// `NSTimeInterval` is seconds. One function so the division has one place to be
+/// wrong in, and one test.
+fn secondsFromMilliseconds(ms: f64) f64 {
+    return ms / 1000.0;
+}
+
+// =============================================================================
+// Framework constants — transcribed, so pinned by the tests below. This is the
+// `bridge_mobile_permissions.zig` convention: a constant nobody can look up at
+// runtime is a constant a test has to hold.
+// =============================================================================
+
+/// `EKEntityType`: `NSUInteger`. event = 0, reminder = 1. Already pinned once at
+/// `bridge_mobile_permissions.zig:497`; pinned again here because a wrong value
+/// would request access to reminders and report it as calendar access.
+const ek_entity_type_event: c_ulong = 0;
+
+/// `EKSpan`: `NSInteger`. `EKSpanThisEvent` = 0, `EKSpanFutureEvents` = 1.
+/// Swift passes `.thisEvent` to both `save` and `remove`; the future-events span
+/// would edit or delete every occurrence of a recurring event.
+const ek_span_this_event: c_long = 0;
+
+/// `NSCalendarUnitMonth` = `1 << 3` — `NSCalendarUnit`, an `NSUInteger`.
+/// Nothing in this repo pinned it before. It is what makes
+/// `Calendar.current.date(byAdding: .month, value: 1, to: Date())` (3298) a
+/// **calendar month in the user's calendar and time zone** — 28, 29, 30 or 31
+/// days depending on when it is called. "+30 days" is a different default range
+/// and is not substituted.
+const ns_calendar_unit_month: c_ulong = 1 << 3;
+
+/// The `options:` argument of `dateByAddingUnit:value:toDate:options:`.
+/// `Calendar.current.date(byAdding:value:to:)` passes no
+/// `NSCalendarOptions`, which is 0.
+const ns_calendar_options_none: c_ulong = 0;
+
+/// `NSUTF8StringEncoding`. Used only to ask a string how long it really is, so a
+/// NUL-truncated read can be told from a short string.
+const ns_utf8_string_encoding: c_ulong = 4;
+
+/// The Info.plist key `packages/ios/src/index.ts:190` writes if and only if
+/// `config.enableCalendar`.
+const key_calendars_usage = "NSCalendarsUsageDescription";
+
+// =============================================================================
+// Objective-C: everything looked up once at dispatch, then a completion that
+// cannot look anything up.
+// =============================================================================
+
+fn selector(name: [*:0]const u8) !Id {
+    if (!is_darwin) return error.UnsupportedPlatform;
+    return objc.sel_registerName(name) orelse error.SelectorNotFound;
+}
+
+/// The main bundle's Info.plist value for `key`, or null when it has none.
+///
+/// Errors rather than answering null when the runtime itself will not cooperate:
+/// "there is no NSBundle class" and "this app was not built with calendar
+/// enabled" are different facts, and collapsing them would blame the app's
+/// configuration for a broken process.
+fn infoPlistValue(comptime key: [*:0]const u8) !Id {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    const NSBundle = objc.objc_getClass("NSBundle") orelse return error.ClassNotFound;
+    const sel_main = objc.sel_registerName("mainBundle") orelse return error.SelectorNotFound;
+    const bundle = objc.msgSendId(NSBundle, sel_main) orelse return error.NoMainBundle;
+
+    const NSString = objc.objc_getClass("NSString") orelse return error.ClassNotFound;
+    const sel_string = objc.sel_registerName("stringWithUTF8String:") orelse
+        return error.SelectorNotFound;
+    const ns_key = objc.msgSendId1(NSString, sel_string, key) orelse return error.NativeCallFailed;
+
+    const sel_lookup = objc.sel_registerName("objectForInfoDictionaryKey:") orelse
+        return error.SelectorNotFound;
+    return objc.msgSendId1(bundle, sel_lookup, ns_key);
+}
+
+/// Refuse when the app was not built with `enableCalendar`.
+///
+/// Checked first, matching Swift's `if config.enableCalendar` guarding all three
+/// cases, and — for the two actions that request access — checked **before** the
+/// store is touched, because `requestAccessToEntityType:` without this key raises
+/// `NSInternalInconsistencyException`, which from Zig is an uncatchable SIGABRT.
+/// That is the difference from `bridge_mobile_contactpicker.zig`'s gate, which
+/// guards a picker needing no authorization at all: here the key is a genuine
+/// precondition of the API and not merely evidence of a config flag.
+/// `deleteCalendarEvent` requests nothing, so for that one action it *is* only
+/// evidence of the flag — which is why it is still checked.
+fn requireCalendarConfigured(action: []const u8) !void {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    if ((try infoPlistValue(key_calendars_usage)) == null) {
+        std.log.warn(
+            "{s} refused: Info.plist has no {s}, so this app was not built with calendar " ++
+                "enabled (and requesting access without it would terminate the process)",
+            .{ action, key_calendars_usage },
+        );
+        return bridge_error.BridgeError.PermissionDenied;
+    }
+}
+
+/// Everything the completion needs, resolved while a synchronous error can still
+/// reach the page.
+///
+/// The completion runs long after the dispatch frame is gone, where a failed
+/// `sel_registerName` could only be logged. Resolving here turns that whole class
+/// of failure into an ordinary rejection.
+///
+/// Four *class* objects ride along for the same reason. `EKEvent` is guarded
+/// with a message naming EventKit.framework, because the fix is a link line
+/// rather than anything in this file — the zig-slice fixture
+/// (`packages/ios/fixtures/zig-slice/build-and-run.sh:65`) links only UIKit,
+/// WebKit, Foundation and Security, so this is exactly what it hits.
+const Sels = struct {
+    // Classes used as receivers of class methods.
+    event_class: Id,
+    date_class: Id,
+    calendar_class: Id,
+    string_class: Id,
+
+    // EKEventStore
+    request_access: Id,
+    predicate_for_events: Id,
+    events_matching: Id,
+    default_calendar: Id,
+    save_event: Id,
+    event_with_identifier: Id,
+    remove_event: Id,
+
+    // EKEvent (class method, then getters, then setters)
+    event_with_event_store: Id,
+    event_identifier: Id,
+    title: Id,
+    location: Id,
+    notes: Id,
+    start_date: Id,
+    end_date: Id,
+    /// The property is `allDay` with `getter=isAllDay`; the selector really is
+    /// `isAllDay` and the setter really is `setAllDay:`.
+    is_all_day: Id,
+    set_title: Id,
+    set_location: Id,
+    set_notes: Id,
+    set_start_date: Id,
+    set_end_date: Id,
+    set_all_day: Id,
+    set_calendar: Id,
+
+    // NSDate
+    date_with_interval: Id,
+    time_interval_since_1970: Id,
+    date_now: Id,
+
+    // NSCalendar
+    current_calendar: Id,
+    date_by_adding_unit: Id,
+
+    // NSArray
+    count: Id,
+    object_at: Id,
+
+    // NSString
+    utf8: Id,
+    length_of_bytes: Id,
+    string_with_utf8: Id,
+
+    // NSError, for the log line a BridgeError cannot carry.
+    localized_description: Id,
+
+    fn resolve(action: []const u8) !Sels {
+        if (!is_darwin) return error.UnsupportedPlatform;
+
+        const event_class = objc.objc_getClass("EKEvent") orelse {
+            std.log.err(
+                "{s} refused: this process has no EKEvent; EventKit.framework is not linked",
+                .{action},
+            );
+            return bridge_error.BridgeError.PlatformNotSupported;
+        };
+        const date_class = objc.objc_getClass("NSDate") orelse return error.ClassNotFound;
+        const calendar_class = objc.objc_getClass("NSCalendar") orelse return error.ClassNotFound;
+        const string_class = objc.objc_getClass("NSString") orelse return error.ClassNotFound;
+
+        return .{
+            .event_class = event_class,
+            .date_class = date_class,
+            .calendar_class = calendar_class,
+            .string_class = string_class,
+
+            .request_access = try selector("requestAccessToEntityType:completion:"),
+            .predicate_for_events = try selector("predicateForEventsWithStartDate:endDate:calendars:"),
+            .events_matching = try selector("eventsMatchingPredicate:"),
+            .default_calendar = try selector("defaultCalendarForNewEvents"),
+            .save_event = try selector("saveEvent:span:error:"),
+            .event_with_identifier = try selector("eventWithIdentifier:"),
+            .remove_event = try selector("removeEvent:span:error:"),
+
+            .event_with_event_store = try selector("eventWithEventStore:"),
+            .event_identifier = try selector("eventIdentifier"),
+            .title = try selector("title"),
+            .location = try selector("location"),
+            .notes = try selector("notes"),
+            .start_date = try selector("startDate"),
+            .end_date = try selector("endDate"),
+            .is_all_day = try selector("isAllDay"),
+            .set_title = try selector("setTitle:"),
+            .set_location = try selector("setLocation:"),
+            .set_notes = try selector("setNotes:"),
+            .set_start_date = try selector("setStartDate:"),
+            .set_end_date = try selector("setEndDate:"),
+            .set_all_day = try selector("setAllDay:"),
+            .set_calendar = try selector("setCalendar:"),
+
+            .date_with_interval = try selector("dateWithTimeIntervalSince1970:"),
+            .time_interval_since_1970 = try selector("timeIntervalSince1970"),
+            .date_now = try selector("date"),
+
+            .current_calendar = try selector("currentCalendar"),
+            .date_by_adding_unit = try selector("dateByAddingUnit:value:toDate:options:"),
+
+            .count = try selector("count"),
+            .object_at = try selector("objectAtIndex:"),
+
+            .utf8 = try selector("UTF8String"),
+            .length_of_bytes = try selector("lengthOfBytesUsingEncoding:"),
+            .string_with_utf8 = try selector("stringWithUTF8String:"),
+
+            .localized_description = try selector("localizedDescription"),
+        };
+    }
+};
+
+/// The one `EKEventStore`, created on first use and never released.
+///
+/// `bridge_mobile_permissions.zig:33-38` names this as the exact reason it left
+/// calendar's `requestPermission` with the shim: the store has to outlive the
+/// dispatch frame, because the completion is what answers. Swift keeps one as a
+/// coordinator property for the life of the app (`CraftApp.swift:406, 452-453`)
+/// and so does this — a lazily created, never-released singleton, which is the
+/// same object graph rather than a new mechanism.
+///
+/// Creating a store neither prompts nor requires authorization; only
+/// `requestAccessToEntityType:` does, and the Info.plist gate runs before this.
+var event_store: Id = null;
+var store_mutex: compat_mutex.Mutex = .{};
+
+fn ensureStore(action: []const u8) !Id {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    store_mutex.lock();
+    defer store_mutex.unlock();
+
+    if (event_store) |existing| return existing;
+
+    const StoreClass = objc.objc_getClass("EKEventStore") orelse {
+        std.log.err(
+            "{s} refused: this process has no EKEventStore; EventKit.framework is not linked",
+            .{action},
+        );
+        return bridge_error.BridgeError.PlatformNotSupported;
+    };
+
+    const store = (try objc.allocInit(StoreClass)) orelse return error.NativeCallFailed;
+    event_store = store;
+    return store;
+}
+
+/// `+[NSString stringWithUTF8String:]` over caller bytes.
+///
+/// The classes and selectors come from `Sels`, resolved at dispatch, so this
+/// performs no lookups and can be called from the completion. A nil result means
+/// the bytes were not valid UTF-8 — refused, never substituted.
+fn makeString(sels: Sels, allocator: std.mem.Allocator, text: []const u8) !Id {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    const z = try memory.dupeZ(allocator, u8, text);
+    defer allocator.free(z);
+
+    return objc.msgSendId1(sels.string_class, sels.string_with_utf8, z.ptr) orelse
+        error.NativeCallFailed;
+}
+
+/// One `NSString` as bytes, or a refusal.
+///
+/// The truncation check is why this is not one line. `UTF8String` hands back a
+/// NUL-terminated buffer, so a value containing U+0000 — which
+/// `JSONSerialization` would have preserved on the Swift side — reads back as its
+/// prefix. `lengthOfBytesUsingEncoding:` counts the real encoded bytes, so a
+/// mismatch is exactly that case, and reporting a prefix as the whole title is
+/// the one thing worse than failing.
+///
+/// The returned slice borrows the string's internal buffer, valid for the
+/// current autorelease pool; every caller copies it into the reply before
+/// returning.
+fn readString(ns: Id, sels: Sels) ![]const u8 {
+    if (!is_darwin) return error.UnsupportedPlatform;
+    if (ns == null) return error.NilNativeString;
+
+    const Utf8Fn = *const fn (Id, Id) callconv(.c) ?[*:0]const u8;
+    const utf8: Utf8Fn = @ptrCast(&objc.objc_msgSend);
+    const cstr = utf8(ns, sels.utf8) orelse return error.NativeCallFailed;
+    const text = std.mem.span(cstr);
+
+    const LenFn = *const fn (Id, Id, c_ulong) callconv(.c) c_ulong;
+    const len_of: LenFn = @ptrCast(&objc.objc_msgSend);
+    if (len_of(ns, sels.length_of_bytes, ns_utf8_string_encoding) != text.len) {
+        return error.EmbeddedNulInNativeString;
+    }
+
+    return text;
+}
+
+/// `readString` for the four `EKEvent` properties that are genuinely nullable.
+/// Null is not a failure here — `title`, `location`, `notes` and
+/// `eventIdentifier` are all `nullable` and Swift coalesces every one of them.
+fn readOptionalString(ns: Id, sels: Sels) !?[]const u8 {
+    if (ns == null) return null;
+    return try readString(ns, sels);
+}
+
+/// The `NSError`'s `localizedDescription`, for a log line.
+///
+/// Never for a reply: `BridgeError` carries a fixed code and message, so a
+/// localised EventKit string has nowhere to go on the wire. Saying it in the log
+/// is the honest half of that, and claiming it reached the page would be the
+/// dishonest one.
+fn errorText(err: Id, sels: Sels) ?[]const u8 {
+    if (!is_darwin) return null;
+    if (err == null) return null;
+
+    const description = objc.msgSendId(err, sels.localized_description) orelse return null;
+    return readString(description, sels) catch null;
+}
+
+fn logNativeError(comptime prefix: []const u8, err: Id, sels: Sels) void {
+    if (errorText(err, sels)) |text| {
+        std.log.err(prefix ++ ": {s}", .{text});
+    } else {
+        // Possible in principle, and said rather than asserted: `NO` with a nil
+        // `NSError` gets `NATIVE_CALL_FAILED` and a log line admitting there was
+        // no message, instead of a message that was never received.
+        std.log.err(prefix ++ " (no NSError was provided)", .{});
+    }
+}
+
+/// `+[NSDate dateWithTimeIntervalSince1970:]` on the wire's milliseconds.
+fn dateFromMilliseconds(sels: Sels, ms: f64) Id {
+    if (!is_darwin) return null;
+
+    const DateFn = *const fn (Id, Id, f64) callconv(.c) Id;
+    const make: DateFn = @ptrCast(&objc.objc_msgSend);
+    return make(sels.date_class, sels.date_with_interval, secondsFromMilliseconds(ms));
+}
+
+/// `+[NSDate date]` — Swift's `Date()`, evaluated inside the completion exactly
+/// where Swift evaluates it.
+fn nowDate(sels: Sels) Id {
+    if (!is_darwin) return null;
+    return objc.msgSendId(sels.date_class, sels.date_now);
+}
+
+/// `Calendar.current.date(byAdding: .month, value: 1, to: Date())!` (3298).
+///
+/// A **calendar month**, not thirty days: the length depends on the month and on
+/// the user's calendar and time zone. Swift force-unwraps the result; here a nil
+/// is checked, which is the same hazard `CraftApp.swift:3301` has with
+/// `predicate!` and the reason neither force-unwrap is translated.
+fn defaultEndDate(sels: Sels) Id {
+    if (!is_darwin) return null;
+
+    const calendar = objc.msgSendId(sels.calendar_class, sels.current_calendar) orelse return null;
+    const now = nowDate(sels) orelse return null;
+
+    const AddFn = *const fn (Id, Id, c_ulong, c_long, Id, c_ulong) callconv(.c) Id;
+    const add: AddFn = @ptrCast(&objc.objc_msgSend);
+    return add(
+        calendar,
+        sels.date_by_adding_unit,
+        ns_calendar_unit_month,
+        1,
+        now,
+        ns_calendar_options_none,
+    );
+}
+
+/// Read one `EKEvent` the way Swift's `eventData` map reads it (3304-3312).
+///
+/// Every string is `?? ""`-collapsed, including the identifier — that is the
+/// fetch shape, and it is *not* the create shape, where a nil identifier is bare
+/// `null`. The two are deliberately not shared.
+///
+/// `startDate` and `endDate` are the exception: Swift force-unwraps them
+/// (`event.startDate.timeIntervalSince1970`) and would crash on nil. There is no
+/// `?? ""` to copy and no honest substitute — `0` would be an event dated 1 Jan
+/// 1970 reported as real — so a nil date refuses the whole reply.
+fn readEvent(event: Id, sels: Sels) !CalEvent {
+    if (!is_darwin) return error.UnsupportedPlatform;
+    if (event == null) return error.NativeCallFailed;
+
+    const DoubleFn = *const fn (Id, Id) callconv(.c) f64;
+    const send_double: DoubleFn = @ptrCast(&objc.objc_msgSend);
+    const BoolFn = *const fn (Id, Id) callconv(.c) bool;
+    const send_bool: BoolFn = @ptrCast(&objc.objc_msgSend);
+
+    const start = objc.msgSendId(event, sels.start_date) orelse {
+        logEventMissingDate(event, sels, "startDate");
+        return error.EventHasNoStartDate;
+    };
+    const end = objc.msgSendId(event, sels.end_date) orelse {
+        logEventMissingDate(event, sels, "endDate");
+        return error.EventHasNoEndDate;
+    };
+
+    return .{
+        .id = (try readOptionalString(objc.msgSendId(event, sels.event_identifier), sels)) orelse "",
+        .title = (try readOptionalString(objc.msgSendId(event, sels.title), sels)) orelse "",
+        .location = (try readOptionalString(objc.msgSendId(event, sels.location), sels)) orelse "",
+        .notes = (try readOptionalString(objc.msgSendId(event, sels.notes), sels)) orelse "",
+        .start_ms = send_double(start, sels.time_interval_since_1970) * 1000.0,
+        .end_ms = send_double(end, sels.time_interval_since_1970) * 1000.0,
+        .all_day = send_bool(event, sels.is_all_day),
+    };
+}
+
+/// Name the event a nil date refused, which is the only thing that makes the
+/// refusal actionable: "one of your events has no start date" cannot be looked
+/// up, and `getCalendarEvents` fails as a whole rather than per row.
+///
+/// Best-effort on the id itself. An event broken enough to have a nil
+/// `startDate` may have an unreadable `eventIdentifier` too, and the *cause*
+/// matters more than the id, so an unreadable one degrades to a placeholder
+/// rather than replacing the log line with a different failure.
+fn logEventMissingDate(event: Id, sels: Sels, comptime which: []const u8) void {
+    if (!is_darwin) return;
+
+    const id_ns = objc.msgSendId(event, sels.event_identifier);
+    const id_text = (readOptionalString(id_ns, sels) catch null) orelse "<unreadable>";
+    std.log.err(
+        "getCalendarEvents: event '{s}' has no " ++ which ++ "; refusing the whole reply " ++
+            "rather than dating it 1970",
+        .{id_text},
+    );
+}
+
+/// Walk `NSArray<EKEvent *>` into `CalEvent` entries.
+///
+/// A nil array is refused rather than answered `[]`. `events(matching:)` returns
+/// a non-optional `[EKEvent]`; Swift's `?? []` guards `self?` being nil, not the
+/// array, so nil here would mean the framework broke its own contract and "there
+/// are no events in that range" is a claim with no basis.
+fn readEvents(allocator: std.mem.Allocator, array: Id, sels: Sels) ![]CalEvent {
+    if (!is_darwin) return error.UnsupportedPlatform;
+    if (array == null) return error.NativeCallFailed;
+
+    const CountFn = *const fn (Id, Id) callconv(.c) c_ulong;
+    const count_of: CountFn = @ptrCast(&objc.objc_msgSend);
+    const total = count_of(array, sels.count);
+
+    var out: std.ArrayListUnmanaged(CalEvent) = .empty;
+    errdefer out.deinit(allocator);
+
+    var i: c_ulong = 0;
+    while (i < total) : (i += 1) {
+        const event = objc.msgSendId1(array, sels.object_at, i) orelse return error.NativeCallFailed;
+        try out.append(allocator, try readEvent(event, sels));
+    }
+
+    return out.toOwnedSlice(allocator);
+}
+
+// =============================================================================
+// The per-slot completion block, and the side table that gives it a ticket.
+//
+// A global block captures nothing, which is what makes `Block_copy` on it the
+// identity function and removes every lifetime question. The price is that the
+// block knows only its own slot index, baked in at comptime — so the ticket, the
+// selectors resolved at dispatch, the store, and the request's own parameters
+// are looked up here.
+// =============================================================================
+
+/// What the completion still has to do, and everything it needs to do it.
+const Request = union(enum) {
+    fetch: Range,
+    create: NewEvent,
+
+    fn deinit(self: Request, allocator: std.mem.Allocator) void {
+        switch (self) {
+            .fetch => {},
+            .create => |event| event.deinit(allocator),
+        }
+    }
+};
+
+const PendingCall = struct {
+    ticket: ios_async.Ticket,
+    sels: Sels,
+    store: Id,
+    request: Request,
+};
+
+/// One entry per `ios_async` slot, not one entry total.
+///
+/// `bridge_mobile_contactpicker.zig`'s single `pending` is right for a modal
+/// picker, where a second call cannot happen while the first is on screen.
+/// Nothing here is modal: two `getCalendarEvents` in flight is an ordinary page,
+/// and a single slot would refuse the second for no reason.
+var pending_calls: [ios_async.max_in_flight]?PendingCall = @splat(null);
+var pending_mutex: compat_mutex.Mutex = .{};
+
+/// Record the call a slot's block will answer. The slot is leased exclusively by
+/// this ticket, so the entry is ours to write.
+fn publishPendingCall(ticket: ios_async.Ticket, sels: Sels, store: Id, request: Request) void {
+    pending_mutex.lock();
+    defer pending_mutex.unlock();
+    pending_calls[ticket.index] = .{
+        .ticket = ticket,
+        .sels = sels,
+        .store = store,
+        .request = request,
+    };
+}
+
+/// Read and clear a slot's entry. Clearing is what makes a second fire of the
+/// same completion a no-op rather than a second reply — and, here, rather than a
+/// double free of the pending event's strings.
+fn takePendingCall(index: u5) ?PendingCall {
+    pending_mutex.lock();
+    defer pending_mutex.unlock();
+    const call = pending_calls[index];
+    pending_calls[index] = null;
+    return call;
+}
+
+const BlockDescriptor = extern struct {
+    reserved: c_ulong = 0,
+    size: c_ulong,
+};
+
+/// `void (^)(BOOL granted, NSError *error)` — the shape of
+/// `-[EKEventStore requestAccessToEntityType:completion:]`.
+///
+/// `ios_async.boolErrorBlock` has this exact invoke shape and is still the wrong
+/// block for two of these three actions: it replies the strings
+/// `"granted"`/`"denied"`, and the page is owed the *events* or the new
+/// *identifier*. A grant is the beginning of the work here, not the answer.
+const AccessBlock = extern struct {
+    isa: ?*anyopaque,
+    flags: c_int,
+    reserved: c_int = 0,
+    invoke: *const anyopaque,
+    descriptor: *const BlockDescriptor,
+};
+
+/// 1 << 28. `Block_copy` on a global block returns the same pointer, so a
+/// module-level block can be handed to an API that escapes it with no heap copy,
+/// no copy/dispose helpers, and no descriptor lifetime.
+const BLOCK_IS_GLOBAL: c_int = 1 << 28;
+
+const access_block_descriptor = BlockDescriptor{ .size = @sizeOf(AccessBlock) };
+
+extern var _NSConcreteGlobalBlock: anyopaque;
+
+/// One invoke per slot, comptime-generated so each block knows which slot it is
+/// without capturing anything.
+fn makeAccessInvoke(comptime index: u5) *const anyopaque {
+    const S = struct {
+        fn invoke(_: *const AccessBlock, granted: bool, err: Id) callconv(.c) void {
+            accessCompletionFired(index, granted, err);
+        }
+    };
+    return @ptrCast(&S.invoke);
+}
+
+fn makeAccessBlocks() [ios_async.max_in_flight]AccessBlock {
+    var out: [ios_async.max_in_flight]AccessBlock = undefined;
+    for (&out, 0..) |*b, i| {
+        b.* = .{
+            .isa = &_NSConcreteGlobalBlock,
+            .flags = BLOCK_IS_GLOBAL,
+            .invoke = makeAccessInvoke(@intCast(i)),
+            .descriptor = &access_block_descriptor,
+        };
+    }
+    return out;
+}
+
+var access_blocks: [ios_async.max_in_flight]AccessBlock =
+    if (is_darwin) makeAccessBlocks() else undefined;
+
+fn accessBlock(ticket: ios_async.Ticket) *anyopaque {
+    return @ptrCast(&access_blocks[ticket.index]);
+}
+
+/// Runs on whatever queue EventKit chose.
+///
+/// Nothing replies from here: `evaluateJavaScript:` is main-thread-only *and* the
+/// `request_context` that names the waiting call is long gone, so every answer
+/// goes through `ios_async`, which copies the payload, hops to the main queue,
+/// and replies under the id captured back at dispatch.
+///
+/// The blocking EventKit work — `eventsMatchingPredicate:`, `saveEvent:` — is
+/// deliberately done *here*, on the background queue, which is where Swift does
+/// it too.
+fn accessCompletionFired(index: u5, granted: bool, err: Id) void {
+    if (!is_darwin) return;
+
+    const allocator = std.heap.c_allocator;
+
+    const call = takePendingCall(index) orelse {
+        std.log.warn(
+            "calendar: an access completion fired for slot {d} with no call recorded; ignored " ++
+                "rather than answered to whoever holds the slot next",
+            .{index},
+        );
+        return;
+    };
+    // The pending event's strings belong to this call whichever way it ends.
+    defer call.request.deinit(allocator);
+
+    if (!granted) {
+        if (errorText(err, call.sels)) |text| {
+            std.log.warn(
+                "calendar: access to events was not granted ({s}); rejecting as PERMISSION_DENIED " ++
+                    "(Swift sends CRAFT_ERROR with this text, which BridgeError cannot carry)",
+                .{text},
+            );
+        } else {
+            std.log.warn(
+                "calendar: access to events was not granted; rejecting as PERMISSION_DENIED",
+                .{},
+            );
+        }
+        // A user declining a prompt is not a native call failing — the call
+        // worked and the answer is "no". `deliverError`'s NATIVE_CALL_FAILED
+        // would send whoever reads it looking for a bug that is not there.
+        ios_async.deliverErrorCode(call.ticket, bridge_error.BridgeError.PermissionDenied);
+        return;
+    }
+
+    switch (call.request) {
+        .fetch => |range| runFetch(call.ticket, call.sels, call.store, range),
+        .create => |event| runCreate(call.ticket, call.sels, call.store, event),
+    }
+}
+
+/// The granted half of `getCalendarEvents` (3297-3315).
+fn runFetch(ticket: ios_async.Ticket, sels: Sels, store: Id, range: Range) void {
+    if (!is_darwin) return;
+
+    const allocator = std.heap.c_allocator;
+
+    const start = (if (range.start_ms) |ms| dateFromMilliseconds(sels, ms) else nowDate(sels)) orelse {
+        std.log.err("getCalendarEvents: the start date could not be built; rejecting", .{});
+        ios_async.deliverError(ticket);
+        return;
+    };
+    const end = (if (range.end_ms) |ms| dateFromMilliseconds(sels, ms) else defaultEndDate(sels)) orelse {
+        std.log.err(
+            "getCalendarEvents: the end date could not be built (Calendar.current + 1 month " ++
+                "answered nil); rejecting rather than substituting a range the page did not ask for",
+            .{},
+        );
+        ios_async.deliverError(ticket);
+        return;
+    };
+
+    const PredicateFn = *const fn (Id, Id, Id, Id, Id) callconv(.c) Id;
+    const make_predicate: PredicateFn = @ptrCast(&objc.objc_msgSend);
+    // `calendars: nil` — every calendar, as Swift passes (3300).
+    const predicate = make_predicate(
+        store,
+        sels.predicate_for_events,
+        start,
+        end,
+        @as(Id, null),
+    ) orelse {
+        std.log.err("getCalendarEvents: predicateForEventsWithStartDate: answered nil; rejecting", .{});
+        ios_async.deliverError(ticket);
+        return;
+    };
+
+    const array = objc.msgSendId1(store, sels.events_matching, predicate);
+
+    const events = readEvents(allocator, array, sels) catch |read_err| {
+        std.log.err(
+            "getCalendarEvents: could not read the matched events ({}); rejecting rather than " ++
+                "replying with a list that was not read",
+            .{read_err},
+        );
+        ios_async.deliverError(ticket);
+        return;
+    };
+    defer allocator.free(events);
+
+    const json = shapeEvents(allocator, events) catch |shape_err| {
+        std.log.err("getCalendarEvents: could not shape the reply ({}); rejecting", .{shape_err});
+        ios_async.deliverError(ticket);
+        return;
+    };
+    defer allocator.free(json);
+
+    // An empty range is `[]` and resolves — see `shapeEvents`.
+    ios_async.deliverJson(ticket, json);
+}
+
+/// The granted half of `createCalendarEvent` (3326-3346).
+///
+/// Field for field with Swift, including the two things that look like
+/// omissions and are not: `location`/`notes` are assigned even when nil (Swift
+/// assigns the result of `as? String` unconditionally), and `startDate`/`endDate`
+/// are assigned only when present (Swift's `if let`), which is what lets
+/// `saveEvent:` fail with "No start date has been set" instead of this file
+/// inventing a date.
+fn runCreate(ticket: ios_async.Ticket, sels: Sels, store: Id, new_event: NewEvent) void {
+    if (!is_darwin) return;
+
+    const allocator = std.heap.c_allocator;
+
+    const EventFn = *const fn (Id, Id, Id) callconv(.c) Id;
+    const make_event: EventFn = @ptrCast(&objc.objc_msgSend);
+    const event = make_event(sels.event_class, sels.event_with_event_store, store) orelse {
+        std.log.err("createCalendarEvent: +[EKEvent eventWithEventStore:] answered nil; rejecting", .{});
+        ios_async.deliverError(ticket);
+        return;
+    };
+
+    const ns_title = makeString(sels, allocator, new_event.title) catch |err| {
+        std.log.err("createCalendarEvent: the title could not be bridged to NSString ({}); rejecting", .{err});
+        ios_async.deliverError(ticket);
+        return;
+    };
+    objc.msgSendVoid1(event, sels.set_title, ns_title);
+
+    // Assigned even when absent: Swift writes `event.location = data["location"]
+    // as? String`, which stores nil. Skipping the message would be a different
+    // call, not a shortcut.
+    const ns_location: Id = if (new_event.location) |text| makeString(sels, allocator, text) catch |err| {
+        std.log.err("createCalendarEvent: the location could not be bridged to NSString ({}); rejecting", .{err});
+        ios_async.deliverError(ticket);
+        return;
+    } else null;
+    objc.msgSendVoid1(event, sels.set_location, ns_location);
+
+    const ns_notes: Id = if (new_event.notes) |text| makeString(sels, allocator, text) catch |err| {
+        std.log.err("createCalendarEvent: the notes could not be bridged to NSString ({}); rejecting", .{err});
+        ios_async.deliverError(ticket);
+        return;
+    } else null;
+    objc.msgSendVoid1(event, sels.set_notes, ns_notes);
+
+    if (new_event.start_ms) |ms| {
+        const date = dateFromMilliseconds(sels, ms) orelse {
+            std.log.err("createCalendarEvent: the start date could not be built; rejecting", .{});
+            ios_async.deliverError(ticket);
+            return;
+        };
+        objc.msgSendVoid1(event, sels.set_start_date, date);
+    }
+    if (new_event.end_ms) |ms| {
+        const date = dateFromMilliseconds(sels, ms) orelse {
+            std.log.err("createCalendarEvent: the end date could not be built; rejecting", .{});
+            ios_async.deliverError(ticket);
+            return;
+        };
+        objc.msgSendVoid1(event, sels.set_end_date, date);
+    }
+
+    objc.msgSendVoid1(event, sels.set_all_day, new_event.all_day);
+
+    // Unconditional, exactly as Swift's 3338. `defaultCalendarForNewEvents` is
+    // nullable — a freshly erased simulator, or a device with no writable
+    // calendar, answers nil — and assigning nil is what lets `saveEvent:` fail
+    // with "No calendar has been set". Pre-empting that with a synthetic check
+    // would claim a different cause, and falling back to the first writable
+    // calendar would write the event somewhere the shim would not.
+    objc.msgSendVoid1(event, sels.set_calendar, objc.msgSendId(store, sels.default_calendar));
+
+    var ns_error: Id = null;
+    const SaveFn = *const fn (Id, Id, Id, c_long, ?*Id) callconv(.c) bool;
+    const save: SaveFn = @ptrCast(&objc.objc_msgSend);
+    if (!save(store, sels.save_event, event, ek_span_this_event, &ns_error)) {
+        logNativeError("createCalendarEvent: saveEvent:span:error: failed", ns_error, sels);
+        ios_async.deliverError(ticket);
+        return;
+    }
+
+    const identifier = readOptionalString(objc.msgSendId(event, sels.event_identifier), sels) catch |err| {
+        std.log.err(
+            "createCalendarEvent: the event was saved but its identifier could not be read ({}); " ++
+                "rejecting rather than replying with an identifier that was not read",
+            .{err},
+        );
+        ios_async.deliverError(ticket);
+        return;
+    };
+
+    if (identifier == null) {
+        std.log.warn(
+            "createCalendarEvent: the event was saved but eventIdentifier was nil; replying " ++
+                "bare null, which craft-bridge.js's `payload || {{}}` turns into {{}} on this route",
+            .{},
+        );
+    }
+
+    const json = shapeCreatedId(allocator, identifier) catch |err| {
+        std.log.err("createCalendarEvent: could not shape the reply ({}); rejecting", .{err});
+        ios_async.deliverError(ticket);
+        return;
+    };
+    defer allocator.free(json);
+
+    ios_async.deliverJson(ticket, json);
+}
+
+// =============================================================================
+// Tests — host-only.
+//
+// Everything that decides page-visible bytes is pure and pinned here: routing in
+// both directions, every `as? T` coercion and every refusal, the seven keys and
+// their order, the empty-array resolve, the bare-null create reply, the bare-true
+// delete reply, escaping, the transcribed constants, and the per-slot side table
+// that makes two calls in flight possible.
+//
+// Nothing here creates an `EKEventStore` or matches a predicate. The one
+// Objective-C path a host *does* reach is the Info.plist gate, and it is
+// exercised for real, because the test runner is exactly the process without a
+// usage description that the gate exists for — the same call
+// `bridge_mobile_notifications.zig` makes with the bundle identifier.
+// =============================================================================
+
+const testing = std.testing;
+
+/// The side table is module state, and a test that left an entry behind would
+/// make the next one read someone else's call.
+fn resetPendingForTesting() void {
+    pending_mutex.lock();
+    defer pending_mutex.unlock();
+    pending_calls = @splat(null);
+}
+
+fn fakeTicket(index: u5, generation: u32) ios_async.Ticket {
+    return .{ .index = index, .generation = generation };
+}
+
+fn fakeSels() Sels {
+    // Every field is a plain `Id`; nothing below dereferences them, and the
+    // side-table behaviour under test does not care what they point at.
+    return std.mem.zeroes(Sels);
+}
+
+// ---------------------------------------------------------------------------
+// The table, and the dispatch it claims to describe
+// ---------------------------------------------------------------------------
+
+test "the declared actions are the ones the handler serves" {
+    try testing.expectEqual(@as(usize, 3), capability_actions.len);
+    try testing.expectEqualStrings(A.get_calendar_events, capability_actions[0].name);
+    try testing.expectEqualStrings(A.create_calendar_event, capability_actions[1].name);
+    try testing.expectEqualStrings(A.delete_calendar_event, capability_actions[2].name);
+
+    for (capability_actions) |decl| {
+        // A `.result` whose handler never replies parks the caller on a promise
+        // with no timeout; a `.none` that is awaited resolves immediately and
+        // means nothing. Swift resolves or rejects every path, so `.result`.
+        try testing.expectEqual(capabilities.Reply.result, decl.reply);
+        // `.unavailable` would make Zig dispatch and then refuse an action the
+        // shim serves correctly.
+        try testing.expectEqual(capabilities.ActionStatus.live, decl.status);
+        // `.live` with a reason would be a contradiction the manifest shows apps.
+        try testing.expect(decl.reason == null);
+    }
+}
+
+test "the action names match the Swift case labels exactly" {
+    // The conformance ratchet compares this block against the `case "…":` labels
+    // in `CraftApp.swift` in both directions; a prettier spelling would read as
+    // Zig serving an action the spec does not have.
+    try testing.expectEqualStrings("getCalendarEvents", A.get_calendar_events);
+    try testing.expectEqualStrings("createCalendarEvent", A.create_calendar_event);
+    try testing.expectEqualStrings("deleteCalendarEvent", A.delete_calendar_event);
+}
+
+test "every declared action is one the dispatcher routes" {
+    for (capability_actions) |decl| {
+        if (routeFor(decl.name) == null) {
+            std.debug.print("declared action '{s}' does not route\n", .{decl.name});
+            return error.DeclaredActionDoesNotRoute;
+        }
+    }
+}
+
+test "every route the dispatcher has is a declared action" {
+    // The other direction: a route with a handler and no declaration is an
+    // action the page can call and the manifest denies exists. Each declaration
+    // must claim a *distinct* route — counting alone would let two rows share
+    // one route while another went undeclared.
+    var claimed = std.mem.zeroes([std.enums.values(Route).len]bool);
+    for (capability_actions) |decl| {
+        const route = routeFor(decl.name) orelse return error.DeclaredActionDoesNotRoute;
+        const slot = @backingInt(route);
+        if (claimed[slot]) {
+            std.debug.print("two declarations route to {s}\n", .{@tagName(route)});
+            return error.TwoDeclarationsShareARoute;
+        }
+        claimed[slot] = true;
+    }
+    for (claimed, 0..) |taken, slot| {
+        if (!taken) {
+            std.debug.print(
+                "route {s} has a handler but no capability_actions row\n",
+                .{@tagName(@as(Route, @fromBackingInt(@intCast(slot))))},
+            );
+            return error.RouteNotDeclared;
+        }
+    }
+}
+
+test "each calendar action routes to its own handler" {
+    try testing.expectEqual(Route.get_events, routeFor("getCalendarEvents").?);
+    try testing.expectEqual(Route.create_event, routeFor("createCalendarEvent").?);
+    try testing.expectEqual(Route.delete_event, routeFor("deleteCalendarEvent").?);
+}
+
+test "an action this module does not serve is refused as UnknownAction" {
+    // Not any other error: `ios_dispatch.route` reads UnknownAction as "not mine,
+    // ask the next module" and anything else as a final answer. Getting this
+    // wrong would make this file swallow another module's action — or the shim's.
+    var bridge = CalendarBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    for ([_][]const u8{
+        // Neighbours in the same tier, and the reminders actions EventKit also
+        // serves — none of which this module implements.
+        "getContacts",
+        "addContact",
+        "pickContact",
+        "getReminders",
+        "createReminder",
+        "requestPermission",
+        // Casing and pluralisation are how a real typo arrives, and a miss does
+        // not fail loudly: the action would quietly fall through to the shim.
+        "getcalendarevents",
+        "GetCalendarEvents",
+        "getCalendarEvent",
+        "createCalendarEvents",
+        "deleteCalendarEvents",
+        "",
+    }) |action| {
+        try testing.expectError(
+            bridge_error.BridgeError.UnknownAction,
+            bridge.handleMessage(action, "{}"),
+        );
+        try testing.expect(routeFor(action) == null);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Payload parsing: getCalendarEvents
+// ---------------------------------------------------------------------------
+
+test "an absent range is absent, so the native side can apply Swift's defaults" {
+    // `ios_dispatch.payloadOf` hands an absent `d` through as `{}`, which is the
+    // first case. Both fields must come back null rather than 0 — a zero would be
+    // 1 Jan 1970 and would fetch a range nobody asked for.
+    const empty = try parseRange(testing.allocator, "{}");
+    try testing.expect(empty.start_ms == null);
+    try testing.expect(empty.end_ms == null);
+
+    const other = try parseRange(testing.allocator, "{\"unrelated\":1}");
+    try testing.expect(other.start_ms == null);
+    try testing.expect(other.end_ms == null);
+
+    // JSON null is the same as absent — `NSNull as? Double` is nil, and Swift
+    // defaults.
+    const nulls = try parseRange(testing.allocator, "{\"startDate\":null,\"endDate\":null}");
+    try testing.expect(nulls.start_ms == null);
+    try testing.expect(nulls.end_ms == null);
+}
+
+test "a numeric range is carried through in milliseconds, undivided" {
+    // The wire is milliseconds and `NSTimeInterval` is seconds; the division
+    // belongs next to the NSDate, not here. A struct holding "seconds" filled
+    // from a millisecond value is the unit slip nothing catches.
+    const range = try parseRange(
+        testing.allocator,
+        "{\"startDate\":1700000000000,\"endDate\":1700003600000.5}",
+    );
+    try testing.expectEqual(@as(f64, 1700000000000), range.start_ms.?);
+    try testing.expectEqual(@as(f64, 1700003600000.5), range.end_ms.?);
+}
+
+test "a wrong-typed range field is refused rather than silently defaulted" {
+    // This is the divergence the module comment argues for. Swift's `as? Double`
+    // answers nil and then uses `Date()` / `Date() + 1 month`, so
+    // `getEvents('2024-01-01')` resolves with events from a range the page never
+    // asked for and cannot detect. Refusing is observable.
+    for ([_][]const u8{
+        "{\"startDate\":\"2024-01-01\"}",
+        "{\"endDate\":\"2024-01-01\"}",
+        "{\"startDate\":[1,2]}",
+        "{\"endDate\":{\"ms\":1}}",
+        // The `__NSCFBoolean` wart: whether Foundation would read this as 1.0 is
+        // genuinely unsettled, and it is nonsense on either reading.
+        "{\"startDate\":true}",
+        "{\"endDate\":false}",
+    }) |body| {
+        try testing.expectError(
+            bridge_error.BridgeError.InvalidParameter,
+            parseRange(testing.allocator, body),
+        );
+    }
+}
+
+test "a range literal too wide for i64 is read, and a non-finite one is refused" {
+    // `std.json` parks both in `.number_string`: one is a number the page really
+    // sent, the other is not a date at all.
+    const wide = try parseRange(testing.allocator, "{\"startDate\":123456789012345678901}");
+    try testing.expectEqual(@as(f64, 123456789012345678901.0), wide.start_ms.?);
+
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        parseRange(testing.allocator, "{\"startDate\":1e400}"),
+    );
+}
+
+test "a body that is not a JSON object is InvalidJSON, never a default range" {
+    for ([_][]const u8{ "[]", "5", "\"nope\"", "{", "" }) |body| {
+        try testing.expectError(
+            bridge_error.BridgeError.InvalidJSON,
+            parseRange(testing.allocator, body),
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Payload parsing: createCalendarEvent
+// ---------------------------------------------------------------------------
+
+test "a message with no event object is MissingData, not the shim's silence" {
+    // Swift's `case` is `if config.enableCalendar, let eventData = body["event"]
+    // as? [String: Any]`, with no `else` — the page's hand-built promise never
+    // settles. An explicit rejection is strictly better and is observable.
+    for ([_][]const u8{ "{}", "{\"title\":\"no wrapper\"}", "{\"event\":null}" }) |body| {
+        try testing.expectError(
+            bridge_error.BridgeError.MissingData,
+            parseNewEvent(testing.allocator, body),
+        );
+    }
+}
+
+test "an event that is not an object is InvalidParameter, distinct from absent" {
+    for ([_][]const u8{
+        "{\"event\":\"Standup\"}",
+        "{\"event\":42}",
+        "{\"event\":[{\"title\":\"a\"}]}",
+        "{\"event\":true}",
+    }) |body| {
+        try testing.expectError(
+            bridge_error.BridgeError.InvalidParameter,
+            parseNewEvent(testing.allocator, body),
+        );
+    }
+}
+
+test "an empty event object takes Swift's defaults exactly" {
+    // `title` is `?? ""`; `location` and `notes` are plain `as? String`, so nil;
+    // `isAllDay` is `?? false`; and both dates are left **unset**, which is what
+    // makes `saveEvent:` fail with "No start date has been set" instead of this
+    // file inventing one.
+    const event = try parseNewEvent(testing.allocator, "{\"event\":{}}");
+    defer event.deinit(testing.allocator);
+
+    try testing.expectEqualStrings("", event.title);
+    try testing.expect(event.location == null);
+    try testing.expect(event.notes == null);
+    try testing.expect(event.start_ms == null);
+    try testing.expect(event.end_ms == null);
+    try testing.expect(!event.all_day);
+}
+
+test "every event field the page sends is carried, none of them dropped" {
+    const event = try parseNewEvent(
+        testing.allocator,
+        "{\"event\":{\"title\":\"Standup\",\"location\":\"Room 2\",\"notes\":\"bring laptop\"," ++
+            "\"startDate\":1700000000000,\"endDate\":1700003600000,\"isAllDay\":true}}",
+    );
+    defer event.deinit(testing.allocator);
+
+    try testing.expectEqualStrings("Standup", event.title);
+    try testing.expectEqualStrings("Room 2", event.location.?);
+    try testing.expectEqualStrings("bring laptop", event.notes.?);
+    try testing.expectEqual(@as(f64, 1700000000000), event.start_ms.?);
+    try testing.expectEqual(@as(f64, 1700003600000), event.end_ms.?);
+    try testing.expect(event.all_day);
+}
+
+test "an explicitly null location or notes is nil, which is not the empty string" {
+    // Three states on the wire collapse to two here, exactly as `as? String`
+    // collapses them: nil sets the EKEvent property to nil, and `""` sets it to
+    // an empty string. They are different events.
+    const nulled = try parseNewEvent(
+        testing.allocator,
+        "{\"event\":{\"location\":null,\"notes\":null}}",
+    );
+    defer nulled.deinit(testing.allocator);
+    try testing.expect(nulled.location == null);
+    try testing.expect(nulled.notes == null);
+
+    const empty = try parseNewEvent(
+        testing.allocator,
+        "{\"event\":{\"location\":\"\",\"notes\":\"\"}}",
+    );
+    defer empty.deinit(testing.allocator);
+    try testing.expectEqualStrings("", empty.location.?);
+    try testing.expectEqualStrings("", empty.notes.?);
+}
+
+test "a wrong-typed event string is refused rather than silently defaulted" {
+    for ([_][]const u8{
+        "{\"event\":{\"title\":42}}",
+        "{\"event\":{\"title\":true}}",
+        "{\"event\":{\"location\":[\"Room 2\"]}}",
+        "{\"event\":{\"notes\":{\"text\":\"x\"}}}",
+    }) |body| {
+        try testing.expectError(
+            bridge_error.BridgeError.InvalidParameter,
+            parseNewEvent(testing.allocator, body),
+        );
+    }
+}
+
+test "a wrong-typed nested date is refused before any framework call" {
+    // Swift's `if let … as? Double` leaves the property unset and `saveEvent:`
+    // rejects with "No start date has been set". Both end in a rejection; this
+    // one names the actual cause and happens before EventKit is touched.
+    for ([_][]const u8{
+        "{\"event\":{\"startDate\":\"2024-01-01T09:00:00Z\"}}",
+        "{\"event\":{\"endDate\":\"2024-01-01T10:00:00Z\"}}",
+        "{\"event\":{\"startDate\":1e400}}",
+    }) |body| {
+        try testing.expectError(
+            bridge_error.BridgeError.InvalidParameter,
+            parseNewEvent(testing.allocator, body),
+        );
+    }
+}
+
+test "isAllDay accepts exactly what NSNumber-as-Bool accepts" {
+    // `as? Bool` on a bridged NSNumber succeeds for a real boolean and for the
+    // numbers 0 and 1, and for nothing else. `2` is truthy in JavaScript and is
+    // still not a Bool.
+    const cases = [_]struct { body: []const u8, expected: bool }{
+        .{ .body = "{\"event\":{\"isAllDay\":true}}", .expected = true },
+        .{ .body = "{\"event\":{\"isAllDay\":false}}", .expected = false },
+        .{ .body = "{\"event\":{\"isAllDay\":1}}", .expected = true },
+        .{ .body = "{\"event\":{\"isAllDay\":0}}", .expected = false },
+        .{ .body = "{\"event\":{\"isAllDay\":1.0}}", .expected = true },
+        .{ .body = "{\"event\":{\"isAllDay\":0.0}}", .expected = false },
+        .{ .body = "{\"event\":{\"isAllDay\":null}}", .expected = false },
+    };
+    for (cases) |case| {
+        const event = try parseNewEvent(testing.allocator, case.body);
+        defer event.deinit(testing.allocator);
+        try testing.expectEqual(case.expected, event.all_day);
+    }
+
+    for ([_][]const u8{
+        "{\"event\":{\"isAllDay\":2}}",
+        "{\"event\":{\"isAllDay\":0.5}}",
+        "{\"event\":{\"isAllDay\":\"yes\"}}",
+        "{\"event\":{\"isAllDay\":[]}}",
+    }) |body| {
+        try testing.expectError(
+            bridge_error.BridgeError.InvalidParameter,
+            parseNewEvent(testing.allocator, body),
+        );
+    }
+}
+
+test "an embedded NUL in an event string is refused rather than truncated" {
+    // `stringWithUTF8String:` stops at the NUL, so carrying this across would
+    // create an event titled "Stand" and report success. Swift's `as? String`
+    // keeps the whole thing.
+    for ([_][]const u8{
+        "{\"event\":{\"title\":\"Stand\\u0000up\"}}",
+        "{\"event\":{\"location\":\"Room\\u00002\"}}",
+        "{\"event\":{\"notes\":\"a\\u0000b\"}}",
+    }) |body| {
+        try testing.expectError(
+            bridge_error.BridgeError.InvalidParameter,
+            parseNewEvent(testing.allocator, body),
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Payload parsing: deleteCalendarEvent
+// ---------------------------------------------------------------------------
+
+test "an eventId that is absent is MissingData and one that is mistyped is InvalidParameter" {
+    for ([_][]const u8{ "{}", "{\"id\":\"E1\"}", "{\"eventId\":null}" }) |body| {
+        try testing.expectError(
+            bridge_error.BridgeError.MissingData,
+            parseEventId(testing.allocator, body),
+        );
+    }
+    for ([_][]const u8{
+        "{\"eventId\":42}",
+        "{\"eventId\":true}",
+        "{\"eventId\":[\"E1\"]}",
+        // A NUL would make `eventWithIdentifier:` look up a different string
+        // than the page sent.
+        "{\"eventId\":\"E\\u00001\"}",
+    }) |body| {
+        try testing.expectError(
+            bridge_error.BridgeError.InvalidParameter,
+            parseEventId(testing.allocator, body),
+        );
+    }
+}
+
+test "an empty eventId is accepted, because the shim accepts it and answers not-found" {
+    // Refusing it here would answer a different question than the shim answers:
+    // `event(withIdentifier: "")` is nil, which is "Event not found".
+    const id = try parseEventId(testing.allocator, "{\"eventId\":\"\"}");
+    defer testing.allocator.free(id);
+    try testing.expectEqualStrings("", id);
+}
+
+test "an eventId is copied, so it survives the parse tree being freed" {
+    const id = try parseEventId(testing.allocator, "{\"eventId\":\"E-1234-ABCD\"}");
+    defer testing.allocator.free(id);
+    try testing.expectEqualStrings("E-1234-ABCD", id);
+}
+
+// ---------------------------------------------------------------------------
+// Reply shaping
+// ---------------------------------------------------------------------------
+
+const sample_event = CalEvent{
+    .id = "E1",
+    .title = "Standup",
+    .location = "Room 2",
+    .notes = "bring laptop",
+    .start_ms = 1700000000000,
+    .end_ms = 1700003600000,
+    .all_day = false,
+};
+
+test "one event carries all seven keys, in a fixed order, as a bare array" {
+    const json = try shapeEvents(testing.allocator, &.{sample_event});
+    defer testing.allocator.free(json);
+
+    try testing.expectEqualStrings(
+        "[{\"id\":\"E1\",\"title\":\"Standup\",\"location\":\"Room 2\"," ++
+            "\"notes\":\"bring laptop\",\"startDate\":1700000000000," ++
+            "\"endDate\":1700003600000,\"isAllDay\":false}]",
+        json,
+    );
+}
+
+test "an event with no location or notes still carries both keys, as empty strings" {
+    // `craft.d.ts:1174-1183` declares them optional; the runtime emits
+    // `event.location ?? ""` unconditionally, and the runtime is the contract. A
+    // page reading `e.location.length` must not meet undefined.
+    var event = sample_event;
+    event.location = "";
+    event.notes = "";
+
+    const json = try shapeEvents(testing.allocator, &.{event});
+    defer testing.allocator.free(json);
+
+    try testing.expect(std.mem.indexOf(u8, json, "\"location\":\"\"") != null);
+    try testing.expect(std.mem.indexOf(u8, json, "\"notes\":\"\"") != null);
+    try testing.expect(std.mem.indexOf(u8, json, "null") == null);
+}
+
+test "an empty result is [] and resolves, rather than being an error" {
+    const json = try shapeEvents(testing.allocator, &.{});
+    defer testing.allocator.free(json);
+    try testing.expectEqualStrings("[]", json);
+}
+
+test "several events are separated, and every one is complete" {
+    var second = sample_event;
+    second.id = "E2";
+    second.title = "Retro";
+    second.all_day = true;
+
+    const json = try shapeEvents(testing.allocator, &.{ sample_event, second });
+    defer testing.allocator.free(json);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+
+    const array = parsed.value.array;
+    try testing.expectEqual(@as(usize, 2), array.items.len);
+    for (array.items) |item| {
+        const object = item.object;
+        try testing.expectEqual(@as(usize, 7), object.count());
+        for ([_][]const u8{ "id", "title", "location", "notes", "startDate", "endDate", "isAllDay" }) |key| {
+            try testing.expect(object.get(key) != null);
+        }
+    }
+    try testing.expectEqualStrings("E2", array.items[1].object.get("id").?.string);
+    try testing.expect(array.items[1].object.get("isAllDay").?.bool);
+}
+
+test "isAllDay is a JSON boolean, not the string \"true\"" {
+    // `"false"` is truthy in JavaScript, so a quoted flag would make every timed
+    // event read as all-day.
+    var event = sample_event;
+    event.all_day = true;
+
+    const json = try shapeEvents(testing.allocator, &.{event});
+    defer testing.allocator.free(json);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqual(std.json.Value.bool, std.meta.activeTag(parsed.value.array.items[0].object.get("isAllDay").?));
+}
+
+test "user text is escaped rather than breaking the reply script" {
+    // Titles, locations and notes are user data and will contain quotes and
+    // backslashes in the wild. The reply is replayed into the source
+    // `evaluateJavaScript:` parses, so an unescaped quote is a syntax error in
+    // the page rather than a wrong field.
+    var event = sample_event;
+    event.id = "E\"1";
+    event.title = "1:1 with \"Sam\"";
+    event.location = "C:\\Rooms\\2";
+    event.notes = "line one\nline two\ttabbed";
+
+    const json = try shapeEvents(testing.allocator, &.{event});
+    defer testing.allocator.free(json);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+
+    const object = parsed.value.array.items[0].object;
+    try testing.expectEqualStrings("E\"1", object.get("id").?.string);
+    try testing.expectEqualStrings("1:1 with \"Sam\"", object.get("title").?.string);
+    try testing.expectEqualStrings("C:\\Rooms\\2", object.get("location").?.string);
+    try testing.expectEqualStrings("line one\nline two\ttabbed", object.get("notes").?.string);
+}
+
+test "the timestamps keep their fraction rather than being truncated to a millisecond" {
+    // `timeIntervalSince1970 * 1000` is a fractional double. Rounding it would be
+    // a quiet change to a value pages use to order and place events.
+    var event = sample_event;
+    event.start_ms = 1700000000123.456;
+    event.end_ms = 1700003600987.5;
+
+    const json = try shapeEvents(testing.allocator, &.{event});
+    defer testing.allocator.free(json);
+
+    try testing.expect(std.mem.indexOf(u8, json, "\"startDate\":1700000000123.456") != null);
+    try testing.expect(std.mem.indexOf(u8, json, "\"endDate\":1700003600987.5") != null);
+}
+
+test "a non-finite timestamp is refused, not printed" {
+    // `inf` and `nan` are not JSON. Printing either would produce a syntax error
+    // inside the reply script with nothing to point at; `JSONSerialization`
+    // refuses them too. Both fields are checked, because one unguarded call site
+    // is all it takes.
+    for ([_]f64{ std.math.inf(f64), -std.math.inf(f64), std.math.nan(f64) }) |bad| {
+        var start_bad = sample_event;
+        start_bad.start_ms = bad;
+        try testing.expectError(
+            bridge_error.BridgeError.InvalidParameter,
+            shapeEvents(testing.allocator, &.{start_bad}),
+        );
+
+        var end_bad = sample_event;
+        end_bad.end_ms = bad;
+        try testing.expectError(
+            bridge_error.BridgeError.InvalidParameter,
+            shapeEvents(testing.allocator, &.{end_bad}),
+        );
+    }
+}
+
+test "the created event's reply is a bare JSON string" {
+    const json = try shapeCreatedId(testing.allocator, "E-1234-ABCD");
+    defer testing.allocator.free(json);
+    try testing.expectEqualStrings("\"E-1234-ABCD\"", json);
+}
+
+test "a nil identifier is bare null, not an empty string and not a rejection" {
+    // Swift's `resolveCallback(id, result: event.eventIdentifier)` on a nil
+    // implicitly-unwrapped optional renders `null` under `.fragmentsAllowed`.
+    // Rejecting would tell the page the event was not created when it was;
+    // `""` is swallowed by `payload || {}` just the same *and* is false about the
+    // identifier. See the module comment.
+    const json = try shapeCreatedId(testing.allocator, null);
+    defer testing.allocator.free(json);
+    try testing.expectEqualStrings("null", json);
+}
+
+test "an identifier is escaped like any other user-visible string" {
+    const json = try shapeCreatedId(testing.allocator, "E\"1\\2");
+    defer testing.allocator.free(json);
+    try testing.expectEqualStrings("\"E\\\"1\\\\2\"", json);
+}
+
+test "the delete reply is bare true, which is what the page resolves" {
+    // `craft.d.ts:295` declares `Promise<void>`; `resolveCallback(id, result:
+    // true)` puts `true` on the wire. `payload || {}` passes `true` through
+    // unchanged, so this is the one reply here the coercion does not touch.
+    try testing.expectEqualStrings("true", true_fragment);
+}
+
+test "milliseconds become seconds exactly once" {
+    // Swift divides at the NSDate (3297-3298, 3332, 3335). Doing it twice, or
+    // not at all, moves every event by a factor of a thousand — 1970 or the year
+    // 55000, both of which look like data rather than a bug.
+    try testing.expectEqual(@as(f64, 1700000000), secondsFromMilliseconds(1700000000000));
+    try testing.expectEqual(@as(f64, 0), secondsFromMilliseconds(0));
+    try testing.expectEqual(@as(f64, -1.5), secondsFromMilliseconds(-1500));
+    try testing.expectEqual(@as(f64, 1700000000.1234), secondsFromMilliseconds(1700000000123.4));
+}
+
+// ---------------------------------------------------------------------------
+// Transcribed constants
+// ---------------------------------------------------------------------------
+
+test "the framework constants are the ones the headers give" {
+    // Transcribed from headers rather than read from the runtime, so a test is
+    // the only thing holding them. A wrong entity type requests reminders and
+    // reports it as calendar access; a wrong span edits or deletes every
+    // occurrence of a recurring event; a wrong calendar unit changes the default
+    // range from a month to a day or a year.
+    try testing.expectEqual(@as(c_ulong, 0), ek_entity_type_event);
+    try testing.expectEqual(@as(c_long, 0), ek_span_this_event);
+    try testing.expectEqual(@as(c_ulong, 8), ns_calendar_unit_month);
+    try testing.expectEqual(@as(c_ulong, 0), ns_calendar_options_none);
+    try testing.expectEqual(@as(c_ulong, 4), ns_utf8_string_encoding);
+    try testing.expectEqualStrings("NSCalendarsUsageDescription", key_calendars_usage);
+}
+
+test "the deprecated access request is the one this file makes" {
+    // Swift 3291/3320 call `requestAccessToEntityType:` with no availability
+    // fork, and `packages/ios/src/index.ts:190` writes only
+    // NSCalendarsUsageDescription. The iOS 17 replacement needs
+    // NSCalendarsFullAccessUsageDescription, which nothing in this repo writes,
+    // so calling it would terminate the app.
+    //
+    // The needle is the *call* form rather than the bare API name, so the prose
+    // in this file cannot match itself and the assertion keeps meaning
+    // something — which is why the needle is not spelled out in any comment,
+    // including this one.
+    const source = @embedFile("bridge_mobile_calendar.zig");
+    try testing.expect(std.mem.indexOf(u8, source, "selector(\"requestFullAccess") == null);
+    // Non-vacuity: the same scan finds the call that is present, so a needle
+    // that stopped matching anything could not pass unnoticed.
+    try testing.expect(std.mem.indexOf(u8, source, "selector(\"requestAccessToEntityType") != null);
+}
+
+// ---------------------------------------------------------------------------
+// The side table
+// ---------------------------------------------------------------------------
+
+test "a second completion for the same slot finds nothing to answer" {
+    // Clearing on read is what makes a duplicate fire a no-op rather than a
+    // second reply to a promise that has already settled — and, for a pending
+    // create, rather than a double free of its strings.
+    resetPendingForTesting();
+    defer resetPendingForTesting();
+
+    const ticket = fakeTicket(3, 7);
+    publishPendingCall(ticket, fakeSels(), null, .{ .fetch = .{} });
+
+    const first = takePendingCall(3);
+    try testing.expect(first != null);
+    try testing.expectEqual(@as(u32, 7), first.?.ticket.generation);
+
+    try testing.expect(takePendingCall(3) == null);
+}
+
+test "two calls in flight keep separate entries" {
+    // The reason this is a per-slot table rather than contactpicker's single
+    // `pending`: nothing here is modal, so two getCalendarEvents at once is an
+    // ordinary page, and one slot would refuse the second for no reason.
+    resetPendingForTesting();
+    defer resetPendingForTesting();
+
+    publishPendingCall(fakeTicket(0, 1), fakeSels(), null, .{ .fetch = .{ .start_ms = 1 } });
+    publishPendingCall(fakeTicket(1, 1), fakeSels(), null, .{ .fetch = .{ .start_ms = 2 } });
+
+    const second = takePendingCall(1) orelse return error.EntryMissing;
+    try testing.expectEqual(@as(f64, 2), second.request.fetch.start_ms.?);
+
+    // Taking one must not disturb the other.
+    const first = takePendingCall(0) orelse return error.EntryMissing;
+    try testing.expectEqual(@as(f64, 1), first.request.fetch.start_ms.?);
+}
+
+test "a pending create owns its strings and frees them all" {
+    // The strings outlive the dispatch frame, so they are allocated from the
+    // allocator the completion frees with. Running it under the testing
+    // allocator is what proves the ownership is complete rather than asserted.
+    const event = try parseNewEvent(
+        testing.allocator,
+        "{\"event\":{\"title\":\"Standup\",\"location\":\"Room 2\",\"notes\":\"bring laptop\"}}",
+    );
+
+    resetPendingForTesting();
+    defer resetPendingForTesting();
+
+    publishPendingCall(fakeTicket(2, 4), fakeSels(), null, .{ .create = event });
+
+    const call = takePendingCall(2) orelse return error.EntryMissing;
+    try testing.expectEqualStrings("Standup", call.request.create.title);
+    call.request.deinit(testing.allocator);
+}
+
+// ---------------------------------------------------------------------------
+// The gates, exercised for real
+// ---------------------------------------------------------------------------
+
+test "a process without the calendar usage description is refused before EventKit is touched" {
+    // The test runner is exactly the process the gate exists for: no bundle
+    // Info.plist, so no NSCalendarsUsageDescription. On a device that is an app
+    // built with `enableCalendar: false`, and requesting access there would raise
+    // NSInternalInconsistencyException — an uncatchable SIGABRT — which is why
+    // this runs before the store is ever created.
+    //
+    // Off Darwin the same call is refused one step earlier, at the platform
+    // guard. Either way the answer is a rejection and never silence, and neither
+    // path reaches EventKit.
+    var bridge = CalendarBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    const expected = if (is_darwin)
+        bridge_error.BridgeError.PermissionDenied
+    else
+        error.UnsupportedPlatform;
+
+    try testing.expectError(expected, bridge.handleMessage(A.get_calendar_events, "{}"));
+    try testing.expectError(
+        expected,
+        bridge.handleMessage(A.create_calendar_event, "{\"event\":{\"title\":\"x\"}}"),
+    );
+    // Delete is gated too. It requests no access, so for that one action the key
+    // is only evidence of `config.enableCalendar` — but the flag guards all three
+    // Swift cases, so it guards all three here.
+    try testing.expectError(
+        expected,
+        bridge.handleMessage(A.delete_calendar_event, "{\"eventId\":\"E1\"}"),
+    );
+}
+
+test "a malformed payload is refused before any platform or permission gate" {
+    // Parsing first is what makes a bad body report the same cause on every
+    // platform, and report it before a framework is consulted. These three
+    // assertions hold identically on a host with no EventKit and on a device.
+    var bridge = CalendarBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidJSON,
+        bridge.handleMessage(A.get_calendar_events, "not json"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.MissingData,
+        bridge.handleMessage(A.create_calendar_event, "{}"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.MissingData,
+        bridge.handleMessage(A.delete_calendar_event, "{}"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        bridge.handleMessage(A.get_calendar_events, "{\"startDate\":\"2024-01-01\"}"),
+    );
+}

--- a/packages/zig/src/bridge_mobile_contacts.zig
+++ b/packages/zig/src/bridge_mobile_contacts.zig
@@ -1,0 +1,2479 @@
+//! `getContacts` and `addContact` — the address book itself, read and written
+//! through `CNContactStore`.
+//!
+//! The Swift original is `CraftApp.swift:705-713` (dispatch), `3224-3258`
+//! (`getContacts`), `3260-3287` (`addContact`), `1763-1780` (the injected JS
+//! that decides the wire payload) and `402-403`/`449-451` (the one store
+//! instance). Every claim below is measured against those lines.
+//!
+//! This is a sibling of `bridge_mobile_contactpicker.zig` and not a variation
+//! on it: the picker runs out of process, needs no authorization and answers a
+//! *selection*; these two ask TCC for access to the whole book and then read or
+//! write it. The reply shapes differ too — see "Two writers" below.
+//!
+//! ## The payloads
+//!
+//! **`getContacts` sends nothing.** `craft.contacts.getAll()` posts
+//! `{action:'getContacts', callbackId: id}` and Swift's case reads nothing off
+//! `body`, so `d` arrives as `{}`. There is no limit, no offset and no paging
+//! anywhere in the spec. The handler therefore takes no `data` parameter at
+//! all — a test pins that signature — because a body this action never reads
+//! must not be able to fail the call: rejecting a malformed `d` here would fail
+//! a call the shim answers.
+//!
+//! **`addContact` sends one field, `contact`, and it is a nested object.**
+//! `craft.contacts.add(contact)` posts `{action:'addContact', contact: contact,
+//! callbackId: id}`, so the stringified `d` has a root key `contact` whose
+//! value is an object. Swift reads exactly four keys out of it, each with
+//! `as? String`:
+//!
+//!   `givenName`, `familyName` -> set directly on a `CNMutableContact`;
+//!   `phone` -> one `CNLabeledValue(label: CNLabelPhoneNumberMain,
+//!               value: CNPhoneNumber(stringValue:))`;
+//!   `email` -> one `CNLabeledValue(label: CNLabelHome, value: email as NSString)`.
+//!
+//! `as? String` is ported exactly, and it is not a coercion: a non-string value
+//! (`{"phone": 5551234}`, a bool, a null, an object) makes the `if let` fail and
+//! leaves the property *unset*. It is not an error, and it is emphatically not
+//! "stringify it anyway". `contactFieldFrom` below is that rule, and the tests
+//! pin it.
+//!
+//! **`displayName` on the way in is dropped, deliberately.**
+//! `craft.d.ts:1166-1172` declares `NewContact.displayName?` and
+//! `test-bridges.html:816` sends it, but `CraftApp.swift:3267-3275` never reads
+//! it and `CNMutableContact` has no settable `displayName` — it is derived from
+//! the name components. Dropping it is spec parity, not a Zig regression, and
+//! saying so here is the point: silently omitting it would read as an oversight
+//! the next time somebody diffs the two.
+//!
+//! ## The replies, which are two different shapes
+//!
+//! `resolveCallback` serialises with `.fragmentsAllowed`, so bare fragments are
+//! real answers rather than a mistake.
+//!
+//!   - **`getContacts` resolves a JSON array** of six-key objects:
+//!     `{"id","givenName","familyName","displayName","phoneNumbers",
+//!     "emailAddresses"}`, where `phoneNumbers` and `emailAddresses` are **flat
+//!     arrays of strings** (`phone.value.stringValue`, `email.value as String`).
+//!     An empty address book is `[]`, and `[]` **resolves** — a fresh Simulator
+//!     answers exactly that, `test-bridges.html:804` prints `Found 0 contacts`,
+//!     and reporting it as a failure would be a lie about a call that worked.
+//!   - **`addContact` resolves a bare JSON string**: Swift passes
+//!     `contact.identifier`, a `String`, through `.fragmentsAllowed`, which
+//!     serialises to `"ABCD-1234-..."` *including the quotes*. The page does
+//!     `'Contact created with ID: ' + id`. So the reply bytes are a quoted,
+//!     escaped string literal — the same shape `ios_async` already sends for
+//!     `"granted"`.
+//!
+//! Swift builds `[String: Any]`, whose key order is a `Dictionary`'s and
+//! therefore arbitrary; one order is fixed here so the bytes are testable, the
+//! same call `bridge_mobile_contactpicker.appendContact` makes.
+//!
+//! **Neither action emits anything.** There is no `sendToWeb` on any contacts
+//! path in `CraftApp.swift` and no contacts listener in `test-bridges.html`.
+//! `ios_events.Event` has no contacts member and must not grow one for this:
+//! an event here would be a message the shim never sends.
+//!
+//! ## Two writers, on purpose
+//!
+//! `bridge_mobile_contactpicker.zig` also serialises `CNContact`s, and its
+//! `formatContact` port emits `phoneNumbers: [{label, number}]` /
+//! `emailAddresses: [{label, address}]`. This file emits flat `string[]`. Both
+//! are correct: they are two Swift functions with two shapes
+//! (`CraftApp.swift:3244-3251` here, `5106-5136` there), and
+//! `craft.d.ts:1157-1164` — which declares `string[]` — agrees with *this* one
+//! and is wrong for the picker. Unifying them would break one of the two pages
+//! that consume them, so the two writers stay, and each names its Swift source.
+//!
+//! The reading layer is a different story and worth stating plainly: `Sels`,
+//! `readString`, `infoPlistValue` and `requireContactsConfigured` here overlap
+//! the picker's file-private versions. Sharing them is a one-line-per-decl
+//! `pub` change in that file plus an import, and it was left undone only
+//! because this round was scoped to one new file. Two things would still not
+//! have been shared: the picker's `readLabeledValues` computes a localized
+//! label via `+[CNLabeledValue localizedStringForLabel:]` that `getContacts`
+//! throws away — once per value across an entire address book — and the
+//! picker's `Sels.resolve` hard-fails when `CNContactFormatter` is absent, a
+//! class neither of these actions uses. So the honest note is "duplicated, ~70
+//! lines, remedy known", not "could not be shared".
+//!
+//! ## The Info.plist gate is a real precondition here
+//!
+//! `packages/ios/src/index.ts:189` writes `NSContactsUsageDescription` if and
+//! only if `config.enableContacts`, which is what makes the key readable as
+//! evidence of the flag Swift guards both cases with. But unlike the picker —
+//! which qualifies its own gate as *only* evidence — this is also the
+//! framework's own precondition: `requestAccessForEntityType:` in a process
+//! without that key does not return an error, TCC **kills the process**. From
+//! Zig that is an uncatchable SIGABRT, so the key is checked first on both
+//! actions, before `CNContactStore` is touched.
+//!
+//! `CNContactStore` itself is guarded separately and named in the log, because
+//! `packages/ios/fixtures/zig-slice` links neither Contacts nor ContactsUI and
+//! the fix for that is a link line rather than anything in this file.
+//!
+//! ## What diverges from the shim, stated rather than smoothed over
+//!
+//! **A denial's code and message change.** Swift rejects with
+//! `code: "CRAFT_ERROR"` and `error?.localizedDescription ?? "Permission
+//! denied"` (3226) / `"Permission denied"` (3263). Here a denial is
+//! `ios_async.deliverErrorCode(ticket, PermissionDenied)`, which the page sees
+//! as `code:"PERMISSION_DENIED"`, `message:"Permission denied"`. The code is
+//! *more* accurate — a user declining a prompt is not a native call failing —
+//! and a page branching on `err.code` still sees a change.
+//! `test-bridges.html:806/822` prints `e.message`.
+//!
+//! **`localizedDescription` cannot be carried.** `ios_async` transports a
+//! `BridgeError` enum and nothing else, so an `NSError`'s domain, code and
+//! description are logged where they happen and never reach the page. Inventing
+//! a second reply channel to carry them would reach around the generation guard
+//! that stops a stale completion answering somebody else's call.
+//!
+//! **A missing or non-object `contact` rejects where Swift hangs.**
+//! `case "addContact"` has no `else` (709-713), and the promise it leaves
+//! unanswered is hand-built (1772-1779) rather than made by `_createCallback`,
+//! so it carries none of the 30-second timeout at 1196-1209: the page waits
+//! forever. Here it is `MISSING_DATA` (absent) or `INVALID_PARAMETER` (present
+//! but not an object). Everybody settles, which is strictly better, and it is a
+//! difference a page can observe. The same is true of `enableContacts: false`,
+//! which Swift answers with silence on both actions and this file answers with
+//! `PERMISSION_DENIED`.
+//!
+//! **An embedded NUL is refused rather than truncated.** On the way *in*,
+//! `objc.createNSString` goes through `stringWithUTF8String:`, which stops at
+//! the first NUL — so a `givenName` containing U+0000 would be silently stored
+//! as its prefix. That is a wrong value written to the user's address book, so
+//! it is rejected as `INVALID_PARAMETER` instead; Swift would have stored the
+//! whole string. On the way *out*, `readString`'s length check fails the whole
+//! `getContacts` for one such contact, which is the picker's pre-existing
+//! divergence inherited unchanged rather than a new one.
+//!
+//! **An unfetched key still crashes.** Touching a property outside
+//! `keysToFetch` raises `CNContactPropertyNotFetchedException`, an uncatchable
+//! SIGABRT from Zig. Swift cannot catch `NSException` either, so this is parity
+//! — and there is deliberately no comment below claiming a guard, because there
+//! is none. The five keys are fetched precisely because of it.
+//!
+//! **iOS 18 limited access is reported as what it returned.**
+//! `requestAccessForEntityType:` can answer `granted = YES` with only a
+//! user-chosen subset visible; enumeration then walks that subset. The array is
+//! what was actually returned, and nothing here annotates it with a
+//! completeness claim the framework did not make.
+//!
+//! ## Concurrency
+//!
+//! Unlike the picker, which owns one on-screen resource and refuses a second
+//! call, nothing here is exclusive: two `getContacts` in flight are two reads.
+//! So the pending state is one entry per `ios_async` slot — the
+//! `bridge_mobile_notifications.zig` pattern — and each slot is leased
+//! exclusively by its ticket, which is what makes a plain write to
+//! `pending_calls[ticket.index]` safe. The mutex is still held on every access,
+//! because "the completion should be on the main thread" is not a guard and
+//! `requestAccessForEntityType:` promises no queue at all.
+//!
+//! `enumerateContactsWithFetchRequest:error:usingBlock:` is *synchronous* — its
+//! block runs on the calling thread and the call returns when the walk ends —
+//! so the enumeration state is a pointer to a stack frame that provably
+//! outlives every fire, published under its own mutex for the duration of the
+//! call and cleared immediately after.
+//!
+//! No reply is ever sent from a completion directly. `ios_async` is the only
+//! channel, and its main-queue hop is not merely thread safety: it restores the
+//! `request_context` captured at dispatch, so the reply names the call that is
+//! waiting instead of falling back to action-name matching.
+//!
+//! ## A loose end that belongs to the page, not to this file
+//!
+//! `test-bridges.html:803/813` calls `window.craft.getContacts()` and
+//! `window.craft.addContact({...})`, but the injected JS defines only
+//! `window.craft.contacts.getAll()` and `.add(contact)`. As written the test
+//! page throws `TypeError` into its own `catch` and never reaches the bridge,
+//! so a green run of it proves nothing about either action. The wire contract
+//! above comes from the injected JS (the only authority for what is posted) and
+//! from Swift's resolve calls; `craft.d.ts:258/265`, `packages/ios/README.md`
+//! and `examples/basic-app.ts` agree on the *shapes* even where they use the
+//! flat names.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const capabilities = @import("capabilities.zig");
+const bridge_error = @import("bridge_error.zig");
+const objc_runtime = @import("objc_runtime.zig");
+const ios_async = @import("ios_async.zig");
+const compat_mutex = @import("compat_mutex.zig");
+
+const objc = objc_runtime.objc;
+const is_darwin = builtin.target.os.tag.isDarwin();
+
+/// The same type as `objc.id` — `?*anyopaque` — spelled locally, per the
+/// picker/location/notifications precedent: `objc_runtime.objc` is an empty
+/// struct off Darwin and a `callconv(.c)` function *signature* is analysed even
+/// where a comptime platform guard prunes the body. A single optional pointer,
+/// never `?objc.id`, which would be a double optional and illegal in
+/// `callconv(.c)`.
+const Id = ?*anyopaque;
+
+/// The action names, spelled exactly as the Swift `case` labels spell them.
+/// `test/ios_conformance_test.zig` matches this block against those labels in
+/// both directions and fails the build if two modules declare one name.
+pub const A = struct {
+    pub const get_contacts = "getContacts";
+    pub const add_contact = "addContact";
+};
+
+/// `.result` for both: every Swift path out of either action terminates in
+/// exactly one `resolveCallback` or one `rejectCallback`. `.none` would claim
+/// nothing answers, and on these hand-built promises — no `_createCallback`, no
+/// `setTimeout` — that is a page parked for its lifetime rather than 30
+/// seconds.
+///
+/// `.live`, not `.unavailable`: in an app built with `enableContacts` both work
+/// end to end, on the Simulator included. Every refusal below is a specific
+/// condition (not configured, Contacts unlinked, access declined, the async
+/// pool full), never the normal answer.
+pub const capability_actions = [_]capabilities.ActionDecl{
+    .{ .name = A.get_contacts, .reply = .result },
+    .{ .name = A.add_contact, .reply = .result },
+};
+
+/// Which handler an action selects, split out from `handleMessage` so the
+/// table-versus-dispatch agreement is assertable on a host without touching
+/// Contacts.framework.
+const Route = enum { get_contacts, add_contact };
+
+fn routeFor(action: []const u8) ?Route {
+    if (std.mem.eql(u8, action, A.get_contacts)) return .get_contacts;
+    if (std.mem.eql(u8, action, A.add_contact)) return .add_contact;
+    return null;
+}
+
+pub const ContactsBridge = struct {
+    allocator: std.mem.Allocator,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator) Self {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(_: *Self) void {}
+
+    pub fn handleMessage(self: *Self, action: []const u8, data: []const u8) !void {
+        const route = routeFor(action) orelse return bridge_error.BridgeError.UnknownAction;
+        // Exhaustive, so a `Route` without a handler is a compile error.
+        return switch (route) {
+            .get_contacts => self.getContacts(),
+            .add_contact => self.addContact(data),
+        };
+    }
+
+    /// Ask for access, then enumerate the whole book.
+    ///
+    /// No `data` parameter, and that is the contract rather than an omission:
+    /// Swift reads nothing off the body, so there is no field to drop and no
+    /// malformed payload that may fail this call.
+    ///
+    /// Ordering is load-bearing. Every fallible step — the Info.plist gate, the
+    /// store, every selector the completion and the enumeration will need, the
+    /// five key constants, the fetch request — runs *before*
+    /// `ios_async.acquire`, because after the lease a failure can only be
+    /// logged. No path leaves after the lease without reaching the framework
+    /// call — `publishPendingCall` and the `msgSend` are both infallible — and
+    /// a future edit that adds one must `ios_async.abandon` on its way out or
+    /// the slot narrows the pool for the life of the process.
+    fn getContacts(_: *Self) !void {
+        if (!is_darwin) return error.UnsupportedPlatform;
+
+        try requireContactsConfigured(A.get_contacts);
+
+        const store = try contactStore();
+        const sels = try ReadSels.resolve();
+        // +1. Released by the completion, on every path including denial.
+        const request = try fetchRequest();
+        errdefer objc.release(request);
+
+        const ticket = ios_async.acquire(A.get_contacts) orelse return poolFull(A.get_contacts);
+
+        // Published *before* the framework call, never after: a completion that
+        // fired first would otherwise find no ticket to answer with.
+        publishPendingCall(.{
+            .ticket = ticket,
+            .store = store.object,
+            .work = .{ .get_contacts = .{ .request = request, .sels = sels } },
+        });
+
+        requestAccess(store, ticket);
+    }
+
+    /// Build the contact synchronously, then ask for access and save it.
+    ///
+    /// The `CNMutableContact` and its `CNSaveRequest` are assembled here rather
+    /// than in the completion for the reason above: building them needs no
+    /// authorization, and doing it at dispatch keeps every fallible
+    /// Objective-C step ahead of the lease — while also avoiding a copy of four
+    /// payload strings into slot storage that outlives this frame. Both objects
+    /// are +1 and both are released by the completion, denial included.
+    fn addContact(self: *Self, data: []const u8) !void {
+        var fields = try parseNewContact(self.allocator, data);
+        defer fields.deinit(self.allocator);
+
+        if (!is_darwin) return error.UnsupportedPlatform;
+
+        try requireContactsConfigured(A.add_contact);
+
+        const store = try contactStore();
+        const sels = try SaveSels.resolve();
+        const build = try BuildSels.resolve();
+
+        const contact = try buildContact(self.allocator, fields, build);
+        errdefer objc.release(contact);
+
+        const save = try buildSaveRequest(contact, build);
+        errdefer objc.release(save);
+
+        const ticket = ios_async.acquire(A.add_contact) orelse return poolFull(A.add_contact);
+
+        publishPendingCall(.{
+            .ticket = ticket,
+            .store = store.object,
+            .work = .{ .add_contact = .{ .contact = contact, .save = save, .sels = sels } },
+        });
+
+        requestAccess(store, ticket);
+    }
+};
+
+/// The answer for a full block pool, copied from `bridge_mobile_location` and
+/// the picker: `BridgeError` has no "Busy", `INVALID_PARAMETER` is the
+/// migration notes' designated stand-in, and the point is that the caller gets
+/// an explicit rejection instead of a promise that never settles.
+fn poolFull(action: []const u8) bridge_error.BridgeError {
+    std.log.warn(
+        "{s} refused: all {d} async slots are in flight",
+        .{ action, ios_async.max_in_flight },
+    );
+    return bridge_error.BridgeError.InvalidParameter;
+}
+
+// =============================================================================
+// Payload parsing. Pure — no Objective-C — so the exact `as? String` rule Swift
+// applies is pinned by host tests on every platform.
+// =============================================================================
+
+/// The four fields Swift reads out of `contact`, each present only if it
+/// arrived as a JSON string. `null` means "Swift's `if let` would not have
+/// fired", which leaves the property unset — not empty, unset.
+const NewContact = struct {
+    given_name: ?[]const u8 = null,
+    family_name: ?[]const u8 = null,
+    phone: ?[]const u8 = null,
+    email: ?[]const u8 = null,
+
+    /// The strings are copies: the parsed JSON tree is freed before the
+    /// `NSString`s are built from them.
+    fn deinit(self: *NewContact, allocator: std.mem.Allocator) void {
+        if (self.given_name) |s| allocator.free(s);
+        if (self.family_name) |s| allocator.free(s);
+        if (self.phone) |s| allocator.free(s);
+        if (self.email) |s| allocator.free(s);
+        self.* = .{};
+    }
+};
+
+/// `body["contact"] as? [String: Any]`, plus the rejection Swift does not have.
+///
+/// A malformed `d`, a non-object `d`, an absent `contact` and a non-object
+/// `contact` are four different facts and are reported as three different
+/// errors. Swift collapses all of them into "answer nothing", on a promise with
+/// no timeout — see the module comment.
+fn parseNewContact(allocator: std.mem.Allocator, data: []const u8) !NewContact {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch
+        return bridge_error.BridgeError.InvalidJSON;
+    defer parsed.deinit();
+
+    const root = switch (parsed.value) {
+        .object => |obj| obj,
+        else => return bridge_error.BridgeError.InvalidJSON,
+    };
+
+    const contact_value = root.get("contact") orelse {
+        std.log.warn(
+            "addContact refused: the message carries no `contact` object " ++
+                "(Swift answers such a call with nothing at all)",
+            .{},
+        );
+        return bridge_error.BridgeError.MissingData;
+    };
+
+    const contact = switch (contact_value) {
+        .object => |obj| obj,
+        else => {
+            std.log.warn(
+                "addContact refused: `contact` is not an object, so there is nothing to save",
+                .{},
+            );
+            return bridge_error.BridgeError.InvalidParameter;
+        },
+    };
+
+    var out = NewContact{};
+    errdefer out.deinit(allocator);
+
+    out.given_name = try contactFieldFrom(allocator, contact, "givenName");
+    out.family_name = try contactFieldFrom(allocator, contact, "familyName");
+    out.phone = try contactFieldFrom(allocator, contact, "phone");
+    out.email = try contactFieldFrom(allocator, contact, "email");
+
+    return out;
+}
+
+/// One `data["key"] as? String`, as a total function.
+///
+/// Absent is null. Present-but-not-a-string is *also* null, because that is
+/// what `as? String` yields and what Swift's `if let` then skips: erroring on
+/// `{"phone": 5551234}` would refuse a call the shim accepts, and stringifying
+/// it would write a value the page never sent.
+///
+/// The one refusal is an embedded NUL, which `stringWithUTF8String:` would
+/// truncate silently — a wrong value in the user's address book. See the module
+/// comment.
+fn contactFieldFrom(
+    allocator: std.mem.Allocator,
+    contact: std.json.ObjectMap,
+    comptime key: []const u8,
+) !?[]const u8 {
+    const value = contact.get(key) orelse return null;
+
+    const text = switch (value) {
+        .string => |s| s,
+        // A number (including `number_string`, which is still a number), a
+        // bool, a null, an array, an object. `as? String` is nil for every one.
+        else => {
+            std.log.info(
+                "addContact: `" ++ key ++ "` is not a string, so it is left unset — " ++
+                    "the same thing Swift's `as? String` does with it",
+                .{},
+            );
+            return null;
+        },
+    };
+
+    if (std.mem.indexOfScalar(u8, text, 0) != null) {
+        std.log.warn(
+            "addContact refused: `" ++ key ++ "` contains an embedded NUL, which " ++
+                "stringWithUTF8String: would silently truncate",
+            .{},
+        );
+        return bridge_error.BridgeError.InvalidParameter;
+    }
+
+    return try allocator.dupe(u8, text);
+}
+
+// =============================================================================
+// Reply shaping. Pure — no Objective-C — so the exact bytes the page receives
+// are pinned by host tests.
+// =============================================================================
+
+/// One contact as `CraftApp.swift:3244-3251` assembles it.
+///
+/// `phones` and `emails` are flat strings, not `{label, ...}` pairs: this is
+/// the `getContacts` shape, and the picker's is the other one. See "Two
+/// writers" in the module comment before making these agree.
+///
+/// The strings borrow whatever buffer they were read from — on the native path
+/// an `NSString`'s internal UTF-8 buffer, valid for the enclosing autorelease
+/// pool — and every one of them is copied into the JSON before that pool ends.
+const ContactRow = struct {
+    id: []const u8,
+    given_name: []const u8,
+    family_name: []const u8,
+    display_name: []const u8,
+    phones: []const []const u8,
+    emails: []const []const u8,
+};
+
+fn appendJsonString(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    s: []const u8,
+) !void {
+    try out.append(allocator, '"');
+    // Names, numbers and addresses are user data and will contain `"` and `\`
+    // in the wild. The reply is replayed into the source `evaluateJavaScript:`
+    // parses, so an unescaped quote is a syntax error in the page rather than a
+    // wrong field.
+    try bridge_error.appendJsonEscaped(allocator, out, s);
+    try out.append(allocator, '"');
+}
+
+fn appendStringArray(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    items: []const []const u8,
+) !void {
+    try out.append(allocator, '[');
+    for (items, 0..) |item, i| {
+        if (i != 0) try out.append(allocator, ',');
+        try appendJsonString(allocator, out, item);
+    }
+    try out.append(allocator, ']');
+}
+
+/// One contact as a JSON object, in a fixed key order.
+///
+/// Swift's `[String: Any]` has no order at all; fixing one here is what makes
+/// the bytes testable. Both array keys are always written, so a page reading
+/// `contact.phoneNumbers.length` never meets `undefined`.
+fn appendContactRow(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    row: ContactRow,
+) !void {
+    try out.appendSlice(allocator, "{\"id\":");
+    try appendJsonString(allocator, out, row.id);
+    try out.appendSlice(allocator, ",\"givenName\":");
+    try appendJsonString(allocator, out, row.given_name);
+    try out.appendSlice(allocator, ",\"familyName\":");
+    try appendJsonString(allocator, out, row.family_name);
+    try out.appendSlice(allocator, ",\"displayName\":");
+    try appendJsonString(allocator, out, row.display_name);
+    try out.appendSlice(allocator, ",\"phoneNumbers\":");
+    try appendStringArray(allocator, out, row.phones);
+    try out.appendSlice(allocator, ",\"emailAddresses\":");
+    try appendStringArray(allocator, out, row.emails);
+    try out.append(allocator, '}');
+}
+
+/// The `getContacts` reply, built one contact at a time.
+///
+/// Incremental because the source is an enumeration callback rather than a
+/// list: `enumerateContactsWithFetchRequest:` hands over one `CNContact` at a
+/// time and there is no count to size anything from. The alternative — collect
+/// every contact into a slice of borrowed slices first — would keep an entire
+/// address book's worth of `NSString` buffers alive on the promise that the
+/// autorelease pool outlives the walk, which is exactly the kind of claim this
+/// file should not be making.
+///
+/// The bracket and comma bookkeeping lives here rather than at the call site so
+/// the native path and the tests build the array through the same code.
+const RowWriter = struct {
+    out: std.ArrayListUnmanaged(u8) = .empty,
+    rows: usize = 0,
+
+    fn begin(self: *RowWriter, allocator: std.mem.Allocator) !void {
+        try self.out.append(allocator, '[');
+    }
+
+    fn append(self: *RowWriter, allocator: std.mem.Allocator, row: ContactRow) !void {
+        if (self.rows != 0) try self.out.append(allocator, ',');
+        try appendContactRow(allocator, &self.out, row);
+        self.rows += 1;
+    }
+
+    /// `[]` for an empty address book, which **resolves**. See the module
+    /// comment: a fresh Simulator answers exactly that and it is a correct
+    /// answer, not a failure.
+    fn finish(self: *RowWriter, allocator: std.mem.Allocator) ![]u8 {
+        try self.out.append(allocator, ']');
+        return self.out.toOwnedSlice(allocator);
+    }
+
+    fn deinit(self: *RowWriter, allocator: std.mem.Allocator) void {
+        self.out.deinit(allocator);
+    }
+};
+
+/// The `addContact` reply: a bare, quoted, escaped JSON string.
+///
+/// Not an object, and not the identifier raw. Swift resolves the `String`
+/// itself under `.fragmentsAllowed`, so `{"id": ...}` here would make the
+/// page's `'ID: ' + id` print `[object Object]`.
+fn shapeIdentifier(allocator: std.mem.Allocator, identifier: []const u8) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+    try appendJsonString(allocator, &out, identifier);
+    return out.toOwnedSlice(allocator);
+}
+
+/// `"\(givenName) \(familyName)"` — always exactly one space, before trimming.
+///
+/// The trim itself is deliberately *not* done here. Swift's
+/// `trimmingCharacters(in: .whitespaces)` is Unicode general category Zs plus
+/// U+0009, both ends only, interior runs preserved, and a byte-wise `" \t"`
+/// trim would be an approximation that diverges on a name padded with U+00A0.
+/// `readDisplayName` hands this string to
+/// `-[NSString stringByTrimmingCharactersInSet:]` with
+/// `+[NSCharacterSet whitespaceCharacterSet]` — the same object
+/// `CharacterSet.whitespaces` bridges to — so the result is Swift's, not an
+/// imitation of it.
+fn joinName(allocator: std.mem.Allocator, given: []const u8, family: []const u8) ![]u8 {
+    return std.fmt.allocPrint(allocator, "{s} {s}", .{ given, family });
+}
+
+// =============================================================================
+// Objective-C. Everything resolved at dispatch, where a failure can still be an
+// ordinary rejection; nothing is looked up inside a completion.
+//
+// Every function below opens with the Darwin guard. That is not decoration: off
+// Darwin `objc_runtime.objc` is an empty struct, and a comptime-false `if` that
+// returns is what stops the rest of the body being analysed at all.
+// =============================================================================
+
+/// The Info.plist key `packages/ios/src/index.ts:189` writes if and only if
+/// `config.enableContacts` — and the key `requestAccessForEntityType:` requires
+/// on pain of process death. See the module comment.
+const key_contacts_usage = "NSContactsUsageDescription";
+
+/// `NSUTF8StringEncoding`. Used only to ask a string how long it really is, so
+/// a NUL-truncated read can be told from a short string.
+const ns_utf8_string_encoding: c_ulong = 4;
+
+/// `CNEntityType.contacts` = 0. `CNEntityType` is `NSInteger`, hence `c_long`;
+/// `bridge_mobile_permissions.zig:505` spells the same constant the same way.
+const cn_entity_type_contacts: c_long = 0;
+
+/// The five keys `CraftApp.swift:3230` fetches, in its order.
+///
+/// Resolved by `dlsym` rather than hardcoded. Their documented *values* are the
+/// KVC names (`"givenName"`, `"identifier"`, ...), so a fallback would be
+/// defensible — but a wrong or missing fetch key does not fail loudly: it
+/// produces a contact whose property access raises
+/// `CNContactPropertyNotFetchedException`, an uncatchable SIGABRT. Refusing
+/// when `dlsym` misses trades a crash for a rejection, and if `CNContactStore`
+/// resolved then Contacts.framework is loaded and these symbols are present.
+const contact_key_symbols = [_][:0]const u8{
+    "CNContactGivenNameKey",
+    "CNContactFamilyNameKey",
+    "CNContactPhoneNumbersKey",
+    "CNContactEmailAddressesKey",
+    "CNContactIdentifierKey",
+};
+
+/// The two labels `addContact` writes. Same `dlsym`-or-refuse policy, and here
+/// the argument is stronger: a wrong label does not fail at all, it saves a
+/// contact whose number is filed under the wrong heading in the user's address
+/// book. Documented values are `"_$!<Main>!$_"` and `"_$!<Home>!$_"`, and
+/// guessing them is exactly what this avoids.
+const label_phone_main = "CNLabelPhoneNumberMain";
+const label_email_home = "CNLabelHome";
+
+fn selector(name: [*:0]const u8) !Id {
+    if (!is_darwin) return error.UnsupportedPlatform;
+    return objc.sel_registerName(name) orelse error.SelectorNotFound;
+}
+
+fn class(name: [*:0]const u8, action: []const u8) !Id {
+    if (!is_darwin) return error.UnsupportedPlatform;
+    return objc.objc_getClass(name) orelse {
+        std.log.err(
+            "{s} refused: this process has no {s}; Contacts.framework is not linked",
+            .{ action, name },
+        );
+        return bridge_error.BridgeError.PlatformNotSupported;
+    };
+}
+
+extern "c" fn dlsym(handle: ?*anyopaque, symbol: [*:0]const u8) ?*anyopaque;
+
+/// dyld's "search every image" pseudo-handle, `(void *)-2` on Darwin.
+const RTLD_DEFAULT: ?*anyopaque = @ptrFromInt(@as(usize, @bitCast(@as(isize, -2))));
+
+/// One `NSString * const` out of Contacts.framework.
+///
+/// The symbol is the *variable*, so one dereference yields the object; a
+/// resolved symbol holding nil is guarded, because nil in one of these
+/// arguments is a fetch that silently omits a key or a labeled value with no
+/// label.
+fn contactsConstant(symbol: [:0]const u8) !Id {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    const sym = dlsym(RTLD_DEFAULT, symbol) orelse {
+        std.log.err(
+            "contacts refused: {s} is not in this process; Contacts.framework is not linked",
+            .{symbol},
+        );
+        return bridge_error.BridgeError.PlatformNotSupported;
+    };
+    const slot: *Id = @ptrCast(@alignCast(sym));
+    return slot.* orelse {
+        std.log.err("contacts refused: {s} resolved to nil", .{symbol});
+        return bridge_error.BridgeError.PlatformNotSupported;
+    };
+}
+
+/// The main bundle's Info.plist value for `key`, or null when it has none.
+///
+/// Errors rather than answering null when the runtime will not cooperate:
+/// "there is no NSBundle" and "this app was not built with contacts enabled"
+/// are different facts, and collapsing them would blame the app's
+/// configuration for a broken process. Same shape as the picker's own gate,
+/// which is private to that file.
+fn infoPlistValue(comptime key: [*:0]const u8) !Id {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    const NSBundle = objc.objc_getClass("NSBundle") orelse return error.ClassNotFound;
+    const sel_main = objc.sel_registerName("mainBundle") orelse return error.SelectorNotFound;
+    const bundle = objc.msgSendId(NSBundle, sel_main) orelse return error.NoMainBundle;
+
+    const NSString = objc.objc_getClass("NSString") orelse return error.ClassNotFound;
+    const sel_string = objc.sel_registerName("stringWithUTF8String:") orelse
+        return error.SelectorNotFound;
+    const ns_key = objc.msgSendId1(NSString, sel_string, key) orelse return error.NativeCallFailed;
+
+    const sel_lookup = objc.sel_registerName("objectForInfoDictionaryKey:") orelse
+        return error.SelectorNotFound;
+    return objc.msgSendId1(bundle, sel_lookup, ns_key);
+}
+
+/// Refuse before `requestAccessForEntityType:` can take the process down.
+///
+/// Checked first on both actions, matching Swift's `if config.enableContacts`
+/// guarding both cases — and here it is genuinely the framework's precondition
+/// rather than only evidence of the flag. Swift answers such a call with
+/// silence; this answers `PERMISSION_DENIED`.
+fn requireContactsConfigured(action: []const u8) !void {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    if ((try infoPlistValue(key_contacts_usage)) == null) {
+        std.log.warn(
+            "{s} refused: Info.plist has no {s}, so this app was not built with contacts " ++
+                "enabled — and requesting access without that key is a TCC process kill",
+            .{ action, key_contacts_usage },
+        );
+        return bridge_error.BridgeError.PermissionDenied;
+    }
+}
+
+/// The one `CNContactStore`, and the selector both actions send it first.
+const Store = struct {
+    object: Id,
+    request_access: Id,
+};
+
+/// Created once for the process, mirroring the single store at
+/// `CraftApp.swift:450`. Never released: it is the process's store, and a
+/// per-call store would re-do Contacts' own setup on every read.
+var store_object: Id = null;
+var store_mutex: compat_mutex.Mutex = .{};
+
+fn contactStore() !Store {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    const sel_request = try selector("requestAccessForEntityType:completionHandler:");
+
+    store_mutex.lock();
+    defer store_mutex.unlock();
+
+    if (store_object) |existing| return .{ .object = existing, .request_access = sel_request };
+
+    const StoreClass = try class("CNContactStore", "contacts");
+    const created = (try objc.allocInit(StoreClass)) orelse return error.NativeCallFailed;
+    store_object = created;
+    return .{ .object = created, .request_access = sel_request };
+}
+
+/// `-[CNContactStore requestAccessForEntityType:completionHandler:]` with this
+/// slot's global block. Infallible by the time it is called: the store, the
+/// selector and the ticket are all in hand.
+fn requestAccess(store: Store, ticket: ios_async.Ticket) void {
+    if (!is_darwin) return;
+
+    const Fn = *const fn (Id, Id, c_long, *anyopaque) callconv(.c) void;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    func(store.object, store.request_access, cn_entity_type_contacts, accessBlock(ticket));
+}
+
+/// `UTF8String` and `lengthOfBytesUsingEncoding:`, the pair `readString` needs.
+const TextSels = struct {
+    utf8: Id,
+    length_of_bytes: Id,
+
+    fn resolve() !TextSels {
+        if (!is_darwin) return error.UnsupportedPlatform;
+        return .{
+            .utf8 = try selector("UTF8String"),
+            .length_of_bytes = try selector("lengthOfBytesUsingEncoding:"),
+        };
+    }
+};
+
+/// One `NSString` as bytes, or a refusal.
+///
+/// The truncation check is why this is not one line. `UTF8String` hands back a
+/// NUL-terminated buffer, so a value containing U+0000 — which
+/// `JSONSerialization` would have preserved on the Swift side — reads back as
+/// its prefix, and reporting a prefix as a whole name is the one thing worse
+/// than failing. Inherited unchanged from the picker, divergence included.
+///
+/// The returned slice borrows the string's internal buffer, valid for the
+/// current autorelease pool; every caller copies it into the reply before
+/// returning.
+fn readString(ns: Id, text: TextSels) ![]const u8 {
+    if (!is_darwin) return error.UnsupportedPlatform;
+    if (ns == null) return error.NilNativeString;
+
+    const Utf8Fn = *const fn (Id, Id) callconv(.c) ?[*:0]const u8;
+    const utf8: Utf8Fn = @ptrCast(&objc.objc_msgSend);
+    const cstr = utf8(ns, text.utf8) orelse return error.NativeCallFailed;
+    const bytes = std.mem.span(cstr);
+
+    const LenFn = *const fn (Id, Id, c_ulong) callconv(.c) c_ulong;
+    const len_of: LenFn = @ptrCast(&objc.objc_msgSend);
+    if (len_of(ns, text.length_of_bytes, ns_utf8_string_encoding) != bytes.len) {
+        return error.EmbeddedNulInNativeString;
+    }
+
+    return bytes;
+}
+
+fn nsString(s: []const u8, allocator: std.mem.Allocator) !Id {
+    if (!is_darwin) return error.UnsupportedPlatform;
+    return (try objc.createNSString(s, allocator)) orelse error.NSStringCreationFailed;
+}
+
+// -----------------------------------------------------------------------------
+// getContacts: the fetch request, and everything the enumeration will need.
+// -----------------------------------------------------------------------------
+
+/// Every selector and class the `getContacts` completion touches, resolved
+/// while a synchronous error can still reach the page.
+///
+/// Deliberately narrower than the picker's `Sels`: no `CNContactFormatter` and
+/// no `+localizedStringForLabel:`, because this action's reply has no localized
+/// labels in it and refusing over a class it never uses would be an over-broad
+/// gate.
+const ReadSels = struct {
+    text: TextSels,
+
+    /// `-[CNContactStore enumerateContactsWithFetchRequest:error:usingBlock:]`.
+    /// Three parts, not two: a two-part spelling registers a selector nothing
+    /// implements and the call goes to `doesNotRecognizeSelector:`.
+    enumerate: Id,
+
+    // NSArray
+    count: Id,
+    object_at: Id,
+
+    // CNContact
+    identifier: Id,
+    given_name: Id,
+    family_name: Id,
+    phone_numbers: Id,
+    email_addresses: Id,
+
+    /// `-[CNLabeledValue value]`. One class for both arrays: the Swift generics
+    /// `CNLabeledValue<CNPhoneNumber>` and `CNLabeledValue<NSString>` are the
+    /// same Objective-C class.
+    value: Id,
+
+    /// `-[CNPhoneNumber stringValue]`, for phones only — see `LabeledKind`.
+    string_value: Id,
+
+    // The displayName trim.
+    character_set_class: Id,
+    whitespace_set: Id,
+    trim: Id,
+
+    fn resolve() !ReadSels {
+        if (!is_darwin) return error.UnsupportedPlatform;
+
+        const NSCharacterSet = objc.objc_getClass("NSCharacterSet") orelse return error.ClassNotFound;
+
+        return .{
+            .text = try TextSels.resolve(),
+            .enumerate = try selector("enumerateContactsWithFetchRequest:error:usingBlock:"),
+
+            .count = try selector("count"),
+            .object_at = try selector("objectAtIndex:"),
+
+            .identifier = try selector("identifier"),
+            .given_name = try selector("givenName"),
+            .family_name = try selector("familyName"),
+            .phone_numbers = try selector("phoneNumbers"),
+            .email_addresses = try selector("emailAddresses"),
+
+            .value = try selector("value"),
+            .string_value = try selector("stringValue"),
+
+            .character_set_class = NSCharacterSet,
+            .whitespace_set = try selector("whitespaceCharacterSet"),
+            .trim = try selector("stringByTrimmingCharactersInSet:"),
+        };
+    }
+};
+
+/// `CNContactFetchRequest(keysToFetch:)` with Swift's five keys and nothing
+/// else set — no predicate, no `unifyResults` change, no sort order, no limit,
+/// because `CraftApp.swift:3231` sets none of them.
+///
+/// Returns +1; the completion releases it.
+fn fetchRequest() !Id {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    const NSMutableArray = objc.objc_getClass("NSMutableArray") orelse return error.ClassNotFound;
+    const sel_array = try selector("array");
+    const sel_add = try selector("addObject:");
+    const RequestClass = try class("CNContactFetchRequest", A.get_contacts);
+    const sel_init = try selector("initWithKeysToFetch:");
+
+    const keys = objc.msgSendId(NSMutableArray, sel_array) orelse return error.NativeCallFailed;
+    for (contact_key_symbols) |symbol| {
+        objc.msgSendVoid1(keys, sel_add, try contactsConstant(symbol));
+    }
+
+    // `alloc` then the designated initialiser, never `allocInit` first: `init`
+    // on a `CNContactFetchRequest` is not the initialiser this class takes.
+    // The keys array is autoreleased and the request retains it, so it outlives
+    // this frame's pool exactly as long as the request does.
+    const raw = (try objc.alloc(RequestClass)) orelse return error.NativeCallFailed;
+    return objc.msgSendId1(raw, sel_init, keys) orelse error.NativeCallFailed;
+}
+
+// -----------------------------------------------------------------------------
+// addContact: building the contact, and saving it.
+// -----------------------------------------------------------------------------
+
+/// Everything the `addContact` *dispatch* needs to assemble a
+/// `CNMutableContact` and its save request.
+const BuildSels = struct {
+    mutable_contact_class: Id,
+    set_given_name: Id,
+    set_family_name: Id,
+    set_phone_numbers: Id,
+    set_email_addresses: Id,
+
+    phone_number_class: Id,
+    phone_number_with: Id,
+
+    labeled_value_class: Id,
+    labeled_value_with: Id,
+
+    array_class: Id,
+    array_with_object: Id,
+
+    save_class: Id,
+    save_add: Id,
+
+    fn resolve() !BuildSels {
+        if (!is_darwin) return error.UnsupportedPlatform;
+
+        const NSArray = objc.objc_getClass("NSArray") orelse return error.ClassNotFound;
+
+        return .{
+            .mutable_contact_class = try class("CNMutableContact", A.add_contact),
+            .set_given_name = try selector("setGivenName:"),
+            .set_family_name = try selector("setFamilyName:"),
+            .set_phone_numbers = try selector("setPhoneNumbers:"),
+            .set_email_addresses = try selector("setEmailAddresses:"),
+
+            .phone_number_class = try class("CNPhoneNumber", A.add_contact),
+            .phone_number_with = try selector("phoneNumberWithStringValue:"),
+
+            .labeled_value_class = try class("CNLabeledValue", A.add_contact),
+            .labeled_value_with = try selector("labeledValueWithLabel:value:"),
+
+            .array_class = NSArray,
+            .array_with_object = try selector("arrayWithObject:"),
+
+            .save_class = try class("CNSaveRequest", A.add_contact),
+            .save_add = try selector("addContact:toContainerWithIdentifier:"),
+        };
+    }
+};
+
+/// Everything the `addContact` *completion* needs.
+const SaveSels = struct {
+    text: TextSels,
+    /// `-[CNContactStore executeSaveRequest:error:]`.
+    execute: Id,
+    /// `-[CNContact identifier]`, read after the save, in Swift's order.
+    identifier: Id,
+
+    fn resolve() !SaveSels {
+        if (!is_darwin) return error.UnsupportedPlatform;
+        return .{
+            .text = try TextSels.resolve(),
+            .execute = try selector("executeSaveRequest:error:"),
+            .identifier = try selector("identifier"),
+        };
+    }
+};
+
+/// `CNMutableContact()` plus Swift's four conditional setters, in Swift's
+/// order. Returns +1.
+///
+/// A field the payload did not carry as a string is not set at all — see
+/// `contactFieldFrom`. `displayName` is not settable and is not attempted.
+fn buildContact(allocator: std.mem.Allocator, fields: NewContact, b: BuildSels) !Id {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    const contact = (try objc.allocInit(b.mutable_contact_class)) orelse return error.NativeCallFailed;
+    errdefer objc.release(contact);
+
+    if (fields.given_name) |s| {
+        objc.msgSendVoid1(contact, b.set_given_name, try nsString(s, allocator));
+    }
+    if (fields.family_name) |s| {
+        objc.msgSendVoid1(contact, b.set_family_name, try nsString(s, allocator));
+    }
+
+    if (fields.phone) |s| {
+        const number = objc.msgSendId1(
+            b.phone_number_class,
+            b.phone_number_with,
+            try nsString(s, allocator),
+        ) orelse return error.NativeCallFailed;
+        const labeled = try labeledValue(b, try contactsConstant(label_phone_main), number);
+        // `phoneNumbers` is a `copy` property, so the autoreleased one-element
+        // array is retained by the contact and outlives this frame's pool.
+        const array = objc.msgSendId1(b.array_class, b.array_with_object, labeled) orelse
+            return error.NativeCallFailed;
+        objc.msgSendVoid1(contact, b.set_phone_numbers, array);
+    }
+
+    if (fields.email) |s| {
+        // An email's value is the `NSString` itself — no `CNPhoneNumber`
+        // wrapper, and no `stringValue` on the way back out either.
+        const labeled = try labeledValue(
+            b,
+            try contactsConstant(label_email_home),
+            try nsString(s, allocator),
+        );
+        const array = objc.msgSendId1(b.array_class, b.array_with_object, labeled) orelse
+            return error.NativeCallFailed;
+        objc.msgSendVoid1(contact, b.set_email_addresses, array);
+    }
+
+    return contact;
+}
+
+/// `+[CNLabeledValue labeledValueWithLabel:value:]` — two object arguments, so
+/// the signature is spelled out rather than left to a one-argument helper.
+fn labeledValue(b: BuildSels, label: Id, value: Id) !Id {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    const Fn = *const fn (Id, Id, Id, Id) callconv(.c) Id;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    return func(b.labeled_value_class, b.labeled_value_with, label, value) orelse
+        error.NativeCallFailed;
+}
+
+/// `CNSaveRequest()` with the contact added to the default container. Returns
+/// +1.
+fn buildSaveRequest(contact: Id, b: BuildSels) !Id {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    const save = (try objc.allocInit(b.save_class)) orelse return error.NativeCallFailed;
+    errdefer objc.release(save);
+
+    // `toContainerWithIdentifier: nil` — Swift's default container. The
+    // parameter type is declared, so the bare `null` has a type to take.
+    const Fn = *const fn (Id, Id, Id, Id) callconv(.c) void;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    func(save, b.save_add, contact, null);
+
+    return save;
+}
+
+// -----------------------------------------------------------------------------
+// NSError, for the log only.
+// -----------------------------------------------------------------------------
+
+/// Log an `NSError`'s domain, code and description.
+///
+/// This is the only channel `localizedDescription` has: `ios_async` carries a
+/// `BridgeError` enum, so the text Swift put in the page's error message is
+/// written to the device log instead of being invented into a reply shape the
+/// page does not expect. Each lookup is guarded and a miss degrades the line
+/// rather than the call — nothing here is on the reply path.
+fn describeNSError(action: []const u8, call: []const u8, ns_error: Id, text: TextSels) void {
+    if (!is_darwin) return;
+
+    std.log.warn("{s}: {s} reported domain={s} code={?d} description={s}", .{
+        action,
+        call,
+        nsErrorString(ns_error, "domain", text) orelse "(none)",
+        nsErrorCode(ns_error),
+        nsErrorString(ns_error, "localizedDescription", text) orelse "(none)",
+    });
+}
+
+fn nsErrorString(ns_error: Id, comptime name: [*:0]const u8, text: TextSels) ?[]const u8 {
+    if (!is_darwin) return null;
+
+    const sel = objc.sel_registerName(name) orelse return null;
+    const value = objc.msgSendId(ns_error, sel) orelse return null;
+    return readString(value, text) catch null;
+}
+
+fn nsErrorCode(ns_error: Id) ?c_long {
+    if (!is_darwin) return null;
+
+    const sel = objc.sel_registerName("code") orelse return null;
+    const Fn = *const fn (Id, Id) callconv(.c) c_long;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    return func(ns_error, sel);
+}
+
+// =============================================================================
+// The per-slot blocks.
+//
+// `ios_async.boolErrorBlock` is the right *shape* for
+// `requestAccessForEntityType:completionHandler:` and the wrong tool: its
+// invoke replies `"granted"`/`"denied"` immediately, and both of these actions
+// have to do their real work after the grant and answer with an array or an
+// id. So each slot gets its own block here — the `bridge_mobile_notifications`
+// pattern, applied rather than extended.
+//
+// A global block captures nothing, which is what makes `Block_copy` on it the
+// identity function and removes every lifetime question. The price is that a
+// block knows only its own slot index, baked in at comptime; the ticket, the
+// selectors and the +1 objects are looked up in the side table below.
+// =============================================================================
+
+const BlockDescriptor = extern struct {
+    reserved: c_ulong = 0,
+    size: c_ulong,
+};
+
+/// One layout for both blocks: a global block's literal is the same five words
+/// whatever its invoke signature is, and only the invoke differs.
+const Block = extern struct {
+    isa: ?*anyopaque,
+    flags: c_int,
+    reserved: c_int = 0,
+    invoke: *const anyopaque,
+    descriptor: *const BlockDescriptor,
+};
+
+/// 1 << 28. A global block is never copied: `Block_copy` returns the same
+/// pointer. No heap block, no copy/dispose pair, no descriptor lifetime.
+const BLOCK_IS_GLOBAL: c_int = 1 << 28;
+
+const block_descriptor = BlockDescriptor{ .size = @sizeOf(Block) };
+
+extern var _NSConcreteGlobalBlock: anyopaque;
+
+/// `void (^)(BOOL granted, NSError * _Nullable error)`.
+fn makeAccessInvoke(comptime index: u5) *const anyopaque {
+    const S = struct {
+        fn invoke(_: *const Block, granted: bool, err: Id) callconv(.c) void {
+            accessCompletionFired(index, granted, err);
+        }
+    };
+    return @ptrCast(&S.invoke);
+}
+
+/// `void (^)(CNContact * _Nonnull contact, BOOL * _Nonnull stop)`.
+///
+/// **Returns void.** A `bool`-returning invoke would register and run and read
+/// its result out of a register nobody wrote — the same silent class of bug as
+/// a wrong method type encoding, with no crash and no compile error to say so.
+fn makeEnumerationInvoke(comptime index: u5) *const anyopaque {
+    const S = struct {
+        fn invoke(_: *const Block, contact: Id, stop: *bool) callconv(.c) void {
+            enumerationFired(index, contact, stop);
+        }
+    };
+    return @ptrCast(&S.invoke);
+}
+
+fn makeBlocks(comptime maker: fn (comptime u5) *const anyopaque) [ios_async.max_in_flight]Block {
+    var out: [ios_async.max_in_flight]Block = undefined;
+    for (&out, 0..) |*b, i| {
+        b.* = .{
+            .isa = &_NSConcreteGlobalBlock,
+            .flags = BLOCK_IS_GLOBAL,
+            .invoke = maker(@intCast(i)),
+            .descriptor = &block_descriptor,
+        };
+    }
+    return out;
+}
+
+var access_blocks: [ios_async.max_in_flight]Block =
+    if (is_darwin) makeBlocks(makeAccessInvoke) else undefined;
+var enumeration_blocks: [ios_async.max_in_flight]Block =
+    if (is_darwin) makeBlocks(makeEnumerationInvoke) else undefined;
+
+fn accessBlock(ticket: ios_async.Ticket) *anyopaque {
+    return @ptrCast(&access_blocks[ticket.index]);
+}
+
+fn enumerationBlock(index: u5) *anyopaque {
+    return @ptrCast(&enumeration_blocks[index]);
+}
+
+// =============================================================================
+// The side table: one entry per async slot.
+//
+// One entry per slot rather than the picker's single `pending`, because nothing
+// here is exclusive — two reads of the address book are two reads, and refusing
+// the second would refuse a call the shim serves. The slot is leased
+// exclusively by its ticket, so a publish can never displace a live call.
+// =============================================================================
+
+/// What the completion has to finish and free, per action.
+const GetWork = struct {
+    /// +1 `CNContactFetchRequest`. Released by the completion on every path.
+    request: Id,
+    sels: ReadSels,
+};
+
+const AddWork = struct {
+    /// +1 `CNMutableContact`, built at dispatch.
+    contact: Id,
+    /// +1 `CNSaveRequest`, holding the contact.
+    save: Id,
+    sels: SaveSels,
+};
+
+const Work = union(Route) {
+    get_contacts: GetWork,
+    add_contact: AddWork,
+};
+
+const PendingCall = struct {
+    ticket: ios_async.Ticket,
+    store: Id,
+    work: Work,
+};
+
+var pending_calls: [ios_async.max_in_flight]?PendingCall = @splat(null);
+var pending_mutex: compat_mutex.Mutex = .{};
+
+fn publishPendingCall(call: PendingCall) void {
+    pending_mutex.lock();
+    defer pending_mutex.unlock();
+    pending_calls[call.ticket.index] = call;
+}
+
+/// Read and clear. Clearing is what makes a second fire of one completion a
+/// no-op rather than a second reply to a promise that has already settled —
+/// and, for the +1 objects, what stops a double release.
+fn takePendingCall(index: u5) ?PendingCall {
+    pending_mutex.lock();
+    defer pending_mutex.unlock();
+    const call = pending_calls[index];
+    pending_calls[index] = null;
+    return call;
+}
+
+// =============================================================================
+// The enumeration's state.
+//
+// `enumerateContactsWithFetchRequest:error:usingBlock:` is synchronous: the
+// block runs on the calling thread and the call returns when the walk ends. So
+// this is a pointer to `collectContacts`'s frame, which provably outlives every
+// fire, published for the duration of that one call and cleared immediately
+// after. The mutex is held anyway — the completion that owns the frame runs on
+// whatever queue Contacts chose, and slots are independent.
+// =============================================================================
+
+const Collector = struct {
+    allocator: std.mem.Allocator,
+    sels: ReadSels,
+    /// `+[NSCharacterSet whitespaceCharacterSet]`, read once per walk rather
+    /// than once per contact.
+    whitespace: Id,
+    writer: *RowWriter,
+    /// The first failure, kept so the walk can stop and the call can reject
+    /// instead of resolving a partial address book as if it were complete.
+    failure: ?anyerror = null,
+};
+
+var collectors: [ios_async.max_in_flight]?*Collector = @splat(null);
+var collectors_mutex: compat_mutex.Mutex = .{};
+
+fn publishCollector(index: u5, collector: *Collector) void {
+    collectors_mutex.lock();
+    defer collectors_mutex.unlock();
+    collectors[index] = collector;
+}
+
+fn collectorFor(index: u5) ?*Collector {
+    collectors_mutex.lock();
+    defer collectors_mutex.unlock();
+    return collectors[index];
+}
+
+fn clearCollector(index: u5) void {
+    collectors_mutex.lock();
+    defer collectors_mutex.unlock();
+    collectors[index] = null;
+}
+
+// =============================================================================
+// The completions. None replies directly: `evaluateJavaScript:` is
+// main-thread-only *and* the `request_context` naming the waiting call is long
+// gone, so every answer goes through `ios_async`, which hops to the main queue
+// and replies under the id captured at dispatch.
+//
+// Plain `fn`, never `export`: `@ptrCast(&f)` works either way and an exported
+// name could collide with a desktop module in the same host-test binary.
+// =============================================================================
+
+fn accessCompletionFired(index: u5, granted: bool, err: Id) void {
+    if (!is_darwin) return;
+
+    const call = takePendingCall(index) orelse {
+        std.log.warn(
+            "contacts: an access completion fired for slot {d} with no call recorded; " ++
+                "ignored rather than answered to whoever holds the slot next",
+            .{index},
+        );
+        return;
+    };
+
+    const allocator = std.heap.c_allocator;
+
+    switch (call.work) {
+        .get_contacts => |work| {
+            defer objc.release(work.request);
+
+            if (!granted) return denied(call.ticket, A.get_contacts, err, work.sels.text);
+
+            const json = collectContacts(allocator, call.store, work, call.ticket.index) catch |e| {
+                std.log.err(
+                    "getContacts: the address book could not be read ({}); rejecting rather " ++
+                        "than replying with a list that was not read",
+                    .{e},
+                );
+                ios_async.deliverErrorCode(call.ticket, failureCode(e));
+                return;
+            };
+            defer allocator.free(json);
+
+            // `[]` for an empty book, and it resolves. See `RowWriter.finish`.
+            ios_async.deliverJson(call.ticket, json);
+        },
+        .add_contact => |work| {
+            // Release order mirrors construction: the save request holds the
+            // contact, so it goes first.
+            defer objc.release(work.contact);
+            defer objc.release(work.save);
+
+            if (!granted) return denied(call.ticket, A.add_contact, err, work.sels.text);
+
+            const json = saveContact(allocator, call.store, work) catch |e| {
+                std.log.err(
+                    "addContact: the contact was not saved ({}); rejecting rather than " ++
+                        "replying with an identifier for a contact that does not exist",
+                    .{e},
+                );
+                ios_async.deliverErrorCode(call.ticket, failureCode(e));
+                return;
+            };
+            defer allocator.free(json);
+
+            ios_async.deliverJson(call.ticket, json);
+        },
+    }
+}
+
+/// The user declined the prompt — or TCC had already declined it for them.
+///
+/// `PermissionDenied`, never the generic failure: the call worked perfectly and
+/// the answer is "no". Reporting `NATIVE_CALL_FAILED` would send whoever reads
+/// the error hunting a bug that is not there. Swift's code and message differ;
+/// the module comment says how.
+fn denied(ticket: ios_async.Ticket, action: []const u8, err: Id, text: TextSels) void {
+    if (!is_darwin) return;
+
+    // A declined prompt carries no NSError at all, which is normal and not
+    // worth a line; an error object means something else happened and is.
+    if (err != null) describeNSError(action, "requestAccessForEntityType:", err, text);
+
+    std.log.info(
+        "{s}: contacts access was not granted; rejecting as PERMISSION_DENIED " ++
+            "(Swift sends CRAFT_ERROR with the NSError's description)",
+        .{action},
+    );
+    ios_async.deliverErrorCode(ticket, bridge_error.BridgeError.PermissionDenied);
+}
+
+/// Which `BridgeError` a completion-side failure reports.
+///
+/// Only three of these are honest distinctions, so only three are made: a
+/// declined permission never reaches here, an allocation failure is one, and
+/// everything else genuinely is a native call that did not produce an answer.
+fn failureCode(err: anyerror) bridge_error.BridgeError {
+    return switch (err) {
+        error.OutOfMemory, error.AllocationFailed => bridge_error.BridgeError.AllocationFailed,
+        error.PermissionDenied => bridge_error.BridgeError.PermissionDenied,
+        else => bridge_error.BridgeError.NativeCallFailed,
+    };
+}
+
+/// Walk the whole address book into the reply array.
+///
+/// No predicate, no sort, no limit — `CraftApp.swift:3235` passes none, and
+/// adding one would answer a different question than the page asked.
+fn collectContacts(
+    allocator: std.mem.Allocator,
+    store: Id,
+    work: GetWork,
+    index: u5,
+) ![]u8 {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    const whitespace = objc.msgSendId(work.sels.character_set_class, work.sels.whitespace_set) orelse
+        return error.NativeCallFailed;
+
+    var writer = RowWriter{};
+    errdefer writer.deinit(allocator);
+    try writer.begin(allocator);
+
+    var collector = Collector{
+        .allocator = allocator,
+        .sels = work.sels,
+        .whitespace = whitespace,
+        .writer = &writer,
+    };
+
+    publishCollector(index, &collector);
+    defer clearCollector(index);
+
+    var err_out: Id = null;
+    const EnumFn = *const fn (Id, Id, Id, ?*Id, *anyopaque) callconv(.c) bool;
+    const enumerate: EnumFn = @ptrCast(&objc.objc_msgSend);
+    const ok = enumerate(store, work.sels.enumerate, work.request, &err_out, enumerationBlock(index));
+
+    // The collector's failure is checked first and on purpose: a block that
+    // stopped the walk early leaves `ok` true, and returning the partial array
+    // would report a truncated address book as a complete one.
+    if (collector.failure) |failure| return failure;
+
+    if (!ok) {
+        if (err_out != null) {
+            describeNSError(
+                A.get_contacts,
+                "enumerateContactsWithFetchRequest:error:usingBlock:",
+                err_out,
+                work.sels.text,
+            );
+        } else {
+            std.log.warn(
+                "getContacts: enumerateContactsWithFetchRequest: returned NO with no NSError",
+                .{},
+            );
+        }
+        return error.NativeCallFailed;
+    }
+
+    return writer.finish(allocator);
+}
+
+/// One `CNContact`, straight into the reply.
+///
+/// Runs on the thread that called `enumerateContacts...`, inside
+/// `collectContacts`'s frame, which is why the collector pointer is valid.
+///
+/// `stop` is what Swift discards (`{ contact, _ in }`) and this file uses: on a
+/// failure the walk stops instead of reading the rest of an address book whose
+/// answer has already been given up on. That is a deliberate improvement over
+/// the shim, not parity — Swift's `contacts.append` would trap rather than
+/// unwind — and the reply is a rejection either way.
+fn enumerationFired(index: u5, contact: Id, stop: *bool) void {
+    if (!is_darwin) return;
+
+    const collector = collectorFor(index) orelse {
+        // No live walk owns this slot's writer, so nothing is being truncated
+        // by stopping — there is simply nowhere to put a contact.
+        std.log.warn(
+            "getContacts: enumeration fired for slot {d} with no collector; stopping the walk",
+            .{index},
+        );
+        stop.* = true;
+        return;
+    };
+
+    if (collector.failure != null) {
+        stop.* = true;
+        return;
+    }
+
+    appendContact(collector, contact) catch |err| {
+        collector.failure = err;
+        stop.* = true;
+    };
+}
+
+fn appendContact(collector: *Collector, contact: Id) !void {
+    if (!is_darwin) return error.UnsupportedPlatform;
+    // The block parameter is declared `_Nonnull`; a nil here would mean the
+    // framework broke its own contract, and "a contact with no fields" is a
+    // claim there would be no basis for.
+    if (contact == null) return error.NativeCallFailed;
+
+    const sels = collector.sels;
+    const allocator = collector.allocator;
+
+    const given = try readString(objc.msgSendId(contact, sels.given_name), sels.text);
+    const family = try readString(objc.msgSendId(contact, sels.family_name), sels.text);
+    const identifier = try readString(objc.msgSendId(contact, sels.identifier), sels.text);
+    const display = try readDisplayName(allocator, given, family, sels, collector.whitespace);
+
+    const phones = try readValueStrings(
+        allocator,
+        objc.msgSendId(contact, sels.phone_numbers),
+        sels,
+        .phone,
+    );
+    defer allocator.free(phones);
+
+    const emails = try readValueStrings(
+        allocator,
+        objc.msgSendId(contact, sels.email_addresses),
+        sels,
+        .email,
+    );
+    defer allocator.free(emails);
+
+    try collector.writer.append(allocator, .{
+        .id = identifier,
+        .given_name = given,
+        .family_name = family,
+        .display_name = display,
+        .phones = phones,
+        .emails = emails,
+    });
+}
+
+/// `"\(givenName) \(familyName)".trimmingCharacters(in: .whitespaces)`, done by
+/// Foundation rather than imitated. See `joinName`.
+///
+/// `given` and `family` have already been through `readString`, so neither can
+/// contain the NUL that would truncate the joined string on the way into
+/// `stringWithUTF8String:`.
+fn readDisplayName(
+    allocator: std.mem.Allocator,
+    given: []const u8,
+    family: []const u8,
+    sels: ReadSels,
+    whitespace: Id,
+) ![]const u8 {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    const joined = try joinName(allocator, given, family);
+    defer allocator.free(joined);
+
+    const ns = try nsString(joined, allocator);
+    const trimmed = objc.msgSendId1(ns, sels.trim, whitespace) orelse return error.NativeCallFailed;
+    return readString(trimmed, sels.text);
+}
+
+/// Which kind of `CNLabeledValue` array is being walked.
+///
+/// The two differ in exactly one step: a phone's `value` is a `CNPhoneNumber`
+/// and needs `stringValue`, while an email's `value` already *is* an
+/// `NSString`. Sending `stringValue` to an `NSString` is an unrecognised
+/// selector — a SIGABRT, not an error to map — so this is a comptime enum
+/// rather than an optional selector that could arrive null.
+const LabeledKind = enum { phone, email };
+
+/// `NSArray<CNLabeledValue *>` into flat strings.
+///
+/// No labels are read at all: `getContacts` throws them away, so the picker's
+/// `+[CNLabeledValue localizedStringForLabel:]` per value — across an entire
+/// address book — would be work done for nothing.
+fn readValueStrings(
+    allocator: std.mem.Allocator,
+    array: Id,
+    sels: ReadSels,
+    comptime kind: LabeledKind,
+) ![][]const u8 {
+    if (!is_darwin) return error.UnsupportedPlatform;
+    // Both properties are declared non-null and answer an empty array for a
+    // contact with none.
+    if (array == null) return error.NativeCallFailed;
+
+    const CountFn = *const fn (Id, Id) callconv(.c) c_ulong;
+    const count_of: CountFn = @ptrCast(&objc.objc_msgSend);
+    const total = count_of(array, sels.count);
+
+    var out: std.ArrayListUnmanaged([]const u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    var i: c_ulong = 0;
+    while (i < total) : (i += 1) {
+        const entry = objc.msgSendId1(array, sels.object_at, i) orelse return error.NativeCallFailed;
+        const raw = objc.msgSendId(entry, sels.value) orelse return error.NativeCallFailed;
+        const ns = switch (kind) {
+            .phone => objc.msgSendId(raw, sels.string_value) orelse return error.NativeCallFailed,
+            .email => raw,
+        };
+        try out.append(allocator, try readString(ns, sels.text));
+    }
+
+    return out.toOwnedSlice(allocator);
+}
+
+/// `try store.execute(saveRequest)` then `contact.identifier`, in Swift's
+/// order: the identifier is only meaningful once the save has succeeded, and
+/// reading it first would put a real-looking id on a contact that was never
+/// written.
+fn saveContact(allocator: std.mem.Allocator, store: Id, work: AddWork) ![]u8 {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    var err_out: Id = null;
+    const ExecFn = *const fn (Id, Id, Id, ?*Id) callconv(.c) bool;
+    const execute: ExecFn = @ptrCast(&objc.objc_msgSend);
+
+    if (!execute(store, work.sels.execute, work.save, &err_out)) {
+        if (err_out != null) {
+            describeNSError(A.add_contact, "executeSaveRequest:error:", err_out, work.sels.text);
+        } else {
+            std.log.warn("addContact: executeSaveRequest: returned NO with no NSError", .{});
+        }
+        return error.NativeCallFailed;
+    }
+
+    const identifier = try readString(
+        objc.msgSendId(work.contact, work.sels.identifier),
+        work.sels.text,
+    );
+    return shapeIdentifier(allocator, identifier);
+}
+
+// =============================================================================
+// Tests — host-only.
+//
+// Everything that decides page-visible bytes is pure and pinned here: routing
+// in both directions, the `as? String` rule, the six keys and their order, the
+// flat string arrays that distinguish this reply from the picker's, the bare
+// identifier string, the empty-book resolve, escaping, and the slot
+// bookkeeping.
+//
+// Nothing here touches `CNContactStore`. On a developer's Mac those classes all
+// exist and `requestAccessForEntityType:` would put a real TCC prompt on
+// someone's screen — so no test calls `handleMessage` with a payload that would
+// reach the native path, and the two that do call it use bodies that are
+// refused during parsing, which is itself the assertion that parsing comes
+// first.
+// =============================================================================
+
+const testing = std.testing;
+
+fn resetSlotsForTesting() void {
+    pending_mutex.lock();
+    pending_calls = @splat(null);
+    pending_mutex.unlock();
+
+    collectors_mutex.lock();
+    collectors = @splat(null);
+    collectors_mutex.unlock();
+}
+
+fn fakeTicket(index: u5, generation: u32) ios_async.Ticket {
+    return .{ .index = index, .generation = generation };
+}
+
+fn fakeGetWork() Work {
+    // Every field is a plain `Id`; nothing below dereferences them, and the
+    // bookkeeping under test does not care what they point at.
+    return .{ .get_contacts = .{ .request = null, .sels = std.mem.zeroes(ReadSels) } };
+}
+
+// ---------------------------------------------------------------------------
+// The action table, against the dispatcher, in both directions
+// ---------------------------------------------------------------------------
+
+test "the declared actions are the ones the handler serves" {
+    try testing.expectEqual(@as(usize, 2), capability_actions.len);
+    try testing.expectEqualStrings(A.get_contacts, capability_actions[0].name);
+    try testing.expectEqualStrings(A.add_contact, capability_actions[1].name);
+
+    for (capability_actions) |decl| {
+        // A `.result` whose handler never replies parks the caller on a promise
+        // with no timeout; a `.none` that is awaited resolves immediately and
+        // means nothing. Swift resolves or rejects every path, so `.result`.
+        try testing.expectEqual(capabilities.Reply.result, decl.reply);
+        try testing.expectEqual(capabilities.ActionStatus.live, decl.status);
+        // `.live` with a reason would be a contradiction the manifest shows apps.
+        try testing.expect(decl.reason == null);
+    }
+}
+
+test "the action names match the Swift case labels exactly" {
+    // The conformance ratchet compares this against the `case "…":` labels in
+    // `CraftApp.swift` in both directions; a prettier spelling would read as Zig
+    // serving an action the spec does not have. It cannot catch both sides
+    // being renamed in step, which this holds.
+    try testing.expectEqualStrings("getContacts", A.get_contacts);
+    try testing.expectEqualStrings("addContact", A.add_contact);
+}
+
+test "every declared action is one the dispatcher routes" {
+    for (capability_actions) |decl| {
+        if (routeFor(decl.name) == null) {
+            std.debug.print("declared action '{s}' does not route\n", .{decl.name});
+            return error.DeclaredActionDoesNotRoute;
+        }
+    }
+}
+
+test "every route the dispatcher has is a declared action" {
+    // The other direction: a route with a handler and no declaration is an
+    // action the page can call and the manifest denies exists. Each declaration
+    // must claim a *distinct* route — counting alone would let two rows share
+    // one route while another went undeclared.
+    var claimed = std.mem.zeroes([std.enums.values(Route).len]bool);
+    for (capability_actions) |decl| {
+        const route = routeFor(decl.name) orelse return error.DeclaredActionDoesNotRoute;
+        const slot = @backingInt(route);
+        if (claimed[slot]) {
+            std.debug.print("two declarations route to {s}\n", .{@tagName(route)});
+            return error.TwoDeclarationsShareARoute;
+        }
+        claimed[slot] = true;
+    }
+    for (claimed, 0..) |taken, slot| {
+        if (!taken) {
+            std.debug.print(
+                "route {s} has a handler but no capability_actions row\n",
+                .{@tagName(@as(Route, @fromBackingInt(@intCast(slot))))},
+            );
+            return error.RouteNotDeclared;
+        }
+    }
+}
+
+test "both actions route to their own handler" {
+    try testing.expectEqual(Route.get_contacts, routeFor("getContacts").?);
+    try testing.expectEqual(Route.add_contact, routeFor("addContact").?);
+}
+
+test "an action this module does not serve is refused as UnknownAction" {
+    // Not any other error: `ios_dispatch.route` reads UnknownAction as "not
+    // mine, ask the next module" and anything else as a final answer. Getting
+    // this wrong would make this file swallow another module's action — or the
+    // shim's.
+    var bridge = ContactsBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    for ([_][]const u8{
+        // The picker's action, which is a different module and a different
+        // reply shape.
+        "pickContact",
+        "getCalendarEvents",
+        "requestPermission",
+        // Casing and plurals are how a real typo arrives, and a miss does not
+        // fail loudly: the action would quietly fall through to the Swift shim.
+        "getcontacts",
+        "GetContacts",
+        "getContact",
+        "addContacts",
+        "addcontact",
+        "",
+    }) |action| {
+        try testing.expectError(
+            bridge_error.BridgeError.UnknownAction,
+            bridge.handleMessage(action, "{}"),
+        );
+        try testing.expect(routeFor(action) == null);
+    }
+}
+
+test "getContacts cannot fail on a payload it never reads" {
+    // Swift's case reads nothing off `body`, so there is no field to drop and
+    // no malformed `d` that may fail this call. The handler taking no `data`
+    // parameter is what makes that structural rather than a promise: `self`
+    // only, where `addContact` takes `self` and the payload.
+    try testing.expectEqual(
+        @as(usize, 1),
+        @typeInfo(@TypeOf(ContactsBridge.getContacts)).@"fn".param_types.len,
+    );
+    try testing.expectEqual(
+        @as(usize, 2),
+        @typeInfo(@TypeOf(ContactsBridge.addContact)).@"fn".param_types.len,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// addContact's payload
+// ---------------------------------------------------------------------------
+
+test "the four fields are read out of the nested contact object" {
+    // The page posts `{action, contact: {...}, callbackId}`, so `d`'s root has
+    // a `contact` key whose value is an object. Reading these off the root
+    // instead would silently save an empty contact.
+    var fields = try parseNewContact(testing.allocator,
+        \\{"contact":{"givenName":"Ada","familyName":"Lovelace","phone":"+1 555 0100","email":"ada@example.com"}}
+    );
+    defer fields.deinit(testing.allocator);
+
+    try testing.expectEqualStrings("Ada", fields.given_name.?);
+    try testing.expectEqualStrings("Lovelace", fields.family_name.?);
+    try testing.expectEqualStrings("+1 555 0100", fields.phone.?);
+    try testing.expectEqualStrings("ada@example.com", fields.email.?);
+}
+
+test "an absent field is unset rather than empty" {
+    // Unset and empty-string are different contacts: `givenName = ""` writes an
+    // empty name over whatever the container would have derived.
+    var fields = try parseNewContact(testing.allocator, "{\"contact\":{\"givenName\":\"Solo\"}}");
+    defer fields.deinit(testing.allocator);
+
+    try testing.expectEqualStrings("Solo", fields.given_name.?);
+    try testing.expect(fields.family_name == null);
+    try testing.expect(fields.phone == null);
+    try testing.expect(fields.email == null);
+}
+
+test "a field that is not a string is left unset, exactly as as? String leaves it" {
+    // `{"phone": 5551234}` is the case that decides this file's behaviour:
+    // Swift's `if let phone = data["phone"] as? String` does not fire, the
+    // property is not set, and the save proceeds. Erroring would refuse a call
+    // the shim accepts; stringifying would write a number the page never sent
+    // as text.
+    var fields = try parseNewContact(testing.allocator,
+        \\{"contact":{"givenName":5551234,"familyName":true,"phone":null,"email":{"a":1}}}
+    );
+    defer fields.deinit(testing.allocator);
+
+    try testing.expect(fields.given_name == null);
+    try testing.expect(fields.family_name == null);
+    try testing.expect(fields.phone == null);
+    try testing.expect(fields.email == null);
+}
+
+test "displayName is dropped, because CNMutableContact has nowhere to put it" {
+    // `craft.d.ts` declares it and `test-bridges.html` sends it; Swift reads
+    // four keys and this is not one of them. Parity, stated in a test so the
+    // next reader does not "fix" it.
+    var fields = try parseNewContact(
+        testing.allocator,
+        "{\"contact\":{\"displayName\":\"Test User\"}}",
+    );
+    defer fields.deinit(testing.allocator);
+
+    try testing.expect(fields.given_name == null);
+    try testing.expect(fields.family_name == null);
+    try testing.expect(fields.phone == null);
+    try testing.expect(fields.email == null);
+    const field_names = @typeInfo(NewContact).@"struct".field_names;
+    try testing.expectEqual(@as(usize, 4), field_names.len);
+    for (field_names) |name| {
+        try testing.expect(!std.mem.eql(u8, name, "display_name"));
+        try testing.expect(!std.mem.eql(u8, name, "displayName"));
+    }
+}
+
+test "a missing or non-object contact rejects, where Swift answers nothing at all" {
+    try testing.expectError(
+        bridge_error.BridgeError.MissingData,
+        parseNewContact(testing.allocator, "{}"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.MissingData,
+        parseNewContact(testing.allocator, "{\"other\":1}"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        parseNewContact(testing.allocator, "{\"contact\":\"Ada\"}"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        parseNewContact(testing.allocator, "{\"contact\":null}"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        parseNewContact(testing.allocator, "{\"contact\":[{\"givenName\":\"Ada\"}]}"),
+    );
+}
+
+test "the payload is validated before anything native is touched" {
+    // The refusal has to reach the page identically on every platform, and it
+    // has to happen before `requestAccessForEntityType:` — which in an app
+    // without NSContactsUsageDescription is a process kill, and in one with it
+    // is a prompt on a user's screen for a call that was already malformed.
+    // This is also why the suite can run these at all.
+    var bridge = ContactsBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    try testing.expectError(
+        bridge_error.BridgeError.MissingData,
+        bridge.handleMessage(A.add_contact, "{}"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidJSON,
+        bridge.handleMessage(A.add_contact, "{\"contact\":"),
+    );
+}
+
+test "a body that cannot be read is an error, not an empty contact" {
+    // Acting on a default for a payload that failed to parse is how an empty
+    // contact gets written to somebody's address book and reported as success.
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidJSON,
+        parseNewContact(testing.allocator, "{\"contact\":{"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidJSON,
+        parseNewContact(testing.allocator, "[{\"givenName\":\"Ada\"}]"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidJSON,
+        parseNewContact(testing.allocator, "\"contact\""),
+    );
+}
+
+test "an embedded NUL is refused rather than silently truncated" {
+    // `stringWithUTF8String:` stops at the first NUL, so accepting this would
+    // write "Ada" where the page sent "Ada\x00Lovelace" — a wrong value in the
+    // user's address book, reported as success. Swift would have stored the
+    // whole string; the divergence is the module comment's, and this is where
+    // it is enforced.
+    // `\u0000` in the JSON text, which is how a NUL legitimately arrives:
+    // `JSON.stringify` emits exactly this escape and the parser decodes it to a
+    // real NUL byte in the value.
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        parseNewContact(testing.allocator, "{\"contact\":{\"givenName\":\"Ada\\u0000Lovelace\"}}"),
+    );
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        parseNewContact(testing.allocator, "{\"contact\":{\"email\":\"a\\u0000b@example.com\"}}"),
+    );
+
+    // A raw NUL *byte* in the message is a different fault — an unescaped
+    // control character is not JSON at all — and is reported as such rather
+    // than as a bad field.
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidJSON,
+        parseNewContact(testing.allocator, "{\"contact\":{\"givenName\":\"Ada\u{0000}Lovelace\"}}"),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// getContacts' reply
+// ---------------------------------------------------------------------------
+
+fn shapeRowsForTesting(allocator: std.mem.Allocator, rows: []const ContactRow) ![]u8 {
+    var writer = RowWriter{};
+    errdefer writer.deinit(allocator);
+    try writer.begin(allocator);
+    for (rows) |row| try writer.append(allocator, row);
+    return writer.finish(allocator);
+}
+
+test "one contact is the six-key object getContacts builds, in a fixed order" {
+    const allocator = testing.allocator;
+    const json = try shapeRowsForTesting(allocator, &.{.{
+        .id = "AB12-CD34",
+        .given_name = "Ada",
+        .family_name = "Lovelace",
+        .display_name = "Ada Lovelace",
+        .phones = &.{"+1 555 0100"},
+        .emails = &.{"ada@example.com"},
+    }});
+    defer allocator.free(json);
+
+    try testing.expectEqualStrings(
+        "[{\"id\":\"AB12-CD34\",\"givenName\":\"Ada\",\"familyName\":\"Lovelace\"," ++
+            "\"displayName\":\"Ada Lovelace\"," ++
+            "\"phoneNumbers\":[\"+1 555 0100\"]," ++
+            "\"emailAddresses\":[\"ada@example.com\"]}]",
+        json,
+    );
+}
+
+test "phone numbers and email addresses are flat strings, not the picker's label pairs" {
+    // The single easiest thing to get wrong here, because the sibling module
+    // does the opposite and both parse. `getContacts` is
+    // `phone.value.stringValue` into `[String]`; `pickContact` is
+    // `{label, number}`. `craft.d.ts:1157-1164` agrees with this one.
+    const allocator = testing.allocator;
+    const json = try shapeRowsForTesting(allocator, &.{.{
+        .id = "1",
+        .given_name = "A",
+        .family_name = "B",
+        .display_name = "A B",
+        .phones = &.{ "555", "556" },
+        .emails = &.{"a@b.c"},
+    }});
+    defer allocator.free(json);
+
+    try testing.expect(std.mem.indexOf(u8, json, "\"label\"") == null);
+    try testing.expect(std.mem.indexOf(u8, json, "\"number\"") == null);
+    try testing.expect(std.mem.indexOf(u8, json, "\"address\"") == null);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json, .{});
+    defer parsed.deinit();
+
+    const one = parsed.value.array.items[0].object;
+    const phones = one.get("phoneNumbers").?.array.items;
+    try testing.expectEqual(@as(usize, 2), phones.len);
+    try testing.expectEqualStrings("555", phones[0].string);
+    try testing.expectEqualStrings("556", phones[1].string);
+    try testing.expectEqualStrings("a@b.c", one.get("emailAddresses").?.array.items[0].string);
+}
+
+test "a contact with no numbers and no addresses keeps both keys as empty arrays" {
+    // Swift always assigns both keys, so a page reading
+    // `contact.phoneNumbers.length` must not meet `undefined`.
+    const allocator = testing.allocator;
+    const json = try shapeRowsForTesting(allocator, &.{.{
+        .id = "1",
+        .given_name = "Solo",
+        .family_name = "",
+        .display_name = "Solo",
+        .phones = &.{},
+        .emails = &.{},
+    }});
+    defer allocator.free(json);
+
+    try testing.expect(std.mem.indexOf(u8, json, "\"phoneNumbers\":[]") != null);
+    try testing.expect(std.mem.indexOf(u8, json, "\"emailAddresses\":[]") != null);
+}
+
+test "an empty address book is an empty array that resolves" {
+    // A fresh Simulator answers exactly this, and `test-bridges.html:804`
+    // prints `Found 0 contacts`. Turning it into an error or a `{}` would fail
+    // a call the shim answers successfully. `[]` is also truthy, so the page's
+    // `payload || {}` leaves it intact.
+    const allocator = testing.allocator;
+    const json = try shapeRowsForTesting(allocator, &.{});
+    defer allocator.free(json);
+
+    try testing.expectEqualStrings("[]", json);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqual(@as(usize, 0), parsed.value.array.items.len);
+}
+
+test "several contacts are one comma-separated array, in enumeration order" {
+    const allocator = testing.allocator;
+    const json = try shapeRowsForTesting(allocator, &.{
+        .{
+            .id = "1",
+            .given_name = "A",
+            .family_name = "One",
+            .display_name = "A One",
+            .phones = &.{},
+            .emails = &.{},
+        },
+        .{
+            .id = "2",
+            .given_name = "B",
+            .family_name = "Two",
+            .display_name = "B Two",
+            .phones = &.{"555"},
+            .emails = &.{},
+        },
+        .{
+            .id = "3",
+            .given_name = "C",
+            .family_name = "Three",
+            .display_name = "C Three",
+            .phones = &.{},
+            .emails = &.{"c@example.com"},
+        },
+    });
+    defer allocator.free(json);
+
+    try testing.expect(json[0] == '[');
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json, .{});
+    defer parsed.deinit();
+
+    const items = parsed.value.array.items;
+    try testing.expectEqual(@as(usize, 3), items.len);
+    try testing.expectEqualStrings("1", items[0].object.get("id").?.string);
+    try testing.expectEqualStrings("2", items[1].object.get("id").?.string);
+    try testing.expectEqualStrings("3", items[2].object.get("id").?.string);
+    try testing.expectEqualStrings("555", items[1].object.get("phoneNumbers").?.array.items[0].string);
+}
+
+test "user data that needs escaping stays valid JSON" {
+    // A contact's name is user data. Before escaping, a single `"` in it would
+    // close the string literal inside the `evaluateJavaScript:` source and turn
+    // the whole reply into a syntax error in the page rather than a wrong field.
+    const allocator = testing.allocator;
+    const json = try shapeRowsForTesting(allocator, &.{.{
+        .id = "x\\y",
+        .given_name = "Ann \"Annie\"",
+        .family_name = "O'Neil\nJr",
+        .display_name = "Ann\t\"Annie\" O'Neil",
+        .phones = &.{"+1\\555"},
+        .emails = &.{"q\"@example.com"},
+    }});
+    defer allocator.free(json);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json, .{});
+    defer parsed.deinit();
+
+    const one = parsed.value.array.items[0].object;
+    try testing.expectEqualStrings("x\\y", one.get("id").?.string);
+    try testing.expectEqualStrings("Ann \"Annie\"", one.get("givenName").?.string);
+    try testing.expectEqualStrings("O'Neil\nJr", one.get("familyName").?.string);
+    try testing.expectEqualStrings("Ann\t\"Annie\" O'Neil", one.get("displayName").?.string);
+    try testing.expectEqualStrings("+1\\555", one.get("phoneNumbers").?.array.items[0].string);
+    try testing.expectEqualStrings("q\"@example.com", one.get("emailAddresses").?.array.items[0].string);
+}
+
+test "the joined name puts exactly one space in and trims nothing itself" {
+    // The trim is Foundation's — Zs plus U+0009, both ends, interior runs
+    // preserved — so this half must not pre-empt it. A name with a double
+    // space in it stays double-spaced in Swift too.
+    const allocator = testing.allocator;
+
+    const both = try joinName(allocator, "Ada", "Lovelace");
+    defer allocator.free(both);
+    try testing.expectEqualStrings("Ada Lovelace", both);
+
+    // The cases the trim exists for: one half empty leaves a trailing or
+    // leading space, and both empty leaves a lone space.
+    const given_only = try joinName(allocator, "Solo", "");
+    defer allocator.free(given_only);
+    try testing.expectEqualStrings("Solo ", given_only);
+
+    const family_only = try joinName(allocator, "", "Lovelace");
+    defer allocator.free(family_only);
+    try testing.expectEqualStrings(" Lovelace", family_only);
+
+    const neither = try joinName(allocator, "", "");
+    defer allocator.free(neither);
+    try testing.expectEqualStrings(" ", neither);
+
+    // Interior whitespace is the caller's data, not padding.
+    const interior = try joinName(allocator, "John  Q", "Doe");
+    defer allocator.free(interior);
+    try testing.expectEqualStrings("John  Q Doe", interior);
+}
+
+// ---------------------------------------------------------------------------
+// addContact's reply
+// ---------------------------------------------------------------------------
+
+test "the addContact reply is a bare quoted string, not an object" {
+    // `resolveCallback(callbackId, result: contact.identifier)` with
+    // `.fragmentsAllowed` puts a quoted string on the wire, and the page does
+    // `'Contact created with ID: ' + id`. An object here prints
+    // `[object Object]`.
+    const allocator = testing.allocator;
+    const json = try shapeIdentifier(allocator, "AB12-CD34-EF56");
+    defer allocator.free(json);
+
+    try testing.expectEqualStrings("\"AB12-CD34-EF56\"", json);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("AB12-CD34-EF56", parsed.value.string);
+}
+
+test "an identifier that needs escaping stays a valid JSON string" {
+    // A `CNContact` identifier is a UUID today. It is still the identifier
+    // Contacts hands back rather than one this file mints, so it is escaped
+    // like any other borrowed string.
+    const allocator = testing.allocator;
+    const json = try shapeIdentifier(allocator, "id\"with\\quotes");
+    defer allocator.free(json);
+
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("id\"with\\quotes", parsed.value.string);
+}
+
+// ---------------------------------------------------------------------------
+// Failure replies
+// ---------------------------------------------------------------------------
+
+test "a denial is a rejection, and these are the exact bytes it puts on the wire" {
+    // `denied` calls `ios_async.deliverErrorCode(..., PermissionDenied)`, which
+    // lands in `deliverOnMain` -> `sendErrorToJS`. This builds the same envelope
+    // that path builds, so the page-visible result of a declined prompt is
+    // pinned rather than described.
+    //
+    // Two things at once. First `"error":true` — it goes out through
+    // `__craftBridgeError`, which *rejects*; a `{"granted":false}` resolve
+    // would run the page's then-branch for a read that never happened. Second,
+    // the divergence in bytes: Swift sends `code:"CRAFT_ERROR"` with the
+    // NSError's `localizedDescription` (or `"Permission denied"`), and this is
+    // what the page gets instead.
+    const allocator = testing.allocator;
+    var ctx = bridge_error.ErrorContext.init(
+        bridge_error.BridgeError.PermissionDenied,
+        A.get_contacts,
+        bridge_error.errorMessage(bridge_error.BridgeError.PermissionDenied),
+    );
+    ctx.request_id = 7;
+
+    const json = try ctx.toJSON(allocator);
+    defer allocator.free(json);
+
+    try testing.expectEqualStrings(
+        "{\"error\":true,\"code\":\"PERMISSION_DENIED\",\"action\":\"getContacts\"," ++
+            "\"message\":\"Permission denied\",\"id\":7}",
+        json,
+    );
+
+    // And it is not a resolve shape: a rejection carries no contacts.
+    try testing.expect(std.mem.indexOf(u8, json, "givenName") == null);
+}
+
+test "a completion-side failure reports its cause rather than the nearest word" {
+    // The rule the migration keeps paying for: an accurate code sends the
+    // reader to the right place. Allocation failure is not a native call
+    // failing, and a native call failing is not a permission problem.
+    try testing.expectEqual(
+        bridge_error.BridgeError.AllocationFailed,
+        failureCode(error.OutOfMemory),
+    );
+    try testing.expectEqual(
+        bridge_error.BridgeError.PermissionDenied,
+        failureCode(error.PermissionDenied),
+    );
+    try testing.expectEqual(
+        bridge_error.BridgeError.NativeCallFailed,
+        failureCode(error.EmbeddedNulInNativeString),
+    );
+    try testing.expectEqual(
+        bridge_error.BridgeError.NativeCallFailed,
+        failureCode(error.NativeCallFailed),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Slot bookkeeping
+// ---------------------------------------------------------------------------
+
+test "each async slot carries its own call, so concurrent reads do not collide" {
+    // The difference from the picker, which owns one on-screen resource and
+    // refuses a second call. Two `getContacts` are two reads and both must be
+    // answerable; the slot is leased exclusively by its ticket, so publishing
+    // one can never displace another.
+    resetSlotsForTesting();
+    defer resetSlotsForTesting();
+
+    publishPendingCall(.{ .ticket = fakeTicket(3, 7), .store = null, .work = fakeGetWork() });
+    publishPendingCall(.{ .ticket = fakeTicket(4, 9), .store = null, .work = fakeGetWork() });
+
+    const first = takePendingCall(3) orelse return error.PendingWentMissing;
+    try testing.expectEqual(@as(u5, 3), first.ticket.index);
+    try testing.expectEqual(@as(u32, 7), first.ticket.generation);
+
+    // Taking one leaves the other alone.
+    const second = takePendingCall(4) orelse return error.PendingWentMissing;
+    try testing.expectEqual(@as(u32, 9), second.ticket.generation);
+}
+
+test "a slot is handed over once, so a double-firing completion cannot reply twice" {
+    resetSlotsForTesting();
+    defer resetSlotsForTesting();
+
+    publishPendingCall(.{ .ticket = fakeTicket(1, 2), .store = null, .work = fakeGetWork() });
+
+    const taken = takePendingCall(1) orelse return error.PendingWentMissing;
+    try testing.expectEqual(@as(u5, 1), taken.ticket.index);
+
+    // A duplicate fire finds nothing. `ios_async` would drop the stale
+    // generation anyway, but the entry has to be empty here so the second fire
+    // never releases the +1 objects a second time either.
+    try testing.expect(takePendingCall(1) == null);
+
+    // And the slot is reusable rather than wedged.
+    publishPendingCall(.{ .ticket = fakeTicket(1, 4), .store = null, .work = fakeGetWork() });
+    try testing.expect(takePendingCall(1) != null);
+}
+
+test "a completion for a slot with no call takes nothing" {
+    // The stray-completion path every invoke begins with. It has to be a no-op
+    // rather than an answer, because the next call to occupy the slot would
+    // otherwise receive this one's result.
+    resetSlotsForTesting();
+    defer resetSlotsForTesting();
+
+    try testing.expect(takePendingCall(0) == null);
+    try testing.expect(takePendingCall(ios_async.max_in_flight - 1) == null);
+}
+
+test "the collector is visible for one walk and gone after it" {
+    // The enumeration block finds its writer through this table. Published
+    // before `enumerateContacts…` and cleared the moment it returns, which is
+    // what makes the pointer-to-a-stack-frame safe.
+    resetSlotsForTesting();
+    defer resetSlotsForTesting();
+
+    var writer = RowWriter{};
+    defer writer.deinit(testing.allocator);
+
+    var collector = Collector{
+        .allocator = testing.allocator,
+        .sels = std.mem.zeroes(ReadSels),
+        .whitespace = null,
+        .writer = &writer,
+    };
+
+    try testing.expect(collectorFor(5) == null);
+    publishCollector(5, &collector);
+    try testing.expectEqual(&collector, collectorFor(5).?);
+    // Slots are independent: publishing one does not make another visible.
+    try testing.expect(collectorFor(6) == null);
+
+    clearCollector(5);
+    try testing.expect(collectorFor(5) == null);
+}
+
+test "a contact that cannot be read stops the walk instead of shortening the book" {
+    // `collectContacts` checks `collector.failure` *before* the BOOL, because a
+    // block that set `stop` leaves the enumeration returning YES. Reporting the
+    // rows read so far would tell the page the user has three contacts when
+    // they have three hundred.
+    //
+    // The half of that mechanism a host can drive is the block, so it is driven
+    // for real rather than described: `enumerationFired` with a nil `CNContact`,
+    // which `appendContact` refuses before it sends a single message. Nothing
+    // here touches Contacts.framework. (Asserting a `failure` this test had
+    // itself assigned would have asserted only the assignment.)
+    if (!is_darwin) return error.SkipZigTest;
+
+    resetSlotsForTesting();
+    defer resetSlotsForTesting();
+
+    const allocator = testing.allocator;
+
+    var writer = RowWriter{};
+    defer writer.deinit(allocator);
+    try writer.begin(allocator);
+    try writer.append(allocator, .{
+        .id = "1",
+        .given_name = "A",
+        .family_name = "One",
+        .display_name = "A One",
+        .phones = &.{},
+        .emails = &.{},
+    });
+
+    var collector = Collector{
+        .allocator = allocator,
+        .sels = std.mem.zeroes(ReadSels),
+        .whitespace = null,
+        .writer = &writer,
+    };
+    publishCollector(2, &collector);
+
+    // The failure is recorded and the walk is told to stop. No row is appended:
+    // half a contact in the array is the fabricated success this path exists to
+    // prevent.
+    var stop = false;
+    enumerationFired(2, null, &stop);
+    try testing.expect(stop);
+    try testing.expect(collector.failure != null);
+    try testing.expectEqual(@as(usize, 1), writer.rows);
+
+    // The partial array exists and is well-formed — which is exactly why the
+    // failure flag, and not the buffer's contents, decides the reply.
+    try testing.expectEqual(
+        bridge_error.BridgeError.NativeCallFailed,
+        failureCode(collector.failure.?),
+    );
+
+    // A fire that lands before the enumeration notices `stop` keeps stopping,
+    // and neither overwrites the first cause nor adds a row.
+    const first_cause = collector.failure.?;
+    stop = false;
+    enumerationFired(2, null, &stop);
+    try testing.expect(stop);
+    try testing.expectEqual(first_cause, collector.failure.?);
+    try testing.expectEqual(@as(usize, 1), writer.rows);
+
+    // And a fire for a slot with no live walk stops rather than reaching for a
+    // writer that is not there.
+    clearCollector(2);
+    stop = false;
+    enumerationFired(2, null, &stop);
+    try testing.expect(stop);
+}
+
+// ---------------------------------------------------------------------------
+// Framework constants and blocks
+// ---------------------------------------------------------------------------
+
+test "the fetch keys are the five Swift asks for, in its order" {
+    // A key missing from this list does not fail: it produces a contact whose
+    // property access raises CNContactPropertyNotFetchedException, which is an
+    // uncatchable SIGABRT. The list is the guard, so the list is pinned.
+    try testing.expectEqual(@as(usize, 5), contact_key_symbols.len);
+    try testing.expectEqualStrings("CNContactGivenNameKey", contact_key_symbols[0]);
+    try testing.expectEqualStrings("CNContactFamilyNameKey", contact_key_symbols[1]);
+    try testing.expectEqualStrings("CNContactPhoneNumbersKey", contact_key_symbols[2]);
+    try testing.expectEqualStrings("CNContactEmailAddressesKey", contact_key_symbols[3]);
+    try testing.expectEqualStrings("CNContactIdentifierKey", contact_key_symbols[4]);
+}
+
+test "the labels are resolved by symbol, never guessed" {
+    // A wrong label does not fail — it files the number under the wrong heading
+    // in somebody's address book. These are the symbol *names*; the values come
+    // from Contacts.framework at runtime.
+    try testing.expectEqualStrings("CNLabelPhoneNumberMain", label_phone_main);
+    try testing.expectEqualStrings("CNLabelHome", label_email_home);
+}
+
+test "CNEntityType.contacts is 0, as an NSInteger" {
+    // Passed in an integer register by a `callconv(.c)` signature that has to
+    // name its width: `CNEntityType` is `NSInteger`, so `c_long`.
+    try testing.expectEqual(@as(c_long, 0), cn_entity_type_contacts);
+    try testing.expectEqual(c_long, @TypeOf(cn_entity_type_contacts));
+}
+
+test "every slot has its own block, so a completion cannot answer another call" {
+    // The invoke is where a slot index is baked in. If `makeBlocks` handed
+    // every slot the same invoke, sixteen callers would share one ticket and
+    // fifteen promises would be answered with somebody else's data — silently,
+    // because every one of those replies is well-formed.
+    if (!is_darwin) return error.SkipZigTest;
+
+    for (access_blocks, 0..) |a, i| {
+        for (access_blocks[i + 1 ..]) |b| {
+            try testing.expect(a.invoke != b.invoke);
+        }
+        // The two block kinds are different functions with different
+        // signatures; sharing one would read arguments from the wrong
+        // registers.
+        try testing.expect(a.invoke != enumeration_blocks[i].invoke);
+    }
+
+    // A global block: never copied, so no heap lifetime and no copy/dispose
+    // helpers. The size in the descriptor is the literal's, not a guess.
+    try testing.expectEqual(@as(c_int, 1 << 28), BLOCK_IS_GLOBAL);
+    try testing.expectEqual(BLOCK_IS_GLOBAL, access_blocks[0].flags);
+    try testing.expectEqual(@as(c_ulong, @sizeOf(Block)), block_descriptor.size);
+
+    // And the accessor really hands out the block belonging to the ticket.
+    try testing.expectEqual(
+        @as(*anyopaque, @ptrCast(&access_blocks[3])),
+        accessBlock(fakeTicket(3, 1)),
+    );
+    try testing.expectEqual(
+        @as(*anyopaque, @ptrCast(&enumeration_blocks[3])),
+        enumerationBlock(3),
+    );
+}
+
+test "nothing in this module emits an event" {
+    // Neither action has a `sendToWeb` on any Swift path and `test-bridges.html`
+    // registers no contacts listener, so an event from here would be a message
+    // the shim never sends — and `ios_events.Event` has no name for one. This
+    // is a source scan rather than prose because the import is the whole
+    // mistake: adding it is what makes the rest possible.
+    const source = @embedFile("bridge_mobile_contacts.zig");
+    try testing.expect(std.mem.indexOf(u8, source, "@import(\"ios_events.zig\")") == null);
+
+    // Non-vacuity: the same scan finds the two reply calls that *are* made, so
+    // a needle that stopped matching anything could not pass unnoticed.
+    //
+    // Both needles carry an argument and are assembled from halves, and both
+    // details are load-bearing. Spelled out whole, each needle would match the
+    // very line asserting it; without the argument, each would match the prose
+    // further up this file, which names both functions. The sibling modules get
+    // the same property from an escaped quote inside their needle — these two
+    // calls have nowhere to put one.
+    const resolve_call = "ios_async.deliverJson(call" ++ ".ticket,";
+    const reject_call = "ios_async.deliverErrorCode(call" ++ ".ticket,";
+    try testing.expect(std.mem.indexOf(u8, source, resolve_call) != null);
+    try testing.expect(std.mem.indexOf(u8, source, reject_call) != null);
+}

--- a/packages/zig/src/bridge_mobile_speech.zig
+++ b/packages/zig/src/bridge_mobile_speech.zig
@@ -1,0 +1,810 @@
+//! The Speech + AVFoundation actions of the `mobile` namespace —
+//! `startListening` and `stopListening` — **researched in full and
+//! deliberately not served**. Both fall through to the working Swift shim.
+//!
+//! This is the outcome rule 6 exists for, and it is the cheapest one in the
+//! migration: the shim answers both actions exactly as the app answers them
+//! today, and — unlike `scheduleNotification`, `registerBackgroundTask` and
+//! `sendToWatch` — **there is no promise to strand**, because neither action
+//! has a `callbackId` and neither ever replies. Falling through costs the page
+//! nothing at all. What is written below is the part a host can honestly
+//! finish and pin: the event vocabulary, the four error messages, and the two
+//! detail shapers. What is missing is named, not glossed.
+//!
+//! ## The contract, read rather than assumed
+//!
+//! **Payload: none, on both actions.** The injected JS is the whole surface
+//! (`CraftApp.swift:1562-1568`):
+//!
+//! ```js
+//! startListening: function() {
+//!     window.webkit.messageHandlers.craft.postMessage({action: 'startListening'});
+//! },
+//! stopListening: function() {
+//!     window.webkit.messageHandlers.craft.postMessage({action: 'stopListening'});
+//! },
+//! ```
+//!
+//! No fields, no `callbackId`, no return value. `ios_dispatch.payloadOf` would
+//! hand a handler `"{}"`. There is no second page surface: the nested mobile
+//! contract block (`:2297-2427`) has no speech methods, and `craft-bridge.js`
+//! has no `mobile` namespace at all — its `window.craft.speech` is desktop TTS
+//! over `AVSpeechSynthesizer`, namespace `t = "speech"`, unrelated. So is
+//! `bridge_speech_recognition.zig`, which is the desktop `speechRecognition`
+//! namespace with actions `isAvailable`/`start`/`stop`; it must not be
+//! confused with this one.
+//!
+//! **Reply: none, on any path.** The dispatcher (`CraftApp.swift:533-536`) is
+//!
+//! ```swift
+//! case "startListening":
+//!     if config.enableSpeechRecognition { startSpeechRecognition() }
+//! case "stopListening":
+//!     stopSpeechRecognition()
+//! ```
+//!
+//! and neither `startSpeechRecognition` (`:2486-2494`), `beginRecording`
+//! (`:2496-2548`) nor `stopSpeechRecognition` (`:2550-2559`) touches
+//! `resolveCallback`, `rejectCallback` or `resolveCallbackJSON` on any line.
+//! `craft.d.ts:188` and `:193` both declare `(): void`, and
+//! `test-bridges.html:785-795` awaits nothing. If this module ever serves
+//! these, the declaration is `.reply = .none` — the same reading
+//! `bridge_mobile_haptics.zig` made for `haptic`, and for the same reason.
+//!
+//! A denial does not reply either; it **emits**. Nor does the flag-off case
+//! emit anything at all: `if config.enableSpeechRecognition { … }` has no
+//! `else`, and `stopListening` is ungated and always runs.
+//!
+//! **Everything is events.** Four names, and the detail of each:
+//!
+//! | event | detail | when |
+//! |---|---|---|
+//! | `craftSpeechError` | `{"error":"Not authorized"}` | auth status is not `.authorized` (`:2489`) |
+//! | `craftSpeechError` | `{"error":"Audio session failed"}` | `setCategory`/`setActive` threw (`:2507`) |
+//! | `craftSpeechError` | `{"error":"Speech recognizer unavailable"}` | request nil, recognizer nil, or not `isAvailable` (`:2515`) |
+//! | `craftSpeechError` | `{"error":"Audio engine failed"}` | `audioEngine.start()` threw (`:2546`) |
+//! | `craftSpeechStart` | `{}` | after `audioEngine.start()` succeeded (`:2543`) |
+//! | `craftSpeechResult` | `{"transcript": String, "isFinal": Bool}` | every partial and every final result (`:2525-2528`) |
+//! | `craftSpeechEnd` | `{}` | every `stopSpeechRecognition()` (`:2557`) |
+//!
+//! The result detail is **exactly two keys**. No `confidence`, no
+//! `alternatives`, no `segments`. Three independent consumers agree —
+//! `test-bridges.html:384-387` reads `e.detail.transcript` and
+//! `e.detail.isFinal`, `packages/ios/README.md:167-176` documents the same
+//! pair, and Android emits the same four names with the same keys
+//! (`CraftBridge.kt.template:1344-1383`). Unlike motion, there is no
+//! doc/implementation mismatch here to report.
+//!
+//! `sendToWeb` (`:4835-4846`) builds
+//! `window.dispatchEvent(new CustomEvent('<name>', {detail: <json>}));` — the
+//! same form `ios_events.formatEvent` builds, so the detail bytes below are
+//! the bytes that reach `e.detail` on either path.
+//!
+//! ## Why nothing is served
+//!
+//! Four blockers. Only the last three are load-bearing; the first is one line
+//! of data that would unblock nothing on its own.
+//!
+//! **1. `craftSpeechStart` cannot be spelled.** `ios_events.Event` carries
+//! `.speech_result`, `.speech_error` and `.speech_end`, and no
+//! `.speech_start`. Serving `startListening` without it would drop the one
+//! event that drives the page's state — `test-bridges.html:380-383` paints
+//! "Listening..." from it and from nothing else — so a working session would
+//! look to the page exactly like a session that never started. Adding the
+//! enum member and its `switch` arm is data rather than mechanism, and the
+//! existing test `"every event name is one an iOS page actually subscribes
+//! to"` already accepts the shape (`startsWith "craft"`, no colon). It is not
+//! left undone because a second file is off limits — landing this module
+//! already edits `ios_dispatch.zig`, `build.zig` and
+//! `test/ios_conformance_test.zig`. It is left undone because adding it alone
+//! serves nothing: blocker 2 stops `startListening` by itself, and an `Event`
+//! member no code emits is vocabulary for an event that never fires. So it is
+//! precondition 1 below rather than a reason of its own — and a test trips
+//! when it lands.
+//!
+//! **2. The realtime tap has no precedent in this tree.**
+//! `-[AVAudioNode installTapOnBus:bufferSize:format:block:]` runs its block on
+//! the audio I/O thread, which is not a queue any existing module touches.
+//! `bridge_mobile_motion.zig`'s handler is an `NSOperationQueue.mainQueue`
+//! callback and is **not** a precedent for it. Swift's
+//! `self?.recognitionRequest?.append(buffer)` gets a free ARC retain for the
+//! duration of the call; Zig has none, so `stopListening` releasing the
+//! request while a tap call is in flight is a use-after-free on a realtime
+//! thread. It is solvable — an atomic pointer, never a mutex (priority
+//! inversion), plus stop-engine, remove-tap, clear-pointer, never-release
+//! ordering — but solving it is building a new foundation, and this round was
+//! asked to apply proven ones and to say so instead.
+//!
+//! **3. The guard the tap needs is asserted, not read.** With no active input
+//! route, `-outputFormatForBus:0` yields a format whose `sampleRate` and
+//! `channelCount` are 0, and `installTapOnBus:` then raises an
+//! `NSException` — which Zig cannot catch, so the process aborts. Swift has
+//! the identical crash at `:2535-2538`. The honest port pre-checks the format
+//! and refuses with `craftSpeechError`; but that behaviour comes from API
+//! knowledge, nothing in this repo documents it, and there is no simulator
+//! here to verify it. Shipping an unverified guard against an unreproducible
+//! abort is the one place rule 5 and rule 1 meet.
+//!
+//! **4. Nothing here can test the audio path.** Every host test that could be
+//! written for a served version would exercise selector interning and block
+//! flags, and nothing of the recognizer, the session, the engine or the tap.
+//! That is a served action whose entire risk surface is untested.
+//!
+//! The gate is *not* among the blockers, because it is solved:
+//! `config.enableSpeechRecognition` defaults to `false`
+//! (`CraftApp.swift:189`, `packages/ios/src/index.ts:117`) and reaches Zig
+//! through nothing, but `packages/ios/src/index.ts:183` writes
+//! `NSSpeechRecognitionUsageDescription` from that flag **and nothing else,
+//! with no `||`** — the exact-proxy shape `bridge_mobile_motion.zig` already
+//! reads. (`NSMicrophoneUsageDescription` at `:184` is
+//! `enableSpeechRecognition || enableAudioRecording` and is **not** an exact
+//! proxy; it must not be used as the gate.) Here the proxy is mandatory
+//! rather than an improvement: without those keys in Info.plist iOS
+//! *terminates the process* on the authorization request or on mic access.
+//!
+//! ## Why falling through, and not `.unavailable`
+//!
+//! `.unavailable` makes `ios_dispatch` route the action into this module and
+//! refuse it. For an action with a pending promise that is a nameable failure
+//! and an improvement on silence. Here there is no pending promise on any
+//! page surface, so the refusal would surface only as a console log — while
+//! taking away a shim path that works completely. That is strictly worse, and
+//! it is why `A` below is empty rather than carrying two `.unavailable` rows.
+//!
+//! Serving only `stopListening` is worse still, and is ruled out for the
+//! reason `bridge_mobile_motion.zig` gives: a session started through the shim
+//! would meet a Zig stop, which would stop Zig's own null engine and emit
+//! `craftSpeechEnd` while Swift's recognizer kept pushing `craftSpeechResult`.
+//! Fabricated success at the event layer. Either both or neither; neither.
+//!
+//! ## What is finished here
+//!
+//! The two shapers and the four messages — the half of the port that decides
+//! page-visible bytes and that a host can pin. This is the precedent
+//! `bridge_mobile_haptics.zig` set with `triggerHapticChecked`: the finished
+//! half of a blocked action lives next to the admission, tested, so that
+//! unblocking it is a small deliberate edit rather than a rewrite.
+//!
+//! `shapeResultDetail` is worth more than it looks. A transcript is arbitrary
+//! spoken text, the detail is inlined into JavaScript source as a literal, and
+//! `ios_events.zig`'s own module comment records what happens when a value
+//! like that is concatenated with hand-rolled escaping: `bridge_iap.zig:362`
+//! "works until a value contains a quote". Swift is safe here only because
+//! `JSONSerialization` escapes for it. Any Zig port must, and this one does.
+//!
+//! ## What a future round still owes
+//!
+//! Five preconditions, all five, before either action moves into `A`:
+//!
+//!  1. `.speech_start => "craftSpeechStart"` in `ios_events.Event`.
+//!  2. Refuse unless Info.plist carries `NSSpeechRecognitionUsageDescription`
+//!     (`bridge_mobile_motion.zig:infoPlistHas` is the shape).
+//!  3. Validate `-sampleRate` and `-channelCount` before `installTapOnBus:`,
+//!     and emit `craftSpeechError` rather than installing on a zero format.
+//!  4. Never release the recognition request while a tap call may be in
+//!     flight — atomically clear the pointer after `removeTapOnBus:`, and
+//!     prefer leaking one request per session over racing the audio thread.
+//!  5. Hop to the main queue with `dispatch_async_f(&_dispatch_main_q, …)`
+//!     before touching `AVAudioEngine` from the recognition task handler; it
+//!     fires on an internal Speech queue. (`ios_events.emit` needs no hop —
+//!     it hops itself.)
+//!
+//! And two decisions that are decisions, not facts, to be taken out loud:
+//!
+//!  - **The error-emission divergence.** On a recognition error Swift emits
+//!    **no** `craftSpeechError` — `:2530-2532` only calls
+//!    `stopSpeechRecognition()`, so the page gets `craftSpeechEnd` and the
+//!    `NSError` is discarded entirely. Android *does* emit one
+//!    (`CraftBridge.kt.template:1367`). Matching Swift makes a simulator
+//!    failure look exactly like a stream that never fires; matching Android
+//!    tells the truth but deviates from the emitter contract this migration
+//!    preserves. `err_recognition_failed` below is deliberately absent: there
+//!    is no Swift string to copy, so inventing one here would prejudge it.
+//!  - **`beginRecording` never stops the engine or removes the old tap**
+//!    (`:2497-2500` cancels only the task). A second `startListening` while
+//!    running installs a second tap on bus 0, which raises on iOS.
+//!    Reproducing that bug is not required; stopping first, as
+//!    `bridge_mobile_motion.zig` chose to, is the defensible port.
+//!
+//! Also worth carrying: both `:2544` and `:2558` fire `triggerHaptic("light")`
+//! directly, bypassing the `config.enableHaptics` gate the dispatcher applies
+//! to `case "haptic"` at `:537`. Swift itself ignores the flag on this path,
+//! so firing it from a served port would be faithful rather than a
+//! divergence — but `triggerHapticChecked` in `bridge_mobile_haptics.zig` is
+//! not `pub`, so reuse needs a visibility change there.
+//!
+//! ## Nothing in this file touches Objective-C
+//!
+//! No `objc_getClass`, no `sel_registerName`, no block, no delegate, no
+//! `ios_async` ticket — there is no reply to correlate and no framework call
+//! to make. So there is nothing to Darwin-gate: the module compiles and its
+//! tests run identically on Linux and macOS, which is the one upside of
+//! serving nothing.
+
+const std = @import("std");
+const capabilities = @import("capabilities.zig");
+const bridge_error = @import("bridge_error.zig");
+const ios_events = @import("ios_events.zig");
+
+/// **Empty on purpose.** No action name here means `ios_dispatch` never routes
+/// `startListening` or `stopListening` into this module, so both reach the
+/// Swift shim that serves them correctly today. See the module comment for the
+/// four blockers and the five preconditions.
+///
+/// `declared_count` is not decoration. `test/ios_conformance_test.zig` scans
+/// this block line by line from `pub const A = struct {` to the first bare
+/// `};`, and `zig fmt` collapses an empty struct onto one line — after which
+/// the scan would never find its terminator and would collect every quoted
+/// string in this file as an action name. A non-string member keeps the block
+/// two-line-safe under `zig fmt --check`, which CI runs.
+pub const A = struct {
+    /// How many actions this module claims. Zero, deliberately.
+    pub const declared_count: usize = 0;
+};
+
+/// Empty, and specifically not two `.unavailable` rows.
+///
+/// `.unavailable` is for an action that dispatches and refuses — honest when a
+/// promise would otherwise hang, wrong here. Neither of these actions has a
+/// promise on any page surface, so a refusal would show up only in the
+/// console while removing a shim path that works end to end. Declaring
+/// nothing is what lets the shim keep answering.
+pub const capability_actions = [_]capabilities.ActionDecl{};
+
+/// The two spec actions this module researched and left with the shim.
+///
+/// Kept as data so the tests can prove both fall through rather than asserting
+/// it in prose, and so a future round has the exact spellings in one place.
+/// These names deliberately live outside the `A` block: inside it, the
+/// conformance scan would read them as served and the ratchet would drop for
+/// actions nothing here answers.
+pub const unserved_actions = [_][]const u8{ "startListening", "stopListening" };
+
+pub const SpeechBridge = struct {
+    /// Held but never used: `ios_dispatch` constructs every mobile bridge with
+    /// `init(allocator)` and the shape is the interface. Nothing here
+    /// allocates, because nothing here answers.
+    allocator: std.mem.Allocator,
+
+    const Self = @This();
+
+    pub fn init(allocator: std.mem.Allocator) Self {
+        return .{ .allocator = allocator };
+    }
+
+    pub fn deinit(_: *Self) void {}
+
+    /// Always `UnknownAction` — "not mine, ask the next" — which is what makes
+    /// the fall-through work.
+    ///
+    /// The payload is deliberately never parsed. `ios_dispatch.route` treats
+    /// any error other than `UnknownAction` as final and stops the chain, so a
+    /// module that parsed first and answered `InvalidJSON` on a malformed
+    /// payload would strand an action it does not even serve. That is the
+    /// failure this signature is shaped to make impossible, and a test below
+    /// pins it with payloads that no parser would accept.
+    pub fn handleMessage(_: *Self, action: []const u8, _: []const u8) !void {
+        _ = action;
+        return bridge_error.BridgeError.UnknownAction;
+    }
+};
+
+// =============================================================================
+// The event vocabulary, as far as it can be spelled today.
+// =============================================================================
+
+/// `craftSpeechResult` — the transcript stream.
+pub const event_result: ios_events.Event = .speech_result;
+
+/// `craftSpeechError` — every refusal, on every path.
+pub const event_error: ios_events.Event = .speech_error;
+
+/// `craftSpeechEnd` — every `stopSpeechRecognition()`, including one that
+/// stops nothing.
+pub const event_end: ios_events.Event = .speech_end;
+
+/// `craftSpeechStart`, which `ios_events.Event` cannot currently spell.
+///
+/// A plain string, not an `Event`, because that is the whole point: there is
+/// no member to name. Pinned here so the eventual enum arm is copied from the
+/// contract rather than retyped from memory.
+pub const event_start_name = "craftSpeechStart";
+
+/// The `data: [:]` of `craftSpeechStart` and `craftSpeechEnd` — an empty
+/// object, not an empty string and not `null`. `ios_events.formatEvent`
+/// inlines the detail as a literal, so `e.detail` must still be an object the
+/// page can index into.
+pub const empty_detail = "{}";
+
+// -----------------------------------------------------------------------------
+// The four `craftSpeechError` messages, verbatim from the Swift.
+//
+// Verbatim matters: `test-bridges.html:391-394` paints `e.detail.error` into
+// the page for a human to read, and `packages/ios/README.md:173-175` documents
+// the key as the thing to log. Nothing downstream matches on the text, which
+// is exactly why a paraphrase would change what a user reads without changing
+// anything a test could see.
+// -----------------------------------------------------------------------------
+
+/// `CraftApp.swift:2489` — the authorization status was not `.authorized`.
+/// A user declining is this, not a native call failing.
+pub const err_not_authorized = "Not authorized";
+
+/// `:2507` — `setCategory:mode:options:error:` or
+/// `setActive:withOptions:error:` failed.
+pub const err_audio_session = "Audio session failed";
+
+/// `:2515` — the request is nil, the recognizer is nil (the
+/// `enableSpeechRecognition` flag was off, `:439-440`), or `-isAvailable` is
+/// NO. A simulator commonly answers NO here.
+pub const err_recognizer_unavailable = "Speech recognizer unavailable";
+
+/// `:2546` — `-startAndReturnError:` returned NO.
+pub const err_audio_engine = "Audio engine failed";
+
+/// Every message the port may emit, in Swift's source order. A future round
+/// adding a fifth must add it to Swift's contract first, or document the
+/// divergence — see the module comment on the recognition-error case.
+pub const error_messages = [_][]const u8{
+    err_not_authorized,
+    err_audio_session,
+    err_recognizer_unavailable,
+    err_audio_engine,
+};
+
+// =============================================================================
+// The detail shapers. Pure, and the bytes are the contract.
+// =============================================================================
+
+/// The `detail` of one `craftSpeechError`: `{"error":"<message>"}`.
+///
+/// Escaped even though all four current messages are plain ASCII, because the
+/// escaping is a property of the position — a JSON string inlined into
+/// JavaScript source — and not of today's inputs. A fifth message quoting a
+/// framework error would otherwise be the bug.
+///
+/// Caller owns the returned slice.
+pub fn shapeErrorDetail(allocator: std.mem.Allocator, message: []const u8) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.appendSlice(allocator, "{\"error\":\"");
+    try bridge_error.appendJsonEscaped(allocator, &out, message);
+    try out.appendSlice(allocator, "\"}");
+
+    return out.toOwnedSlice(allocator);
+}
+
+/// The `detail` of one `craftSpeechResult`:
+/// `{"transcript":"<text>","isFinal":<bool>}`.
+///
+/// Two keys, Swift's two (`CraftApp.swift:2525-2528`), and no third. Swift
+/// builds a `Dictionary`, so its own key order is arbitrary and no page can
+/// depend on it; one order is fixed here so the bytes are testable.
+///
+/// `transcript` is escaped because it is arbitrary spoken text landing in a
+/// JavaScript source position. An unescaped `"` would not corrupt one field —
+/// it would end the object early and make the whole `dispatchEvent` call a
+/// syntax error, so the page would see the stream stop rather than see a bad
+/// transcript. That is the failure `ios_events.zig` records against
+/// `bridge_iap.zig:362`, and the reason Swift is safe here is only that
+/// `JSONSerialization` escapes on its behalf.
+///
+/// `isFinal` is a real JSON boolean, never the string `"true"`: the page
+/// interpolates it into a template literal (`test-bridges.html:386`), where a
+/// quoted `"false"` would render as `false` and read as correct while being a
+/// truthy value to any code that branches on it.
+///
+/// An empty transcript still emits the key. Swift always writes it — a first
+/// partial result can legitimately be empty — and omitting it would make
+/// `e.detail.transcript` `undefined`, which a page cannot tell from a broken
+/// bridge.
+///
+/// Caller owns the returned slice.
+pub fn shapeResultDetail(
+    allocator: std.mem.Allocator,
+    transcript: []const u8,
+    is_final: bool,
+) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.appendSlice(allocator, "{\"transcript\":\"");
+    try bridge_error.appendJsonEscaped(allocator, &out, transcript);
+    try out.appendSlice(allocator, "\",\"isFinal\":");
+    try out.appendSlice(allocator, if (is_final) "true" else "false");
+    try out.append(allocator, '}');
+
+    return out.toOwnedSlice(allocator);
+}
+
+// =============================================================================
+// Tests.
+//
+// Two things are under test. First, that this module really does serve
+// nothing — declaring nothing is only half of it, since a module that
+// answered anything other than `UnknownAction` would break the fall-through
+// even with an empty table. Second, the finished half: the event names and the
+// two detail shapers, whose bytes are what a page reads.
+//
+// Nothing here is Darwin-gated, because nothing in this file touches
+// Objective-C.
+// =============================================================================
+
+const testing = std.testing;
+
+test "this module declares no actions, so both fall through to the shim" {
+    // Table -> dispatch, with the table empty. The shim serves both actions
+    // correctly today and neither has a promise to strand, so an empty table
+    // is the whole feature: `ios_dispatch.route` never enters this module and
+    // `handOffToHost` answers.
+    try testing.expectEqual(@as(usize, 0), capability_actions.len);
+    try testing.expectEqual(@as(usize, 0), A.declared_count);
+}
+
+test "the two unserved actions are the spec's, spelled exactly" {
+    // The spelling a future round will move into `A`. Pinned here so the move
+    // is a copy rather than a retype — `startlistening` would route nowhere and
+    // look exactly like this module still not serving it.
+    try testing.expectEqual(@as(usize, 2), unserved_actions.len);
+    try testing.expectEqualStrings("startListening", unserved_actions[0]);
+    try testing.expectEqualStrings("stopListening", unserved_actions[1]);
+}
+
+test "neither unserved action is in the action table" {
+    // The invariant that keeps the ratchet honest. An action listed in `A`
+    // counts as migrated to `test/ios_conformance_test.zig` whether or not
+    // anything answers it, so a name leaking from `unserved_actions` into the
+    // table would lower the ratchet for work nobody did.
+    for (unserved_actions) |name| {
+        for (capability_actions) |decl| {
+            try testing.expect(!std.mem.eql(u8, decl.name, name));
+        }
+    }
+}
+
+test "handleMessage refuses everything, including the actions it researched" {
+    // Dispatch -> table, with both empty. `UnknownAction` is the only error
+    // `ios_dispatch.route` reads as "not mine, ask the next"; any other error
+    // is treated as final and would stop the chain before the shim.
+    var bridge = SpeechBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    const E = bridge_error.BridgeError;
+
+    for (unserved_actions) |name| {
+        try testing.expectError(E.UnknownAction, bridge.handleMessage(name, "{}"));
+    }
+
+    // Casing, near misses, and the neighbouring namespaces' spellings — the
+    // desktop `speechRecognition` actions in particular, which are a different
+    // namespace and must never be answered from here.
+    for ([_][]const u8{
+        "startlistening",
+        "StartListening",
+        "startListen",
+        "listen",
+        "start",
+        "stop",
+        "isAvailable",
+        "speak",
+        "startMotionUpdates",
+        "getDeviceInfo",
+        "",
+    }) |name| {
+        try testing.expectError(E.UnknownAction, bridge.handleMessage(name, "{}"));
+    }
+}
+
+test "no payload can turn the fall-through into a final error" {
+    // The subtle way a serve-nothing module breaks the thing it is protecting.
+    // `ios_dispatch.route` stops the chain on any error but `UnknownAction`, so
+    // a module that parsed its payload before routing would answer
+    // `InvalidJSON` for a malformed one and strand an action it does not
+    // serve — the page would get a rejection where the shim would have worked.
+    var bridge = SpeechBridge.init(testing.allocator);
+    defer bridge.deinit();
+
+    const E = bridge_error.BridgeError;
+
+    for ([_][]const u8{
+        "{not json",
+        "",
+        "null",
+        "[1,2,3]",
+        "{\"transcript\":\"hello\"}",
+        "{\"callbackId\":\"cb_7\"}",
+    }) |payload| {
+        for (unserved_actions) |name| {
+            try testing.expectError(E.UnknownAction, bridge.handleMessage(name, payload));
+        }
+    }
+}
+
+test "the three spellable events are the ones the page subscribes to" {
+    // `test-bridges.html:384`, `:388`, `:391`, and Swift's `sendToWeb` call
+    // sites. camelCase, no colon — the iOS vocabulary, which is why
+    // `ios_events.Event` exists separately from `capabilities.Channel`.
+    try testing.expectEqualStrings("craftSpeechResult", event_result.eventName());
+    try testing.expectEqualStrings("craftSpeechError", event_error.eventName());
+    try testing.expectEqualStrings("craftSpeechEnd", event_end.eventName());
+
+    // And no desktop channel can spell any of them, so emitting through
+    // `capabilities.Channel` would fire events with no subscriber.
+    for (std.enums.values(capabilities.Channel)) |channel| {
+        try testing.expect(!std.mem.eql(u8, channel.eventName(), event_result.eventName()));
+        try testing.expect(!std.mem.eql(u8, channel.eventName(), event_error.eventName()));
+        try testing.expect(!std.mem.eql(u8, channel.eventName(), event_end.eventName()));
+        try testing.expect(!std.mem.eql(u8, channel.eventName(), event_start_name));
+    }
+    // Non-vacuity: the loop above proves nothing over an empty enum.
+    try testing.expect(std.enums.values(capabilities.Channel).len >= 40);
+}
+
+test "craftSpeechStart is still unspellable, which is blocker one" {
+    // A tripwire, not a preference. This module's first blocker is that
+    // `ios_events.Event` has no `.speech_start`, and the moment somebody adds
+    // it precondition 1 is met — which should be noticed here, in the file
+    // that documents it, rather than in a later round rediscovering the
+    // research. Blockers 2-4 still stand on their own, so this trip is a
+    // prompt to re-read them, never a clearance to serve.
+    if (@hasField(ios_events.Event, "speech_start")) {
+        std.debug.print(
+            "ios_events.Event now has .speech_start, so blocker 1 in " ++
+                "bridge_mobile_speech.zig is lifted.\n" ++
+                "  Emit it through the enum, delete event_start_name, and work " ++
+                "through preconditions 2-5 before moving either action into `A`.\n",
+            .{},
+        );
+        return error.SpeechStartBlockerLifted;
+    }
+
+    // Until then the name exists only as a string, and it is the right one.
+    try testing.expectEqualStrings("craftSpeechStart", event_start_name);
+}
+
+test "start and end carry an empty object, not an empty string" {
+    // `data: [:]` through `JSONSerialization` is `{}`. `ios_events.formatEvent`
+    // inlines the detail as a literal, so `""` would produce
+    // `{detail:}` — a syntax error that takes the whole event with it — and
+    // `"null"` would make `e.detail` null where the page expects an object.
+    try testing.expectEqualStrings("{}", empty_detail);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, empty_detail, .{});
+    defer parsed.deinit();
+    try testing.expectEqual(@as(usize, 0), parsed.value.object.count());
+}
+
+// -----------------------------------------------------------------------------
+// craftSpeechError
+// -----------------------------------------------------------------------------
+
+test "the four error messages are Swift's, character for character" {
+    // These strings are shown to a human (`test-bridges.html:392-393`) and
+    // documented in README.md. A paraphrase changes what a user reads without
+    // changing anything else a test can see.
+    try testing.expectEqualStrings("Not authorized", err_not_authorized);
+    try testing.expectEqualStrings("Audio session failed", err_audio_session);
+    try testing.expectEqualStrings("Speech recognizer unavailable", err_recognizer_unavailable);
+    try testing.expectEqualStrings("Audio engine failed", err_audio_engine);
+    try testing.expectEqual(@as(usize, 4), error_messages.len);
+}
+
+test "an error detail is the single key the page reads" {
+    // `e.detail.error` (`test-bridges.html:392`) and nothing else. A `code` or
+    // `message` key alongside it would be a surface no consumer knows about.
+    const json = try shapeErrorDetail(testing.allocator, err_not_authorized);
+    defer testing.allocator.free(json);
+
+    try testing.expectEqualStrings("{\"error\":\"Not authorized\"}", json);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqual(@as(usize, 1), parsed.value.object.count());
+    try testing.expectEqualStrings("Not authorized", parsed.value.object.get("error").?.string);
+}
+
+test "every one of the four messages shapes and parses back" {
+    for (error_messages) |message| {
+        const json = try shapeErrorDetail(testing.allocator, message);
+        defer testing.allocator.free(json);
+
+        var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+        defer parsed.deinit();
+        try testing.expectEqual(@as(usize, 1), parsed.value.object.count());
+        try testing.expectEqualStrings(message, parsed.value.object.get("error").?.string);
+    }
+}
+
+test "an error message carrying a quote does not end the object early" {
+    // No current message does. The escaping is a property of the position, not
+    // of today's inputs, and a future round quoting a framework error is
+    // exactly how the unescaped case arrives.
+    const json = try shapeErrorDetail(testing.allocator, "recognizer said \"no\"\\ever");
+    defer testing.allocator.free(json);
+
+    try testing.expectEqualStrings(
+        "{\"error\":\"recognizer said \\\"no\\\"\\\\ever\"}",
+        json,
+    );
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings(
+        "recognizer said \"no\"\\ever",
+        parsed.value.object.get("error").?.string,
+    );
+}
+
+// -----------------------------------------------------------------------------
+// craftSpeechResult
+// -----------------------------------------------------------------------------
+
+test "a result detail is exactly transcript and isFinal" {
+    // `CraftApp.swift:2525-2528`, and the two keys `test-bridges.html:386`
+    // reads. These are the bytes `e.detail` receives either way, because
+    // `sendToWeb` and `ios_events.formatEvent` inline the detail identically.
+    const partial = try shapeResultDetail(testing.allocator, "hello world", false);
+    defer testing.allocator.free(partial);
+    try testing.expectEqualStrings(
+        "{\"transcript\":\"hello world\",\"isFinal\":false}",
+        partial,
+    );
+
+    const final = try shapeResultDetail(testing.allocator, "hello world", true);
+    defer testing.allocator.free(final);
+    try testing.expectEqualStrings(
+        "{\"transcript\":\"hello world\",\"isFinal\":true}",
+        final,
+    );
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, final, .{});
+    defer parsed.deinit();
+    try testing.expectEqual(@as(usize, 2), parsed.value.object.count());
+    try testing.expectEqualStrings("hello world", parsed.value.object.get("transcript").?.string);
+    try testing.expectEqual(true, parsed.value.object.get("isFinal").?.bool);
+}
+
+test "the detail does not invent keys the recognizer could have supplied" {
+    // `SFSpeechRecognitionResult` also carries `transcriptions`,
+    // `bestTranscription.segments` and per-segment `confidence`, and Swift
+    // reads none of them. Adding one would be a surface no consumer reads and
+    // a divergence from the emitter contract this migration preserves.
+    const json = try shapeResultDetail(testing.allocator, "x", true);
+    defer testing.allocator.free(json);
+
+    try testing.expect(std.mem.indexOf(u8, json, "confidence") == null);
+    try testing.expect(std.mem.indexOf(u8, json, "alternatives") == null);
+    try testing.expect(std.mem.indexOf(u8, json, "segments") == null);
+    try testing.expect(std.mem.indexOf(u8, json, "\"transcript\":") != null);
+    try testing.expect(std.mem.indexOf(u8, json, "\"isFinal\":") != null);
+}
+
+test "isFinal is a JSON boolean, never a quoted string" {
+    // `${e.detail.isFinal}` renders `"false"` and `false` identically, so a
+    // quoted value would read as correct on the test page while being truthy
+    // to any code that branches on it.
+    const json = try shapeResultDetail(testing.allocator, "", false);
+    defer testing.allocator.free(json);
+
+    try testing.expect(std.mem.indexOf(u8, json, "\"isFinal\":false") != null);
+    try testing.expect(std.mem.indexOf(u8, json, "\"false\"") == null);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqual(false, parsed.value.object.get("isFinal").?.bool);
+}
+
+test "an empty transcript still emits the key" {
+    // A first partial result can legitimately be empty. Omitting the key would
+    // leave `e.detail.transcript` undefined, which a page cannot tell from a
+    // bridge that stopped working.
+    const json = try shapeResultDetail(testing.allocator, "", false);
+    defer testing.allocator.free(json);
+
+    try testing.expectEqualStrings("{\"transcript\":\"\",\"isFinal\":false}", json);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqual(@as(usize, 2), parsed.value.object.count());
+    try testing.expectEqualStrings("", parsed.value.object.get("transcript").?.string);
+}
+
+test "a transcript with a quote does not truncate the event" {
+    // The failure this shaper exists to prevent, and the one
+    // `ios_events.zig` records against `bridge_iap.zig:362`: the detail is
+    // inlined into JavaScript source, so an unescaped `"` does not corrupt one
+    // field, it ends the object early and makes the whole `dispatchEvent` call
+    // a syntax error. The page sees the stream stop, not a bad transcript.
+    //
+    // Dictation really does produce these: it transcribes spoken quotation
+    // marks, and `formattedString` is not sanitised.
+    const json = try shapeResultDetail(testing.allocator, "she said \"hello\"", true);
+    defer testing.allocator.free(json);
+
+    try testing.expectEqualStrings(
+        "{\"transcript\":\"she said \\\"hello\\\"\",\"isFinal\":true}",
+        json,
+    );
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings(
+        "she said \"hello\"",
+        parsed.value.object.get("transcript").?.string,
+    );
+}
+
+test "backslashes, newlines and control bytes survive as escapes" {
+    // A literal newline inside a JavaScript string literal is a syntax error,
+    // and a lone backslash would escape whatever followed it. Both reach the
+    // page as a dead event rather than as bad text.
+    const json = try shapeResultDetail(testing.allocator, "a\\b\nc\td\r\x01", false);
+    defer testing.allocator.free(json);
+
+    try testing.expectEqualStrings(
+        "{\"transcript\":\"a\\\\b\\nc\\td\\r\\u0001\",\"isFinal\":false}",
+        json,
+    );
+
+    // No raw control byte survived into the bytes that become JS source.
+    for (json) |c| try testing.expect(c >= 0x20);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("a\\b\nc\td\r\x01", parsed.value.object.get("transcript").?.string);
+}
+
+test "an apostrophe passes through unescaped, and must" {
+    // The opposite error, and an easy one to make while fixing the quote case.
+    // `formatEvent` single-quotes the event *name* only; the detail is an
+    // object literal, where `'` is an ordinary character inside a
+    // double-quoted JSON string. Escaping it would put a literal backslash
+    // into the transcript the page displays — and "don't" and "it's" are the
+    // most common words dictation produces.
+    const json = try shapeResultDetail(testing.allocator, "don't stop", true);
+    defer testing.allocator.free(json);
+
+    try testing.expectEqualStrings("{\"transcript\":\"don't stop\",\"isFinal\":true}", json);
+    try testing.expect(std.mem.indexOfScalar(u8, json, '\\') == null);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("don't stop", parsed.value.object.get("transcript").?.string);
+}
+
+test "multi-byte UTF-8 is carried through unchanged" {
+    // `formattedString` is whatever locale the recognizer was built with, and
+    // even `en-US` produces curly apostrophes and em dashes. Escaping per byte
+    // rather than per code point would split a sequence and hand the page
+    // invalid JSON.
+    const spoken = "café — naïve 日本語";
+    const json = try shapeResultDetail(testing.allocator, spoken, true);
+    defer testing.allocator.free(json);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings(spoken, parsed.value.object.get("transcript").?.string);
+    try testing.expect(std.unicode.utf8ValidateSlice(json));
+}
+
+test "a shaped detail is a complete JSON value, which is what emit requires" {
+    // `ios_events.emit` documents its argument as a complete JSON value and
+    // inlines it verbatim. A shaper returning a fragment, or leaving a
+    // trailing comma, would produce a `dispatchEvent` call the page cannot
+    // parse — an event that silently never arrives.
+    const details = [_][]u8{
+        try shapeResultDetail(testing.allocator, "one", false),
+        try shapeResultDetail(testing.allocator, "", true),
+        try shapeErrorDetail(testing.allocator, err_audio_engine),
+    };
+    defer for (details) |d| testing.allocator.free(d);
+
+    for (details) |detail| {
+        try testing.expect(std.mem.startsWith(u8, detail, "{"));
+        try testing.expect(std.mem.endsWith(u8, detail, "}"));
+        var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, detail, .{});
+        defer parsed.deinit();
+        try testing.expect(parsed.value == .object);
+    }
+}

--- a/packages/zig/src/ios_dispatch.zig
+++ b/packages/zig/src/ios_dispatch.zig
@@ -29,6 +29,15 @@ const bridge_mobile_motion = @import("bridge_mobile_motion.zig");
 const bridge_mobile_imagepicker = @import("bridge_mobile_imagepicker.zig");
 const bridge_mobile_filepicker = @import("bridge_mobile_filepicker.zig");
 const bridge_mobile_contactpicker = @import("bridge_mobile_contactpicker.zig");
+const bridge_mobile_calendar = @import("bridge_mobile_calendar.zig");
+const bridge_mobile_contacts = @import("bridge_mobile_contacts.zig");
+// `bridge_mobile_speech.zig` is deliberately NOT in the chain. Its
+// capability_actions table is empty — the two speech actions were researched
+// in full and left with the Swift shim — so a module here would iterate,
+// return UnknownAction, and cost a comparison to serve nothing. Keeping it in
+// the chain would also read as coverage it does not provide, which is the
+// habit this migration exists to break. The file stays as the record of that
+// decision and of the Swift behaviour a future port has to match.
 
 const objc = objc_runtime.objc;
 
@@ -239,6 +248,8 @@ const mobile_bridges = .{
     bridge_mobile_imagepicker.ImagePickerBridge,
     bridge_mobile_filepicker.FilePickerBridge,
     bridge_mobile_contactpicker.ContactPickerBridge,
+    bridge_mobile_calendar.CalendarBridge,
+    bridge_mobile_contacts.ContactsBridge,
 };
 
 /// Narrow an arbitrary handler error to one the page's error codes can express.

--- a/packages/zig/test/ios_conformance_test.zig
+++ b/packages/zig/test/ios_conformance_test.zig
@@ -47,6 +47,9 @@ const zig_sources = [_][]const u8{
     @embedFile("src/bridge_mobile_imagepicker.zig"),
     @embedFile("src/bridge_mobile_filepicker.zig"),
     @embedFile("src/bridge_mobile_contactpicker.zig"),
+    @embedFile("src/bridge_mobile_calendar.zig"),
+    @embedFile("src/bridge_mobile_contacts.zig"),
+    @embedFile("src/bridge_mobile_speech.zig"),
 };
 
 /// The action list lives in the `switch action` block, and nowhere else.
@@ -87,7 +90,10 @@ const dispatch_end = "func webView(";
 /// 53 after the presented pickers — image, document and contact — landed on
 /// the delegate factory, the last of the three mechanisms this migration
 /// needed. Everything remaining is a repetition of a proven pattern.
-const max_not_yet_migrated: usize = 53;
+/// 48 after calendar and contacts. Speech was researched in full and left
+/// with the shim: neither action replies, so unlike the earlier deferrals
+/// there is no promise to strand and falling through costs the page nothing.
+const max_not_yet_migrated: usize = 48;
 
 fn dispatcherRegion() []const u8 {
     const begin = std.mem.indexOf(u8, swift_spec, dispatch_begin) orelse return "";


### PR DESCRIPTION
Follow-on to #90. Five actions — `getCalendarEvents`, `createCalendarEvent`, `deleteCalendarEvent`, `getContacts`, `addContact` — and **no new mechanism**.

That was the point. Every foundation written in this session (`ios_async`'s `deliverJson`, `ios_events`, the delegate helper's `?Id`) had a bug in it that review caught. The way to reduce that risk was to stop writing foundations and apply the three that exist.

## Speech: researched in full, deliberately not served

`startListening`/`stopListening` stay with the Swift shim, and this is the cheapest such deferral yet: **neither carries a `callbackId` and neither ever replies**, so unlike `scheduleNotification` or `sendToWatch` there is no promise to strand. Falling through costs the page nothing.

The module stays as the record of that decision and of the Swift behaviour a future port must match — including two bugs it would otherwise have to choose between reproducing and diverging from. But it is **not in the dispatch chain**: a module whose `capability_actions` table is empty can only ever return `UnknownAction`, so keeping it there would cost a comparison to serve nothing and read as coverage it doesn't provide.

## A non-vacuity guard that was itself vacuous

The best find of the round. A test scanned the module's own `@embedFile` for `"ios_async.deliverJson"` to prove the reply path existed — and the needle matched **the assertion line that spelled it**, plus the module prose naming the same function. Deleting every real reply call would have left the test green.

The sibling modules avoid this by embedding an escaped quote so the literal can't match itself; these two calls had no quote to hide behind. Now assembled from halves.

It also found a **claimed diagnostic that did not exist**: the module said a nil event date was "refused with the event's id in the log", and nothing logged the id — leaving an operator with a failing fetch and no way to find the offending row. The log line exists now.

## Verification

Sixteen fixture assertions on an iPhone 17 Pro simulator, plus `zig build test` / `test:ios` / `build-ios` / `build-ios-simulator` / `build-android`, `zig fmt --check`, `verify:cimports`, `pickier`.

**48 of 106 remaining.** Everything left is a repetition of a proven pattern, or Swift-only by nature (WidgetKit, ActivityKit, App Intents, StoreKit 2).