### PR TITLE
fix(lint): drop fourteen unused imports that pickier now errors on

### DIFF
--- a/examples/ecommerce-app/src/main.ts
+++ b/examples/ecommerce-app/src/main.ts
@@ -6,7 +6,7 @@
 // NOTE: Use `win` alias (for windowManager) instead of `window`. `Platform` (value)
 // is exported from 'craft-native/components' to avoid a conflict with the
 // Platform type at the top level.
-import { db, http, win as window, haptics, secureStorage } from 'craft-native'
+import { db, win as window, haptics } from 'craft-native'
 import { Platform } from 'craft-native/components'
 
 // Types

--- a/examples/voice-buddy.ts
+++ b/examples/voice-buddy.ts
@@ -17,7 +17,6 @@
 
 import { createApp } from '../packages/typescript/src/index.ts'
 import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
 
 // Path to the STX file
 const stxPath = '/Users/glennmichaeltorregosa/Documents/Projects/stx/examples/voice-buddy.stx'

--- a/packages/android/src/index.ts
+++ b/packages/android/src/index.ts
@@ -4,7 +4,7 @@
  * Generates native Android apps from web content using WebView.
  */
 
-import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { $ } from 'bun'
 

--- a/packages/ios/src/index.ts
+++ b/packages/ios/src/index.ts
@@ -5,7 +5,7 @@
  */
 
 import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs'
-import { basename, dirname, join, resolve } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import { $ } from 'bun'
 
 const TEMPLATES_DIR = join(dirname(import.meta.dir), 'templates')

--- a/packages/react/src/hooks/useTray.ts
+++ b/packages/react/src/hooks/useTray.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useCraft } from '../index';
 
 interface TrayMenuItem {

--- a/packages/react/src/hooks/useWindow.ts
+++ b/packages/react/src/hooks/useWindow.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { useCraft } from '../index';
 
 interface WindowOptions {

--- a/packages/svelte/src/stores/craft.ts
+++ b/packages/svelte/src/stores/craft.ts
@@ -1,4 +1,4 @@
-import { writable, derived, get } from 'svelte/store';
+import { writable, derived } from 'svelte/store';
 
 interface CraftAPI {
   getPlatform(): Promise<{ platform: string; version: string }>;

--- a/packages/typescript/src/logging/index.ts
+++ b/packages/typescript/src/logging/index.ts
@@ -4,7 +4,7 @@
  */
 
 import { writeFileSync, appendFileSync, existsSync, mkdirSync, readFileSync } from 'fs'
-import { join, dirname } from 'path'
+import { dirname } from 'path'
 import { hostname as osHostname } from 'os'
 
 // Types

--- a/packages/typescript/src/signing/index.ts
+++ b/packages/typescript/src/signing/index.ts
@@ -4,7 +4,7 @@
  */
 
 import { execFile, spawn } from 'child_process'
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs'
+import { existsSync, unlinkSync, writeFileSync } from 'fs'
 import { join, basename } from 'path'
 import { promisify } from 'util'
 

--- a/packages/typescript/src/styles/sidebar-templates.ts
+++ b/packages/typescript/src/styles/sidebar-templates.ts
@@ -8,7 +8,7 @@
  * @module @craft-native/styles/sidebar-templates
  */
 
-import { tahoeStyles, arcStyles, orbstackStyles, cx } from './sidebars.js'
+import { tahoeStyles, arcStyles, orbstackStyles } from './sidebars.js'
 
 // ============================================================================
 // Types

--- a/packages/typescript/src/updater/index.ts
+++ b/packages/typescript/src/updater/index.ts
@@ -7,7 +7,6 @@ import { createReadStream, createWriteStream, existsSync, mkdirSync, readFileSyn
 import { join, basename, dirname } from 'path'
 import { execFileSync, spawn } from 'child_process'
 import { createHash } from 'crypto'
-import { pipeline } from 'stream/promises'
 import { EventEmitter } from 'events'
 
 // Types

--- a/packages/typescript/src/utils/svelte.ts
+++ b/packages/typescript/src/utils/svelte.ts
@@ -3,7 +3,7 @@
  * @module @craft-native/svelte
  */
 
-import { writable, derived, readable, get, type Writable, type Readable } from 'svelte/store';
+import { writable, derived, type Writable, type Readable } from 'svelte/store';
 import { onMount, onDestroy } from 'svelte';
 import { windowManager } from '../api/window.js';
 


### PR DESCRIPTION
`bunx --bun pickier .` resolves the newest pickier at every CI run, and the current release promotes `no-unused-imports` from a warning to an error. Nothing in the repo changed — the rule did — so `lint` is now red on every open PR for fourteen unused imports in files nobody touched.

Removed:

| file | import |
|---|---|
| `packages/react/src/hooks/useWindow.ts` | `useEffect` |
| `packages/react/src/hooks/useTray.ts` | `useEffect` |
| `packages/android/src/index.ts` | `readdirSync` |
| `packages/ios/src/index.ts` | `basename` |
| `packages/typescript/src/logging/index.ts` | `join` |
| `packages/typescript/src/styles/sidebar-templates.ts` | `cx` |
| `packages/typescript/src/updater/index.ts` | `pipeline` |
| `packages/typescript/src/utils/svelte.ts` | `readable`, `get` |
| `packages/typescript/src/signing/index.ts` | `readFileSync` |
| `packages/svelte/src/stores/craft.ts` | `get` |
| `examples/voice-buddy.ts` | `join` |
| `examples/ecommerce-app/src/main.ts` | `http`, `secureStorage` |

Each was verified unused by grepping for the symbol after removal rather than by trusting the rule — `packages/react`, `packages/svelte` and `examples/` are outside the `typecheck` script, so the compiler would not have caught a mistake there. The one apparent survivor, `pipeline` in `updater/index.ts`, is the word inside a comment.

**The cause is worth naming, not just the symptom.** The lint script pins no version, so CI and a local checkout run different linters — a local run here reported 0 errors against the installed 0.1.37 while CI failed against 0.1.65. Today that surfaced as a rule getting stricter, which is the benign direction. The same gap would equally let CI run a *looser* rule set than a developer sees, with nothing to indicate the two ran different code.

## Verification

- `bunx --bun pickier@0.1.65 .` — 0 errors (32 pre-existing warnings, all markdown/quote style)
- `bun run typecheck` — passes