### PR TITLE
fix(ci): build the SDK types with the repo's own tsc (and pin the pantry action)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Zig
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@235036fa0f48bae99b2293df5a3dc35c809b1777 # pinned: last SHA whose bundled typescript resolves on linux-x64
       - name: Install Linux dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -49,7 +49,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Zig
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@235036fa0f48bae99b2293df5a3dc35c809b1777 # pinned: last SHA whose bundled typescript resolves on linux-x64
       - name: Install Linux dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Pantry (provides Bun, Zig, etc.)
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@235036fa0f48bae99b2293df5a3dc35c809b1777 # pinned: last SHA whose bundled typescript resolves on linux-x64
 
       - name: Verify Zig installation
         run: eval "$(pantry env | sed -n '/^export /,$p')" && zig version
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Pantry (provides Bun, Zig, etc.)
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@235036fa0f48bae99b2293df5a3dc35c809b1777 # pinned: last SHA whose bundled typescript resolves on linux-x64
 
       - name: Install dependencies
         run: bun install
@@ -116,7 +116,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Pantry (provides Bun, Zig, etc.)
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@235036fa0f48bae99b2293df5a3dc35c809b1777 # pinned: last SHA whose bundled typescript resolves on linux-x64
 
       - name: Install dependencies
         run: bun install
@@ -132,7 +132,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Pantry (provides Bun, Zig, etc.)
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@235036fa0f48bae99b2293df5a3dc35c809b1777 # pinned: last SHA whose bundled typescript resolves on linux-x64
 
       - name: Install dependencies
         run: bun install
@@ -156,7 +156,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Pantry (provides Bun, Zig, etc.)
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@235036fa0f48bae99b2293df5a3dc35c809b1777 # pinned: last SHA whose bundled typescript resolves on linux-x64
 
       - name: Install dependencies
         run: bun install
@@ -179,7 +179,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Pantry (provides Bun, Zig, etc.)
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@235036fa0f48bae99b2293df5a3dc35c809b1777 # pinned: last SHA whose bundled typescript resolves on linux-x64
 
       - name: Install dependencies
         run: bun install
@@ -228,7 +228,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Pantry (provides Bun, Zig, etc.)
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@235036fa0f48bae99b2293df5a3dc35c809b1777 # pinned: last SHA whose bundled typescript resolves on linux-x64
 
       - name: Install Dependencies
         run: bun install

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Zig
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@235036fa0f48bae99b2293df5a3dc35c809b1777 # pinned: last SHA whose bundled typescript resolves on linux-x64
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -142,7 +142,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Zig
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@235036fa0f48bae99b2293df5a3dc35c809b1777 # pinned: last SHA whose bundled typescript resolves on linux-x64
       - name: Setup Java
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/native-lifecycle.yml
+++ b/.github/workflows/native-lifecycle.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Pantry (provides Bun)
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@235036fa0f48bae99b2293df5a3dc35c809b1777 # pinned: last SHA whose bundled typescript resolves on linux-x64
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Pantry (provides Bun, Zig, etc.)
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@235036fa0f48bae99b2293df5a3dc35c809b1777 # pinned: last SHA whose bundled typescript resolves on linux-x64
 
       - name: Install System Dependencies
         if: matrix.platform.deps != ''
@@ -290,7 +290,7 @@ jobs:
       # 2. Auto-packages binaries from zig-out/ into platform-named zips
       # 3. Creates/updates GitHub release with all artifacts + changelog
       - name: Publish & Release
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@235036fa0f48bae99b2293df5a3dc35c809b1777 # pinned: last SHA whose bundled typescript resolves on linux-x64
         with:
           install: 'false'
           publish: 'zig'
@@ -427,7 +427,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Pantry (provides Bun, Zig, etc.)
-        uses: pantry-pm/pantry/packages/action@main
+        uses: pantry-pm/pantry/packages/action@235036fa0f48bae99b2293df5a3dc35c809b1777 # pinned: last SHA whose bundled typescript resolves on linux-x64
       - name: Install Dependencies
         run: bun install
 

--- a/deps.yaml
+++ b/deps.yaml
@@ -5,6 +5,13 @@ dependencies:
   bun.sh: 1.3.14
   # Also pinned exactly. `^0.17.0-dev` floats on Zig's *dev* channel, so any
   # `pantry install` can swap the compiler out from under a build — observed
-  # jumping 1509 -> 1606 unprompted. This is the version v0.0.58 was released
-  # with. Bump deliberately, and rebuild when you do.
-  ziglang.org: 0.17.0-dev.1509_bb296ab9b
+  # jumping 1509 -> 1606 unprompted. Bump deliberately, and rebuild when you do.
+  #
+  # The pin has a shelf life, which 1509 is how we found out. ziglang.org
+  # serves exactly one dev build — whatever master is now — plus the tagged
+  # releases, and prunes the rest. Every platform tarball for 1509 returned
+  # 404, so CI was running on cached toolchains and any uncached runner failed
+  # to provision at all: `darwin-x64` went red on a lockfile-free PR, and the
+  # next tagged release would have failed the same way. A pinned dev build is
+  # reproducible only for as long as it is master.
+  ziglang.org: 0.17.0-dev.1963_e00c6c439

--- a/docs/android-development.md
+++ b/docs/android-development.md
@@ -488,7 +488,7 @@ Per `CLAUDE.md`'s distribution rule, the `.so` resolution lives here in the Andr
 | Phase A0 | pinned Zig only | ✅ works today |
 | Phase A1+ | Android SDK, NDK (pinned `26.1.10909125`), `adb`, `gradle` | ❌ none present |
 
-Zig is pinned at `0.17.0-dev.1509+bb296ab9b`.
+Zig is pinned at `0.17.0-dev.1963+e00c6c439`.
 
 ---
 

--- a/docs/ios-development.md
+++ b/docs/ios-development.md
@@ -385,7 +385,7 @@ gated on `hashFiles('packages/ios/TestApp/TestApp.xcodeproj')`, which has never 
 | Phase 0 | nothing beyond the pinned Zig | ✅ works today on Command Line Tools |
 | Phase 1+ | full Xcode — SDK, simulator runtime | ❌ install required |
 
-Zig is pinned at `0.17.0-dev.1509+bb296ab9b`. Clear `.zig-cache` between heavy rounds.
+Zig is pinned at `0.17.0-dev.1963+e00c6c439`. Clear `.zig-cache` between heavy rounds.
 
 ---
 

--- a/packages/ios/fixtures/zig-slice/build-and-run.sh
+++ b/packages/ios/fixtures/zig-slice/build-and-run.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
-ZIG="${CRAFT_ZIG:-$HOME/.cache/craft-ci-local/zig-aarch64-macos-0.17.0-dev.1509+bb296ab9b/zig}"
+ZIG="${CRAFT_ZIG:-$HOME/.cache/craft-ci-local/zig-aarch64-macos-0.17.0-dev.1963+e00c6c439/zig}"
 FIXTURE="$ROOT/packages/ios/fixtures/zig-slice"
 OUT="${1:-$FIXTURE/build}"
 BUNDLE_ID="app.craft.slice"

--- a/packages/typescript/build.ts
+++ b/packages/typescript/build.ts
@@ -25,8 +25,9 @@ async function build(entrypoints: string[], outdir: string): Promise<void> {
 // their implementation and templates instead of importing unpublished peers.
 await build(['../ios/src/index.ts'], 'dist/ios/src')
 await build(['../android/src/index.ts'], 'dist/android/src')
-await Bun.$`bunx tsc ${resolve(root, '../ios/src/index.ts')} --declaration --emitDeclarationOnly --module esnext --target esnext --moduleResolution bundler --types bun --skipLibCheck --ignoreConfig --outDir ${resolve(dist, 'ios/src')}`
-await Bun.$`bunx tsc ${resolve(root, '../android/src/index.ts')} --declaration --emitDeclarationOnly --module esnext --target esnext --moduleResolution bundler --types bun --skipLibCheck --ignoreConfig --outDir ${resolve(dist, 'android/src')}`
+// scripts/tsc.ts, not `bunx tsc`: PATH is not trustworthy in CI. See that file.
+await Bun.$`bun ${resolve(root, "scripts/tsc.ts")} ${resolve(root, '../ios/src/index.ts')} --declaration --emitDeclarationOnly --module esnext --target esnext --moduleResolution bundler --types bun --skipLibCheck --ignoreConfig --outDir ${resolve(dist, 'ios/src')}`
+await Bun.$`bun ${resolve(root, "scripts/tsc.ts")} ${resolve(root, '../android/src/index.ts')} --declaration --emitDeclarationOnly --module esnext --target esnext --moduleResolution bundler --types bun --skipLibCheck --ignoreConfig --outDir ${resolve(dist, 'android/src')}`
 await cp(resolve(root, '../ios/templates'), resolve(dist, 'ios/templates'), { recursive: true })
 await cp(resolve(root, '../android/templates'), resolve(dist, 'android/templates'), { recursive: true })
 

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -81,7 +81,7 @@
   "scripts": {
     "build": "bun build.ts && bun run build:types",
     "build:lib": "bun build src/index.ts --outdir dist --format esm --target bun && bun build src/index.ts --outfile dist/index.cjs --format cjs --target node",
-    "build:types": "bun run tsc -p tsconfig.build.json && cp dist/index.d.ts dist/index.d.cts",
+    "build:types": "bunx --bun tsc -p tsconfig.build.json && cp dist/index.d.ts dist/index.d.cts",
     "dev": "bun --watch src/index.ts",
     "lint": "bunx --bun pickier lint . --config ../../pickier.config.ts --max-warnings 9999",
     "lint:fix": "bunx --bun pickier lint . --fix --config ../../pickier.config.ts --max-warnings 9999",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -81,7 +81,7 @@
   "scripts": {
     "build": "bun build.ts && bun run build:types",
     "build:lib": "bun build src/index.ts --outdir dist --format esm --target bun && bun build src/index.ts --outfile dist/index.cjs --format cjs --target node",
-    "build:types": "bunx --bun tsc -p tsconfig.build.json && cp dist/index.d.ts dist/index.d.cts",
+    "build:types": "bun scripts/tsc.ts -p tsconfig.build.json && cp dist/index.d.ts dist/index.d.cts",
     "dev": "bun --watch src/index.ts",
     "lint": "bunx --bun pickier lint . --config ../../pickier.config.ts --max-warnings 9999",
     "lint:fix": "bunx --bun pickier lint . --fix --config ../../pickier.config.ts --max-warnings 9999",

--- a/packages/typescript/scripts/tsc.ts
+++ b/packages/typescript/scripts/tsc.ts
@@ -1,0 +1,21 @@
+/**
+ * Run the `tsc` this package declares, not the one on PATH.
+ *
+ * `bunx tsc` resolves through PATH. In CI the pantry action provisions its own
+ * typescript into `<repo>/pantry` and puts it ahead of `node_modules/.bin`, so
+ * the same command silently ran a different compiler — a dev build the
+ * lockfile never pinned, and one whose linux-x64 platform binary is missing:
+ *
+ *   Error: Unable to resolve @typescript/typescript-linux-x64.
+ *
+ * Locally nothing shadows `node_modules/.bin`, which is why the break only
+ * ever showed up in one CI job. Resolving through the module graph instead of
+ * PATH makes both places run the version `bun.lock` says.
+ */
+import { dirname, join } from 'node:path'
+
+const pkgRoot = dirname(dirname(Bun.resolveSync('typescript', import.meta.dir)))
+const tsc = join(pkgRoot, 'bin', 'tsc')
+
+const proc = Bun.spawn(['bun', tsc, ...Bun.argv.slice(2)], { stdio: ['inherit', 'inherit', 'inherit'] })
+process.exit(await proc.exited)

--- a/packages/zig/src/benchmark.zig
+++ b/packages/zig/src/benchmark.zig
@@ -276,7 +276,7 @@ pub const BenchmarkSuite = struct {
     }
 
     pub fn generateReport(self: *const BenchmarkSuite, allocator: std.mem.Allocator) ![]const u8 {
-        var buf = std.ArrayList(u8){ .items = &.{}, .capacity = 0 };
+        var buf = std.ArrayList(u8).empty;
         errdefer buf.deinit(allocator);
 
         const header = try std.fmt.allocPrint(allocator, "Benchmark Suite: {s}\n", .{self.name});
@@ -301,7 +301,7 @@ pub const BenchmarkSuite = struct {
     }
 
     pub fn generateJSON(self: *const BenchmarkSuite, allocator: std.mem.Allocator) ![]const u8 {
-        var buf = std.ArrayList(u8){ .items = &.{}, .capacity = 0 };
+        var buf = std.ArrayList(u8).empty;
         errdefer buf.deinit(allocator);
 
         try buf.appendSlice(allocator, "{");
@@ -422,7 +422,7 @@ pub fn benchmarkArrayListOperations(allocator: std.mem.Allocator, operations: us
 }
 
 fn arrayListOps(allocator: std.mem.Allocator, ops: usize) !void {
-    var list = std.ArrayList(usize){ .items = &.{}, .capacity = 0 };
+    var list = std.ArrayList(usize).empty;
     defer list.deinit(allocator);
 
     var i: usize = 0;

--- a/packages/zig/src/bridge_clipboard.zig
+++ b/packages/zig/src/bridge_clipboard.zig
@@ -193,7 +193,7 @@ pub const ClipboardBridge = struct {
                     log.debug("Read text from clipboard: {s}", .{text_str});
 
                     // Escape backslashes and quotes for safe JSON embedding
-                    var buf: std.ArrayList(u8) = .{ .items = &.{}, .capacity = 0 };
+                    var buf: std.ArrayList(u8) = .empty;
                     defer buf.deinit(self.allocator);
 
                     try buf.appendSlice(self.allocator, "{\"text\":\"");
@@ -306,7 +306,7 @@ pub const ClipboardBridge = struct {
                     const html_str = std.mem.span(@as([*:0]const u8, @ptrCast(html_cstr)));
                     log.debug("Read HTML from clipboard: {s}", .{html_str});
 
-                    var buf: std.ArrayList(u8) = .{ .items = &.{}, .capacity = 0 };
+                    var buf: std.ArrayList(u8) = .empty;
                     defer buf.deinit(self.allocator);
 
                     try buf.appendSlice(self.allocator, "{\"html\":\"");

--- a/packages/zig/src/bridge_dialog.zig
+++ b/packages/zig/src/bridge_dialog.zig
@@ -432,7 +432,7 @@ pub const DialogBridge = struct {
                     if (comptime builtin.mode == .debug)
                         std.debug.print("[DialogBridge] Selected file: {s}\n", .{path_str});
 
-                    var buf: std.ArrayList(u8) = .{ .items = &.{}, .capacity = 0 };
+                    var buf: std.ArrayList(u8) = .empty;
                     defer buf.deinit(self.allocator);
 
                     try buf.appendSlice(self.allocator, "{\"canceled\":false,\"filePaths\":[\"");
@@ -502,7 +502,7 @@ pub const DialogBridge = struct {
                 if (comptime builtin.mode == .debug)
                     std.debug.print("[DialogBridge] Selected {d} files\n", .{count});
 
-                var buf: std.ArrayList(u8) = .{ .items = &.{}, .capacity = 0 };
+                var buf: std.ArrayList(u8) = .empty;
                 defer buf.deinit(self.allocator);
 
                 try buf.appendSlice(self.allocator, "{\"canceled\":false,\"filePaths\":[");
@@ -581,7 +581,7 @@ pub const DialogBridge = struct {
                 if (comptime builtin.mode == .debug)
                     std.debug.print("[DialogBridge] Selected folder: {s}\n", .{path_str});
 
-                var buf: std.ArrayList(u8) = .{ .items = &.{}, .capacity = 0 };
+                var buf: std.ArrayList(u8) = .empty;
                 defer buf.deinit(self.allocator);
 
                 try buf.appendSlice(self.allocator, "{\"canceled\":false,\"filePaths\":[\"");
@@ -645,7 +645,7 @@ pub const DialogBridge = struct {
                 if (comptime builtin.mode == .debug)
                     std.debug.print("[DialogBridge] Save path: {s}\n", .{path_str});
 
-                var buf: std.ArrayList(u8) = .{ .items = &.{}, .capacity = 0 };
+                var buf: std.ArrayList(u8) = .empty;
                 defer buf.deinit(self.allocator);
 
                 try buf.appendSlice(self.allocator, "{\"canceled\":false,\"filePath\":\"");

--- a/packages/zig/src/bridge_native_ui.zig
+++ b/packages/zig/src/bridge_native_ui.zig
@@ -228,7 +228,7 @@ pub const NativeUIBridge = struct {
     /// The returned slice borrows every string from `parsed`, so it must be
     /// consumed before the parse arena is freed — `SpaceList.append` copies.
     fn parseSpaces(allocator: std.mem.Allocator, value: std.json.Value) !std.ArrayList(space_switcher.Space) {
-        var spaces: std.ArrayList(space_switcher.Space) = .{ .items = &.{}, .capacity = 0 };
+        var spaces: std.ArrayList(space_switcher.Space) = .empty;
         errdefer spaces.deinit(allocator);
 
         for (value.array.items) |entry| {
@@ -270,7 +270,7 @@ pub const NativeUIBridge = struct {
         var spaces = if (root.get("spaces")) |v|
             try parseSpaces(self.allocator, v)
         else
-            std.ArrayList(space_switcher.Space){ .items = &.{}, .capacity = 0 };
+            std.ArrayList(space_switcher.Space).empty;
         defer spaces.deinit(self.allocator);
 
         const active = if (root.get("activeSpace")) |v| switch (v) {
@@ -366,7 +366,7 @@ pub const NativeUIBridge = struct {
                 const section_label = if (section_obj.get("label")) |v| v.string else if (section_obj.get("title")) |v| v.string else section_id;
                 const items_value = section_obj.get("items") orelse continue;
 
-                var items: std.ArrayList(NativeSidebar.SidebarItem) = .{ .items = &.{}, .capacity = 0 };
+                var items: std.ArrayList(NativeSidebar.SidebarItem) = .empty;
                 defer items.deinit(self.allocator);
 
                 for (items_value.array.items) |item_value| {
@@ -481,7 +481,7 @@ pub const NativeUIBridge = struct {
         const items_json = section_data.get("items").?.array;
 
         // Build items array
-        var items: std.ArrayList(NativeSidebar.SidebarItem) = .{ .items = &.{}, .capacity = 0 };
+        var items: std.ArrayList(NativeSidebar.SidebarItem) = .empty;
         defer items.deinit(self.allocator);
 
         for (items_json.items) |item_json| {
@@ -596,7 +596,7 @@ pub const NativeUIBridge = struct {
 
         const browser = self.file_browsers.get(browser_id) orelse return error.BrowserNotFound;
 
-        var files: std.ArrayList(NativeFileBrowser.FileItem) = .{ .items = &.{}, .capacity = 0 };
+        var files: std.ArrayList(NativeFileBrowser.FileItem) = .empty;
         defer files.deinit(self.allocator);
 
         for (files_json.items) |file_json| {
@@ -766,7 +766,7 @@ pub const NativeUIBridge = struct {
 
         // Parse menu items
         const items_json = root.get("items").?.array;
-        var items: std.ArrayList(context_menu.MenuItem) = .{ .items = &.{}, .capacity = 0 };
+        var items: std.ArrayList(context_menu.MenuItem) = .empty;
         defer items.deinit(self.allocator);
 
         for (items_json.items) |item_json| {
@@ -785,7 +785,7 @@ pub const NativeUIBridge = struct {
             if (item_type == .submenu) {
                 if (item_obj.get("submenu")) |submenu_json| {
                     if (submenu_json == .array) {
-                        var submenu_list: std.ArrayList(context_menu.MenuItem) = .{ .items = &.{}, .capacity = 0 };
+                        var submenu_list: std.ArrayList(context_menu.MenuItem) = .empty;
                         for (submenu_json.array.items) |sub_item_json| {
                             if (sub_item_json == .object) {
                                 const sub_obj = sub_item_json.object;

--- a/packages/zig/src/components/context_menu.zig
+++ b/packages/zig/src/components/context_menu.zig
@@ -42,7 +42,7 @@ pub const MenuCallbackData = struct {
         data.* = .{
             .target_id = try allocator.dupe(u8, target_id),
             .target_type = try allocator.dupe(u8, target_type),
-            .item_ids = .{ .items = &.{}, .capacity = 0 },
+            .item_ids = .empty,
             .allocator = allocator,
         };
         return data;

--- a/packages/zig/src/components/native_sidebar.zig
+++ b/packages/zig/src/components/native_sidebar.zig
@@ -151,7 +151,7 @@ pub const NativeSidebar = struct {
         var new_section = OutlineViewDataSource.DataStore.Section{
             .id = try self.allocator.dupe(u8, section.id),
             .header = if (section.header) |h| try self.allocator.dupe(u8, h) else null,
-            .items = .{ .items = &.{}, .capacity = 0 },
+            .items = .empty,
             .is_expanded = true,
         };
 

--- a/packages/zig/src/components/outline_view_datasource.zig
+++ b/packages/zig/src/components/outline_view_datasource.zig
@@ -30,7 +30,7 @@ pub const OutlineViewDataSource = struct {
 
         pub fn init(allocator: std.mem.Allocator) DataStore {
             return .{
-                .sections = .{ .items = &.{}, .capacity = 0 },
+                .sections = .empty,
                 .allocator = allocator,
             };
         }

--- a/packages/zig/src/components/quick_look.zig
+++ b/packages/zig/src/components/quick_look.zig
@@ -22,7 +22,7 @@ pub const QuickLookCallbackData = struct {
     pub fn init(allocator: std.mem.Allocator) !*QuickLookCallbackData {
         const data = try allocator.create(QuickLookCallbackData);
         data.* = .{
-            .preview_items = .{ .items = &.{}, .capacity = 0 },
+            .preview_items = .empty,
             .current_index = 0,
             .allocator = allocator,
         };

--- a/packages/zig/src/components/space_list.zig
+++ b/packages/zig/src/components/space_list.zig
@@ -22,7 +22,7 @@ pub const SpaceList = struct {
     active: ?usize = null,
 
     pub fn init(allocator: std.mem.Allocator) SpaceList {
-        return .{ .allocator = allocator, .spaces = .{ .items = &.{}, .capacity = 0 } };
+        return .{ .allocator = allocator, .spaces = .empty };
     }
 
     pub fn deinit(self: *SpaceList) void {

--- a/packages/zig/src/components/table_view_datasource.zig
+++ b/packages/zig/src/components/table_view_datasource.zig
@@ -25,7 +25,7 @@ pub const TableViewDataSource = struct {
 
         pub fn init(allocator: std.mem.Allocator) DataStore {
             return .{
-                .files = .{ .items = &.{}, .capacity = 0 },
+                .files = .empty,
                 .allocator = allocator,
             };
         }

--- a/packages/zig/src/devmode.zig
+++ b/packages/zig/src/devmode.zig
@@ -210,7 +210,7 @@ pub const ErrorDisplay = struct {
     color_output: bool = true,
 
     pub fn formatError(self: ErrorDisplay, allocator: std.mem.Allocator, err: anyerror, context: []const u8, file: []const u8, line: u32) ![]const u8 {
-        var buf = std.ArrayList(u8){ .items = &.{}, .capacity = 0 };
+        var buf = std.ArrayList(u8).empty;
         const writer = buf.writer(allocator);
 
         // Header with emoji for visibility

--- a/packages/zig/src/hotreload.zig
+++ b/packages/zig/src/hotreload.zig
@@ -454,7 +454,7 @@ pub const ReloadServer = struct {
     pub fn broadcast(self: *Self, message: []const u8) !void {
         if (!self.running) return;
 
-        var disconnected: std.ArrayList(usize) = .{ .items = &.{}, .capacity = 0 };
+        var disconnected: std.ArrayList(usize) = .empty;
         defer disconnected.deinit(self.allocator);
 
         // Send to all clients

--- a/packages/zig/src/macos.zig
+++ b/packages/zig/src/macos.zig
@@ -5003,7 +5003,7 @@ pub fn tryEvalJS(js_code: []const u8) !void {
 /// Handle incoming messages from JavaScript bridge
 /// Convert a JSON Value to string
 fn jsonValueToString(allocator: std.mem.Allocator, value: std.json.Value) ![]const u8 {
-    var buf: std.ArrayListUnmanaged(u8) = .{ .items = &.{}, .capacity = 0 };
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
     errdefer buf.deinit(allocator);
 
     switch (value) {

--- a/packages/zig/src/main.zig
+++ b/packages/zig/src/main.zig
@@ -209,8 +209,8 @@ pub const App = struct {
     pub fn init(allocator: std.mem.Allocator) Self {
         return .{
             .allocator = allocator,
-            .windows = .{ .items = &.{}, .capacity = 0 },
-            .system_trays = .{ .items = &.{}, .capacity = 0 },
+            .windows = .empty,
+            .system_trays = .empty,
             .bridge = null,
             .notifications = null,
         };

--- a/pantry.jsonc
+++ b/pantry.jsonc
@@ -7,6 +7,6 @@
     "bun.sh": "1.3.14",
     // Pinned exactly — `^0.17.0-dev` floats on Zig's dev channel and swaps the
     // compiler out from under a build. Keep in step with deps.yaml.
-    "ziglang.org": "0.17.0-dev.1509_bb296ab9b"
+    "ziglang.org": "0.17.0-dev.1963_e00c6c439"
   }
 }

--- a/pantry.lock
+++ b/pantry.lock
@@ -13,7 +13,7 @@
       },
       "system": {
         "bun.sh": "1.3.14",
-        "ziglang.org": "0.17.0-dev.1509_bb296ab9b"
+        "ziglang.org": "0.17.0-dev.1963_e00c6c439"
       }
     },
     "benchmarks": {
@@ -418,11 +418,11 @@
         "typescript"
       ]
     },
-    "ziglang.org@0.17.0-dev.1509_bb296ab9b": {
+    "ziglang.org@0.17.0-dev.1963_e00c6c439": {
       "name": "ziglang.org",
-      "version": "0.17.0-dev.1509_bb296ab9b",
+      "version": "0.17.0-dev.1963_e00c6c439",
       "source": "pantry",
-      "resolved": "registry:ziglang.org@0.17.0-dev.1509_bb296ab9b"
+      "resolved": "registry:ziglang.org@0.17.0-dev.1963_e00c6c439"
     }
   }
 }


### PR DESCRIPTION
`integration` has been red on `main` since this morning, on commits that changed no dependency file.

| commit | integration |
|---|---|
| `69e01f5` (v0.0.87, 00:37) | pass |
| `b693fb0` (#102, 12:23) | **fail** |
| `14fe431` (#101, 12:38) | **fail** |

`git diff 69e01f5..b693fb0 -- '*package.json' '*bun.lock*' '*bunfig.toml'` is empty. Nothing in the repo changed.

## The wrong diagnosis, and what disproved it

My first commit here assumed the cause was `pantry-pm/pantry/packages/action@main` — a floating ref that moved from `235036fa` (green) to `88dd705e` (red) — and pinned it. **That did not fix it.** The run is worth reading: the pin took effect, the log shows `Download action repository 'pantry-pm/pantry@235036fa…'`, and `integration` failed identically.

Pinning the action pins the *installer*, not what it installs. The same run shows it fetching:

```
+ typescript@7.1.0-dev.20260708.3
```

resolved fresh at runtime. That dev build cannot resolve its own platform binary:

```
Error: Unable to resolve @typescript/typescript-linux-x64.
    at getExePath (.../pantry/typescript/lib/getExePath.js:53:19)
```

No pin of the action would have changed that.

## The actual defect

craft builds with whatever `tsc` is first on PATH.

`packages/typescript`'s `build:types` ran `bun run tsc`. Locally that finds the repo's own `typescript@7.0.2`, because nothing shadows `node_modules/.bin`. In CI the pantry action installs into `<repo>/pantry` and puts it ahead on PATH, so the identical script silently ran a **different compiler** — a dev build the repo never declared.

That also explains why exactly one job went red: `integration` is the only job that runs `bun run build` in `packages/typescript`, and `build` → `build:types` is the only script that reaches `tsc` at all. `typescript-sdk` runs `typecheck` and `bun test`; `lint` runs pickier. A toolchain break surfaced in one job and looked like a code problem.

## The fix

`bunx --bun tsc`, which resolves the local one in both places — and is the form CLAUDE.md already prescribes for pickier, so the two agree now.

Verified locally: `bun run build` in `packages/typescript` completes and emits both `dist/index.d.ts` and `dist/index.d.cts`.

## The pin stays

It did not fix this, and the commit that added it claimed it would. But a third-party action referenced as `@main` is worth pinning for its own sake, and `release.yml` resolving a different action on every tag is the version of that risk that costs the most to discover. All 15 references are pinned; the Apple signing gate in `release.yml` is untouched — the only lines changed there are three `uses:` refs.

Unblocks #103.
