### PR TITLE
fix(ios): answer the shapes the spec answers, now that a bare false survives

### DIFF
--- a/packages/ios/templates/CraftApp.swift
+++ b/packages/ios/templates/CraftApp.swift
@@ -1093,11 +1093,11 @@ struct CraftWebView: UIViewRepresentable {
             // MARK: - Siri Shortcuts
             case "registerSiriShortcut":
                 if let phrase = body["phrase"] as? String,
-                   let action = body["action"] as? String {
+                   let action = body["shortcutAction"] as? String {
                     registerSiriShortcut(phrase: phrase, action: action, callbackId: callbackId)
                 }
             case "removeSiriShortcut":
-                if let action = body["action"] as? String {
+                if let action = body["shortcutAction"] as? String {
                     removeSiriShortcut(action: action, callbackId: callbackId)
                 }
 
@@ -2194,7 +2194,15 @@ struct CraftWebView: UIViewRepresentable {
                     register: function(phrase, action) {
                         var self = window.craft;
                         var id = 'cb_' + (++self._callbackId);
-                        window.webkit.messageHandlers.craft.postMessage({action: 'registerSiriShortcut', phrase: phrase, action: action, callbackId: id});
+                        // `shortcutAction`, not `action`. This object had two
+                        // keys called `action` — the message's own, and the
+                        // shortcut's — and the later one wins, so every call
+                        // arrived labelled with the shortcut's identifier
+                        // instead of 'registerSiriShortcut'. No switch arm
+                        // matched, nothing answered, and these wrappers park in
+                        // `_callbacks` with no timeout: the promise never
+                        // settled at all.
+                        window.webkit.messageHandlers.craft.postMessage({action: 'registerSiriShortcut', phrase: phrase, shortcutAction: action, callbackId: id});
                         return new Promise(function(resolve, reject) {
                             self._callbacks[id] = {resolve: resolve, reject: reject};
                         });
@@ -2202,7 +2210,8 @@ struct CraftWebView: UIViewRepresentable {
                     remove: function(action) {
                         var self = window.craft;
                         var id = 'cb_' + (++self._callbackId);
-                        window.webkit.messageHandlers.craft.postMessage({action: 'removeSiriShortcut', action: action, callbackId: id});
+                        // The same duplicate key as `register` above.
+                        window.webkit.messageHandlers.craft.postMessage({action: 'removeSiriShortcut', shortcutAction: action, callbackId: id});
                         return new Promise(function(resolve, reject) {
                             self._callbacks[id] = {resolve: resolve, reject: reject};
                         });

--- a/packages/zig/src/bridge_mobile_display.zig
+++ b/packages/zig/src/bridge_mobile_display.zig
@@ -105,12 +105,18 @@ pub const DisplayBridge = struct {
         }
     }
 
-    /// `{"count":N}` in, `{"count":<what UIKit now reports>}` out.
+    /// `{"count":N}` in, bare `true` out — what the spec resolves.
     ///
-    /// The reply is an object, not the bare `true` Swift resolves:
-    /// `craft-bridge.js` settles with `payload || {}`, so any falsy scalar
-    /// arrives at the page as `{}` and carries nothing. An object also lets the
-    /// value be checked, which a `true` never could.
+    /// This answered `{"count":<observed>}` until now, to work around
+    /// `craft-bridge.js` settling with `payload || {}`: a falsy scalar reached
+    /// the page as `{}` and carried nothing. That is fixed at its source
+    /// (`_orEmpty`), so the wrapper is gone and pages reading `=== true` work
+    /// again.
+    ///
+    /// The observed count goes to the log rather than the page. It was the one
+    /// thing the object shape bought, and the spec never offered it — a page
+    /// that wants the badge back has no API for it in either implementation,
+    /// so inventing one here would be a second divergence rather than a fix.
     fn setBadge(self: *Self, data: []const u8) !void {
         const requested = try badgeCountFrom(self.allocator, data);
         try self.replyBadge(A.set_badge, try applyBadge(requested));
@@ -125,11 +131,15 @@ pub const DisplayBridge = struct {
     }
 
     fn replyBadge(self: *Self, action: []const u8, observed: i64) !void {
-        var buf: [48]u8 = undefined;
-        bridge_error.sendResultToJS(self.allocator, action, try renderBadgeReply(&buf, observed));
+        std.log.info("{s}: badge is now {d}", .{ action, observed });
+        bridge_error.sendResultToJS(self.allocator, action, badge_applied);
     }
 
-    /// `{"enabled":<bool>}` in, `{"enabled":<what UIKit now reports>}` out.
+    /// `{"enabled":<bool>}` in, the bare observed boolean out.
+    ///
+    /// The spec resolves the `enabled` the page sent; this resolves what UIKit
+    /// reports, which is the same value whenever the write took. Bare rather
+    /// than `{"enabled":…}` for the reason recorded on `replyBadge`.
     ///
     /// Swift also stores `isKeepingAwake`, which nothing in the template ever
     /// reads. It is not ported: a variable with no reader cannot be wrong, and
@@ -140,11 +150,10 @@ pub const DisplayBridge = struct {
         const requested = try keepAwakeFrom(self.allocator, data);
         const observed = try applyKeepAwake(requested);
 
-        var buf: [32]u8 = undefined;
         bridge_error.sendResultToJS(
             self.allocator,
             A.set_keep_awake,
-            try renderKeepAwakeReply(&buf, observed),
+            if (observed) "true" else "false",
         );
     }
 
@@ -185,13 +194,8 @@ pub const DisplayBridge = struct {
 /// Split out because a test that re-typed the format string would pass no
 /// matter what the handler sent — it would be asserting that `std.fmt` works.
 /// These are the strings the page actually receives.
-fn renderBadgeReply(buf: []u8, observed: i64) ![]const u8 {
-    return std.fmt.bufPrint(buf, "{{\"count\":{d}}}", .{observed});
-}
-
-fn renderKeepAwakeReply(buf: []u8, observed: bool) ![]const u8 {
-    return std.fmt.bufPrint(buf, "{{\"enabled\":{}}}", .{observed});
-}
+/// What `setBadge` and `clearBadge` resolve. A bare `true`, matching the spec.
+const badge_applied = "true";
 
 // =============================================================================
 // Payload parsing
@@ -630,27 +634,25 @@ test "the orientation actions refuse, and say which kind of refusal it is" {
     );
 }
 
-test "replies are objects carrying a value, not bare scalars" {
-    // `craft-bridge.js` settles with `payload || {}`. A bare `false` — which
-    // `setKeepAwake(false)` would resolve, following Swift — arrives at the
-    // page as `{}` and loses the answer entirely.
+test "replies are the bare scalars the spec resolves" {
+    // These were objects — `{"count":N}` and `{"enabled":<bool>}` — to work
+    // around `craft-bridge.js` settling with `payload || {}`, which turned a
+    // bare `false` into a truthy `{}`. That is fixed at its source, so the
+    // wrapper is gone and the shapes match the spec again: a page doing
+    // `(await craft.setKeepAwake(false)) === false` gets `false`, and one doing
+    // `(await craft.clearBadge()) === true` gets `true`.
     //
-    // These call the same renderers the handlers do, so changing a key name or
-    // dropping the object wrapper fails here instead of reading as coverage.
-    var buf: [48]u8 = undefined;
+    // Pinned as the literal bytes the handlers send, so re-wrapping either
+    // reply fails here rather than reading as coverage.
+    try testing.expectEqualStrings("true", badge_applied);
 
-    try testing.expectEqualStrings("{\"count\":7}", try renderBadgeReply(&buf, 7));
-    try testing.expectEqualStrings("{\"count\":0}", try renderBadgeReply(&buf, 0));
-    try testing.expectEqualStrings("{\"enabled\":false}", try renderKeepAwakeReply(&buf, false));
-    try testing.expectEqualStrings("{\"enabled\":true}", try renderKeepAwakeReply(&buf, true));
-
-    // The stack buffers the handlers hand these are 48 and 32 bytes; the widest
-    // reply either can produce has to fit, or a legitimate count turns into a
-    // `NoSpaceLeft` the page reads as a native failure.
-    var badge_buf: [48]u8 = undefined;
-    try testing.expect((try renderBadgeReply(&badge_buf, std.math.minInt(i64))).len <= badge_buf.len);
-    var keep_buf: [32]u8 = undefined;
-    try testing.expect((try renderKeepAwakeReply(&keep_buf, false)).len <= keep_buf.len);
+    // Parsed, not just compared, so a literal that is not valid JSON — `True`,
+    // or a stray quote — cannot pass.
+    for ([_][]const u8{ badge_applied, "true", "false" }) |json| {
+        const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+        defer parsed.deinit();
+        try testing.expect(parsed.value == .bool);
+    }
 }
 
 test "UIKit work is refused off Darwin rather than attempted" {

--- a/packages/zig/src/bridge_mobile_display.zig
+++ b/packages/zig/src/bridge_mobile_display.zig
@@ -3,8 +3,12 @@ const builtin = @import("builtin");
 const capabilities = @import("capabilities.zig");
 const bridge_error = @import("bridge_error.zig");
 const objc_runtime = @import("objc_runtime.zig");
+const ios_async = @import("ios_async.zig");
+const compat_mutex = @import("compat_mutex.zig");
 
 const objc = objc_runtime.objc;
+const Id = objc.id;
+const is_darwin = builtin.target.os.tag.isDarwin();
 
 /// The `mobile` display group: the app icon's badge, the idle timer, and the
 /// two orientation actions.
@@ -44,14 +48,16 @@ const objc = objc_runtime.objc;
 /// which WebKit delivers on the main thread. The hop is redundant, and there is
 /// no dispatch-block machinery in this repo to reproduce it with.
 ///
-/// **No badge authorization.** Swift calls
-/// `requestAuthorizationWithOptions:` and rejects with "Badge permission
-/// denied". Reporting that from Zig needs a *capturing* block — every block in
-/// this repo is static and non-capturing — so it is not attempted here. The
-/// consequence is stated rather than hidden: Zig sets the number and proves
-/// UIKit stored it, which is **not** proof that the springboard draws it. An
-/// unauthorized app gets `{"count":N}` and an invisible badge, and will never
-/// see "Badge permission denied" or the first-run prompt Swift triggers.
+/// **Badge authorization, as the spec does it.** `setBadge` and `clearBadge`
+/// call `requestAuthorizationWithOptions:` first and reject with
+/// `PERMISSION_DENIED` when iOS says no — the spec's "Badge permission denied".
+/// This used to be skipped with the note that it needed a *capturing* block,
+/// which no block in the repo was. That stopped being true when
+/// `bridge_mobile_auth.zig` shipped per-slot global blocks whose slot index is
+/// baked in at comptime; the same shape is used here. Without it Zig set the
+/// number, proved UIKit stored it, and answered `true` for a badge an
+/// unauthorised app never draws — a fabricated success, and the one this file
+/// was still producing after every other module had stopped.
 pub const A = struct {
     pub const set_badge = "setBadge";
     pub const clear_badge = "clearBadge";
@@ -119,7 +125,7 @@ pub const DisplayBridge = struct {
     /// so inventing one here would be a second divergence rather than a fix.
     fn setBadge(self: *Self, data: []const u8) !void {
         const requested = try badgeCountFrom(self.allocator, data);
-        try self.replyBadge(A.set_badge, try applyBadge(requested));
+        try requestBadgeAuthorization(self.allocator, A.set_badge, requested);
     }
 
     /// The same path as `setBadge` with a fixed 0, so the two cannot drift.
@@ -127,12 +133,7 @@ pub const DisplayBridge = struct {
     /// `clearBadge` sends no payload at all, so there is nothing to parse:
     /// `payloadOf` hands this `{}` and the count is not the caller's to choose.
     fn clearBadge(self: *Self) !void {
-        try self.replyBadge(A.clear_badge, try applyBadge(0));
-    }
-
-    fn replyBadge(self: *Self, action: []const u8, observed: i64) !void {
-        std.log.info("{s}: badge is now {d}", .{ action, observed });
-        bridge_error.sendResultToJS(self.allocator, action, badge_applied);
+        try requestBadgeAuthorization(self.allocator, A.clear_badge, 0);
     }
 
     /// `{"enabled":<bool>}` in, the bare observed boolean out.
@@ -196,6 +197,212 @@ pub const DisplayBridge = struct {
 /// These are the strings the page actually receives.
 /// What `setBadge` and `clearBadge` resolve. A bare `true`, matching the spec.
 const badge_applied = "true";
+
+// =============================================================================
+// Badge authorization: ask, then set, then answer — on the threads the spec
+// uses for each.
+// =============================================================================
+
+/// `UNAuthorizationOptionBadge`. `UNUserNotificationCenter.h:23` in the
+/// iPhoneSimulator 26.5 SDK: `UNAuthorizationOptionBadge = (1 << 0)`. Pinned
+/// by a test that cites the same line, after a neighbouring module once
+/// guessed a `1 << 2` that named a different option entirely.
+const un_authorization_option_badge: c_ulong = 1 << 0;
+
+/// Ask iOS for badge authorization, and set the badge only once it says yes.
+///
+/// The spec's order exactly: `requestAuthorization(options: .badge)`, then
+/// `applicationIconBadgeNumber = count` inside `DispatchQueue.main.async` on
+/// grant, or reject on refusal. The count is validated *before* anything is
+/// asked, so a malformed call fails as it always did without ever triggering
+/// the first-run prompt.
+///
+/// When UserNotifications is not in the process — the `zig-slice` fixture
+/// links only UIKit, WebKit and Foundation — there is nothing to ask, and the
+/// badge is set directly as before, with a warning saying so. That path cannot
+/// be reached by a generated app: `project.yml` links UserNotifications
+/// unconditionally.
+fn requestBadgeAuthorization(allocator: std.mem.Allocator, action: []const u8, count: i64) !void {
+    if (!is_darwin) return error.UnsupportedPlatform;
+    _ = std.math.cast(c_long, count) orelse return bridge_error.BridgeError.InvalidParameter;
+
+    const UNCenterClass = objc.objc_getClass("UNUserNotificationCenter") orelse {
+        std.log.warn(
+            "{s}: UserNotifications is not in this process, so authorization cannot be " ++
+                "requested; setting the badge directly, which an unauthorised app will not draw",
+            .{action},
+        );
+        const observed = try applyBadge(count);
+        std.log.info("{s}: badge is now {d}", .{ action, observed });
+        bridge_error.sendResultToJS(allocator, action, badge_applied);
+        return;
+    };
+
+    // `currentNotificationCenter` RAISES — not nil — in a process with no
+    // bundle identifier, which is every test runner. Same guard as
+    // `bridge_mobile_permissions.zig` and `bridge_mobile_notifcancel.zig`.
+    try requireBundleIdentifier();
+
+    const sel_current = objc.sel_registerName("currentNotificationCenter") orelse
+        return error.SelectorNotFound;
+    const center = objc.msgSendId(UNCenterClass, sel_current) orelse return error.NoNotificationCenter;
+    const sel = objc.sel_registerName("requestAuthorizationWithOptions:completionHandler:") orelse
+        return error.SelectorNotFound;
+
+    const ticket = ios_async.acquire(action) orelse return poolFull(action);
+    errdefer ios_async.abandon(ticket);
+    publishPendingCall(ticket, action, count);
+
+    const Fn = *const fn (Id, objc.SEL, c_ulong, *anyopaque) callconv(.c) void;
+    const func: Fn = @ptrCast(&objc.objc_msgSend);
+    func(center, sel, un_authorization_option_badge, replyBlock(ticket));
+}
+
+fn requireBundleIdentifier() !void {
+    const NSBundle = objc.objc_getClass("NSBundle") orelse return error.ClassNotFound;
+    const sel_main = objc.sel_registerName("mainBundle") orelse return error.SelectorNotFound;
+    const bundle = objc.msgSendId(NSBundle, sel_main) orelse return error.NoBundleIdentifier;
+    const sel_ident = objc.sel_registerName("bundleIdentifier") orelse return error.SelectorNotFound;
+    if (objc.msgSendId(bundle, sel_ident) == null) return error.NoBundleIdentifier;
+}
+
+fn poolFull(action: []const u8) bridge_error.BridgeError {
+    std.log.warn("{s} refused: all {d} async slots in flight", .{ action, ios_async.max_in_flight });
+    return bridge_error.BridgeError.InvalidParameter;
+}
+
+/// What a slot's block will answer. The ticket is stored, not rebuilt from the
+/// index: a ticket carries a generation, and inventing one at reply time would
+/// defeat the check that stops a late completion answering the slot's next
+/// occupant. `action` is one of the two static names in `A`, never allocated.
+const PendingBadge = struct {
+    ticket: ios_async.Ticket,
+    action: []const u8,
+    count: i64,
+};
+
+var pending_badges: [ios_async.max_in_flight]?PendingBadge = @splat(null);
+var pending_mutex: compat_mutex.Mutex = .{};
+
+fn publishPendingCall(ticket: ios_async.Ticket, action: []const u8, count: i64) void {
+    pending_mutex.lock();
+    defer pending_mutex.unlock();
+    pending_badges[ticket.index] = .{ .ticket = ticket, .action = action, .count = count };
+}
+
+/// Read and clear. Clearing is what makes a second fire a no-op instead of a
+/// second reply.
+fn takePendingCall(index: u5) ?PendingBadge {
+    pending_mutex.lock();
+    defer pending_mutex.unlock();
+    const call = pending_badges[index];
+    pending_badges[index] = null;
+    return call;
+}
+
+const BlockDescriptor = extern struct {
+    reserved: c_ulong = 0,
+    size: c_ulong,
+};
+
+/// `void (^)(BOOL, NSError *)` — `requestAuthorizationWithOptions:`'s
+/// completion. Not `ios_async.boolErrorBlock`: that one answers the page
+/// `"granted"`/`"denied"`, and this one has a badge to set in between.
+const ReplyBlock = extern struct {
+    isa: ?*anyopaque,
+    flags: c_int,
+    reserved: c_int = 0,
+    invoke: *const anyopaque,
+    descriptor: *const BlockDescriptor,
+};
+
+/// 1 << 28. A global block is never copied, so it can be handed to an API that
+/// escapes it with no heap copy and no descriptor lifetime.
+const BLOCK_IS_GLOBAL: c_int = 1 << 28;
+const reply_block_descriptor = BlockDescriptor{ .size = @sizeOf(ReplyBlock) };
+
+extern var _NSConcreteGlobalBlock: anyopaque;
+
+fn makeReplyInvoke(comptime index: u5) *const anyopaque {
+    const S = struct {
+        fn invoke(_: *const ReplyBlock, granted: bool, err: Id) callconv(.c) void {
+            authorizationFired(index, granted, err);
+        }
+    };
+    return @ptrCast(&S.invoke);
+}
+
+fn makeReplyBlocks() [ios_async.max_in_flight]ReplyBlock {
+    var out: [ios_async.max_in_flight]ReplyBlock = undefined;
+    for (&out, 0..) |*b, i| {
+        b.* = .{
+            .isa = &_NSConcreteGlobalBlock,
+            .flags = BLOCK_IS_GLOBAL,
+            .invoke = makeReplyInvoke(@intCast(i)),
+            .descriptor = &reply_block_descriptor,
+        };
+    }
+    return out;
+}
+
+var reply_blocks: [ios_async.max_in_flight]ReplyBlock =
+    if (is_darwin) makeReplyBlocks() else undefined;
+
+fn replyBlock(ticket: ios_async.Ticket) *anyopaque {
+    return @ptrCast(&reply_blocks[ticket.index]);
+}
+
+extern "c" fn dispatch_async_f(
+    queue: *anyopaque,
+    context: ?*anyopaque,
+    work: *const fn (?*anyopaque) callconv(.c) void,
+) void;
+extern var _dispatch_main_q: anyopaque;
+
+/// Runs on whatever queue UserNotifications chose.
+///
+/// A refusal is answered from here — `ios_async` hops to the main queue
+/// itself. A grant is not: the badge has to be *set* on the main thread
+/// before the answer is true, which is what Swift's `DispatchQueue.main.async`
+/// is for in this position. So the grant path hops first and answers after.
+/// The pending entry survives the hop and is taken on the far side, which is
+/// what makes a double fire harmless: the second hop finds nothing.
+fn authorizationFired(index: u5, granted: bool, err: Id) void {
+    if (!is_darwin) return;
+
+    if (!granted) {
+        const call = takePendingCall(index) orelse {
+            std.log.warn("badge authorization fired for slot {d} with no call recorded; ignored", .{index});
+            return;
+        };
+        _ = err;
+        std.log.info("{s}: badge authorization denied", .{call.action});
+        ios_async.deliverErrorCode(call.ticket, bridge_error.BridgeError.PermissionDenied);
+        return;
+    }
+
+    // `index + 1`, never a null context: `ios_async` passes its slot the same
+    // way and for the same reason.
+    dispatch_async_f(&_dispatch_main_q, @ptrFromInt(@as(usize, index) + 1), applyBadgeOnMain);
+}
+
+/// Main thread. Authorized, so set the badge and say so.
+fn applyBadgeOnMain(context: ?*anyopaque) callconv(.c) void {
+    if (!is_darwin) return;
+    const index: u5 = @intCast(@intFromPtr(context) - 1);
+    const call = takePendingCall(index) orelse {
+        std.log.warn("badge grant reached the main queue for slot {d} with no call recorded; ignored", .{index});
+        return;
+    };
+
+    const observed = applyBadge(call.count) catch |e| {
+        std.log.warn("{s}: authorised, but the badge could not be set: {s}", .{ call.action, @errorName(e) });
+        ios_async.deliverErrorCode(call.ticket, bridge_error.BridgeError.NativeCallFailed);
+        return;
+    };
+    std.log.info("{s}: badge is now {d}", .{ call.action, observed });
+    ios_async.deliverJson(call.ticket, badge_applied);
+}
 
 // =============================================================================
 // Payload parsing
@@ -659,4 +866,63 @@ test "UIKit work is refused off Darwin rather than attempted" {
     if (builtin.target.os.tag.isDarwin()) return error.SkipZigTest;
     try testing.expectError(error.UnsupportedPlatform, applyBadge(1));
     try testing.expectError(error.UnsupportedPlatform, applyKeepAwake(true));
+}
+
+test "the badge authorization option is the header's bit, not a guess" {
+    // `UNUserNotificationCenter.h:23`: `UNAuthorizationOptionBadge = (1 << 0)`.
+    // A neighbouring module once pinned a guessed `1 << 2` for a HealthKit
+    // option and shipped a crash; this cites the line instead.
+    try testing.expectEqual(@as(c_ulong, 1), un_authorization_option_badge);
+    try testing.expect(un_authorization_option_badge != 1 << 1); // Sound
+    try testing.expect(un_authorization_option_badge != 1 << 2); // Alert
+}
+
+test "each badge slot's reply block is global and has its own invoke" {
+    if (!is_darwin) return error.SkipZigTest;
+    for (&reply_blocks) |*b| {
+        try testing.expectEqual(&_NSConcreteGlobalBlock, b.isa);
+        try testing.expectEqual(BLOCK_IS_GLOBAL, b.flags);
+        try testing.expectEqual(@sizeOf(ReplyBlock), @as(usize, @intCast(b.descriptor.size)));
+    }
+    try testing.expect(reply_blocks[0].invoke != reply_blocks[1].invoke);
+}
+
+test "a pending badge call is taken exactly once" {
+    // The property a double-fired completion relies on: the second `take`
+    // finds nothing, so it replies to nobody instead of answering twice.
+    const ticket = ios_async.Ticket{ .index = 3, .generation = 42 };
+    publishPendingCall(ticket, A.set_badge, 7);
+    const first = takePendingCall(3) orelse return error.TestUnexpectedResult;
+    try testing.expectEqual(@as(i64, 7), first.count);
+    try testing.expectEqualStrings(A.set_badge, first.action);
+    try testing.expectEqual(@as(u32, 42), first.ticket.generation);
+    try testing.expect(takePendingCall(3) == null);
+}
+
+test "a bad count is refused before any authorization is requested" {
+    // Ordering, not just parsing: the parse failure has to come first, on
+    // every platform, so a malformed call never triggers the first-run prompt.
+    var bridge = DisplayBridge.init(testing.allocator);
+    defer bridge.deinit();
+    try testing.expectError(
+        bridge_error.BridgeError.InvalidParameter,
+        bridge.handleMessage(A.set_badge, "{\"count\":\"three\"}"),
+    );
+}
+
+test "setBadge is refused on the host rather than resolved without asking" {
+    // There is no UIKit and no bundle identifier in a test binary, so the
+    // only correct outcome is a refusal. Which refusal depends on what the
+    // host has loaded — UserNotifications absent takes one path, present
+    // takes another — so this pins the shape (an error, never a reply) and
+    // not the name. A resolve here would be the exact fabricated success this
+    // change exists to remove.
+    var bridge = DisplayBridge.init(testing.allocator);
+    defer bridge.deinit();
+    if (bridge.handleMessage(A.set_badge, "{\"count\":3}")) |_| {
+        return error.TestUnexpectedResult;
+    } else |_| {}
+    if (bridge.handleMessage(A.clear_badge, "{}")) |_| {
+        return error.TestUnexpectedResult;
+    } else |_| {}
 }

--- a/packages/zig/src/bridge_mobile_health.zig
+++ b/packages/zig/src/bridge_mobile_health.zig
@@ -1085,11 +1085,20 @@ fn routeInserted(index: u5, success: bool, err: Id) void {
     const chain = call.workout orelse return;
 
     if (!success) {
+        // Rejects, as the spec does. Resolving here reported a workout with
+        // `"routeId":""`, which is the shape a *successful* finish with a nil
+        // route produces — so a page could not tell "the route saved and had no
+        // id" from "the route did not save at all", and would file the workout
+        // as complete with its locations silently missing.
+        //
+        // The id is not lost, it is logged: a fabricated success costs more
+        // than a rejection, and this module refuses one everywhere else.
         logNSError(A.save_health_workout, err);
-        // Swift rejects. The workout is saved regardless, so the id is
-        // reported rather than lost — losing it would leave a page unable to
-        // reference a workout that exists.
-        replyWithWorkout(call.ticket, chain, null);
+        std.log.info(
+            "saveHealthWorkout: route insert failed; the workout itself was saved as {s}",
+            .{uuidStringOf(chain.workout) orelse "<no uuid>"},
+        );
+        ios_async.deliverErrorCode(call.ticket, bridge_error.BridgeError.NativeCallFailed);
         chain.deinit();
         return;
     }
@@ -1112,8 +1121,15 @@ fn routeFinished(index: u5, route: Id, err: Id) void {
     defer chain.deinit();
 
     if (err != null) {
+        // Same reasoning as `routeInserted`: the spec rejects on a finish
+        // error, and resolving would be indistinguishable from the nil-route
+        // success below.
         logNSError(A.save_health_workout, err);
-        replyWithWorkout(call.ticket, chain, null);
+        std.log.info(
+            "saveHealthWorkout: route finish failed; the workout itself was saved as {s}",
+            .{uuidStringOf(chain.workout) orelse "<no uuid>"},
+        );
+        ios_async.deliverErrorCode(call.ticket, bridge_error.BridgeError.NativeCallFailed);
         return;
     }
     replyWithWorkout(call.ticket, chain, route);
@@ -1124,6 +1140,10 @@ fn routeFinished(index: u5, route: Id, err: Id) void {
 /// Swift emits the second shape only when a route was finished, and its
 /// `routeId` is `route?.uuid.uuidString ?? ""` — so a finished-but-nil route
 /// carries an empty string rather than a missing key.
+///
+/// Only reached on success now. The two failure stages reject instead, because
+/// an empty `routeId` here already means "finished, no id" and cannot also mean
+/// "did not finish".
 fn replyWithWorkout(ticket: ios_async.Ticket, chain: WorkoutChain, route: Id) void {
     const allocator = std.heap.c_allocator;
 

--- a/packages/zig/src/bridge_mobile_siri.zig
+++ b/packages/zig/src/bridge_mobile_siri.zig
@@ -295,7 +295,10 @@ fn readFields(
         else => return BridgeError.InvalidJSON,
     };
 
-    const action = try requiredString(allocator, object, "action");
+    // `shortcutAction`, not `action`: the envelope's own `action` names the
+    // bridge action, and the page used to send both under that one key. See
+    // the wrapper in `CraftApp.swift`.
+    const action = try requiredString(allocator, object, "shortcutAction");
     errdefer allocator.free(action);
 
     const phrase = if (want.phrase) try requiredString(allocator, object, "phrase") else null;
@@ -459,7 +462,7 @@ test "both fields are required for a registration, and neither hangs" {
     // missing phrase replies nothing at all.
     var fields = try readFields(
         testing.allocator,
-        "{\"action\":\"openVault\",\"phrase\":\"open my vault\"}",
+        "{\"shortcutAction\":\"openVault\",\"phrase\":\"open my vault\"}",
         .{ .phrase = true },
     );
     defer fields.deinit(testing.allocator);
@@ -468,7 +471,7 @@ test "both fields are required for a registration, and neither hangs" {
 
     try testing.expectError(BridgeError.MissingData, readFields(
         testing.allocator,
-        "{\"action\":\"openVault\"}",
+        "{\"shortcutAction\":\"openVault\"}",
         .{ .phrase = true },
     ));
     try testing.expectError(BridgeError.MissingData, readFields(
@@ -478,18 +481,18 @@ test "both fields are required for a registration, and neither hangs" {
     ));
     try testing.expectError(BridgeError.InvalidParameter, readFields(
         testing.allocator,
-        "{\"action\":\"\",\"phrase\":\"p\"}",
+        "{\"shortcutAction\":\"\",\"phrase\":\"p\"}",
         .{ .phrase = true },
     ));
     try testing.expectError(BridgeError.InvalidParameter, readFields(
         testing.allocator,
-        "{\"action\":3,\"phrase\":\"p\"}",
+        "{\"shortcutAction\":3,\"phrase\":\"p\"}",
         .{ .phrase = true },
     ));
 }
 
 test "a removal needs only the action" {
-    var fields = try readFields(testing.allocator, "{\"action\":\"openVault\"}", .{ .phrase = false });
+    var fields = try readFields(testing.allocator, "{\"shortcutAction\":\"openVault\"}", .{ .phrase = false });
     defer fields.deinit(testing.allocator);
     try testing.expectEqualStrings("openVault", fields.action);
     try testing.expect(fields.phrase == null);

--- a/packages/zig/src/bridge_mobile_system.zig
+++ b/packages/zig/src/bridge_mobile_system.zig
@@ -63,16 +63,23 @@ pub const capability_actions = [_]capabilities.ActionDecl{
 ///
 /// Named rather than written inline at each `sendResultToJS`, so the test that
 /// pins their shape reads the same bytes the handlers send instead of a copy
-/// of them that can drift. Every one is a JSON *object* carrying a boolean:
-/// `craft-bridge.js` resolves with `payload || {}`, so a bare `false` and an
-/// empty reply are the same value to the page — a fabricated success wearing
-/// the shape of an honest one.
+/// of them that can drift.
+///
+/// Bare booleans, because that is what the spec resolves — `openURL` and
+/// `requestReview` answer `true`, and `share` answers the `completed` flag
+/// from the activity handler. These were objects until now, and the reason is
+/// worth recording: `craft-bridge.js` settled with `payload || {}`, which
+/// turns a truthful `false` into a truthy `{}`, so a bare boolean could not
+/// carry a negative answer. Wrapping it was the workaround. The bug is fixed
+/// at its source (`_orEmpty`), so the wrapper is gone and a cancelled share
+/// reads as `false` again instead of `{completed:false}`, which every page
+/// written against the spec reads as success.
 const R = struct {
-    const opened = "{\"opened\":true}";
-    const not_opened = "{\"opened\":false}";
-    const completed = "{\"completed\":true}";
-    const not_completed = "{\"completed\":false}";
-    const requested = "{\"requested\":true}";
+    const opened = "true";
+    const not_opened = "false";
+    const completed = "true";
+    const not_completed = "false";
+    const requested = "true";
 
     const all = [_][]const u8{ opened, not_opened, completed, not_completed, requested };
 };
@@ -1031,19 +1038,26 @@ test "every reply is a JSON object naming what happened, never a bare boolean" {
     // `craft-bridge.js` resolves with `payload || {}`, so a bare `false` and an
     // empty reply are the same value to the page.
     for (R.all) |json| {
-        const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+        const parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{
+            // A bare `true` is a JSON fragment, not a document. The spec
+            // serialises with `.fragmentsAllowed` for the same reason.
+            .allocate = .alloc_if_needed,
+        });
         defer parsed.deinit();
-        try testing.expect(parsed.value == .object);
-        try testing.expectEqual(@as(usize, 1), parsed.value.object.count());
 
-        // And the member is a boolean the caller can branch on, not a string or
-        // a number that reads as truthy whatever it says.
-        var it = parsed.value.object.iterator();
-        try testing.expect(it.next().?.value_ptr.* == .bool);
+        // A boolean the caller can branch on — not a string, not a number, and
+        // not an object, which is what these were while `payload || {}` made a
+        // bare `false` unrepresentable.
+        try testing.expect(parsed.value == .bool);
     }
 
     // Non-vacuity: every assertion above is satisfied by an empty list.
     try testing.expectEqual(@as(usize, 5), R.all.len);
     try testing.expect(!std.mem.eql(u8, R.opened, R.not_opened));
     try testing.expect(!std.mem.eql(u8, R.completed, R.not_completed));
+
+    // The negative answers really are `false`, which is the whole point of the
+    // change: an object here read as success to every page that branched on it.
+    try testing.expectEqualStrings("false", R.not_opened);
+    try testing.expectEqualStrings("false", R.not_completed);
 }

--- a/packages/zig/src/bridge_mobile_vision.zig
+++ b/packages/zig/src/bridge_mobile_vision.zig
@@ -416,15 +416,33 @@ fn shapeResults(allocator: std.mem.Allocator, kind: Kind, request: Id) ![]u8 {
     const count = try arrayCount(results);
     const limit = if (kind == .classify) @min(count, max_classifications) else count;
 
+    // `written`, not `i`, decides the separator. A recognition observation with
+    // no candidate is skipped rather than emitted, exactly as the spec does, so
+    // the reply can be shorter than the observation list — and keying the comma
+    // off the loop index would then leave a leading or doubled one and hand the
+    // page invalid JSON.
+    var written: usize = 0;
     var i: usize = 0;
     while (i < limit) : (i += 1) {
         const observation = try arrayObjectAt(results, i);
-        if (i != 0) try out.append(allocator, ',');
+        const mark = out.items.len;
+        if (written != 0) try out.append(allocator, ',');
         switch (kind) {
             .classify => try appendClassification(allocator, &out, observation),
             .detect => try appendDetection(allocator, &out, observation),
-            .recognize => try appendRecognizedText(allocator, &out, observation),
+            // The one skippable case. Swift reads `topCandidates(1).first` and
+            // drops the observation when it is nil; rejecting the whole call
+            // instead loses every line that *did* recognise, which is the
+            // answer the page asked for.
+            .recognize => appendRecognizedText(allocator, &out, observation) catch |err| switch (err) {
+                error.NoCandidates => {
+                    out.shrinkRetainingCapacity(mark);
+                    continue;
+                },
+                else => return err,
+            },
         }
+        written += 1;
     }
 
     try out.append(allocator, ']');

--- a/packages/zig/src/js/craft-bridge.js
+++ b/packages/zig/src/js/craft-bridge.js
@@ -65,6 +65,15 @@
     }
   }
 
+  // `payload || {}` was wrong for every action whose answer is a bare boolean:
+  // it turned a truthful `false` into `{}`, which is truthy, so a page reading
+  // `if (await craft.share(...))` took the success branch on a cancelled share.
+  // Only genuinely absent payloads become `{}`; `false`, `0` and `""` are
+  // answers and survive.
+  function _orEmpty(payload) {
+    return payload === undefined || payload === null ? {} : payload
+  }
+
   // Native's answer to one call. `id` is the `i` we sent, echoed back; a reply
   // raised outside any dispatch has none and falls back to the action queue.
   window.__craftBridgeResult = function (action, payload, id) {
@@ -77,7 +86,7 @@
       // call's own, with nothing to indicate anything had gone wrong.
       if (!e) return
       _forget(e)
-      if (e.resolve) e.resolve(payload || {})
+      if (e.resolve) e.resolve(_orEmpty(payload))
       return
     }
 
@@ -87,7 +96,7 @@
     if (!q || q.length === 0) return
     const e = q[0]
     _forget(e)
-    if (e.resolve) e.resolve(payload || {})
+    if (e.resolve) e.resolve(_orEmpty(payload))
   }
 
   // Native calls this when an action fails.


### PR DESCRIPTION
An audit of all 33 mobile modules compared every `.live` action's reply against the Swift arm the seam (#103) now displaces: 80 actions, 61 observable differences, each confirmed by two independent refuters. Most are Zig being *stricter* — refusing embedded NULs, validating filenames, declining overlapping picker calls — and those stay. This PR is the ones where a page written against the spec gets a different answer.

## The root cause, first

`craft-bridge.js` settled with `payload || {}`, which turns a truthful `false` into a truthy `{}`. Five handlers wrapped their booleans in objects *specifically* to survive that, and said so in their comments:

> The reply is an object, not the bare `true` Swift resolves: `craft-bridge.js` settles with `payload || {}`, so any falsy scalar arrives at the page as `{}` and carries nothing.

So the workaround was load-bearing, and the shapes could not be fixed without fixing the bug underneath. `_orEmpty` now substitutes `{}` only for a genuinely absent payload; `false`, `0` and `""` reach the page intact.

## Then the five shapes

| action | was | now (= spec) |
|---|---|---|
| `openURL` | `{"opened":bool}` | `true` / `false` |
| `share` | `{"completed":bool}` | `true` / `false` |
| `requestReview` | `{"requested":true}` | `true` |
| `setBadge` / `clearBadge` | `{"count":N}` | `true` |
| `setKeepAwake` | `{"enabled":bool}` | `true` / `false` |

`share` is the one that mattered. It replied `{"completed":false}` when the user *dismissed* the sheet — and every page doing `if (await craft.share(...))` read that object as success.

## `registerSiriShortcut` and `removeSiriShortcut` never worked

Not a regression from the seam. A duplicate key in the page's own JS:

```js
postMessage({action: 'registerSiriShortcut', phrase: phrase, action: action, callbackId: id})
```

Two keys called `action`; the later one wins. Every call arrived labelled with the *shortcut's* identifier instead of the bridge action, no switch arm matched, nothing answered — and these two wrappers park in `_callbacks` with no timeout, so the promise never settled at all. The payload field is `shortcutAction` now, in the wrapper, the Swift arms and the Zig reader.

## Two behaviour regressions

- **`recognizeText`** rejected the whole call when any observation had no top candidate. The spec skips that observation, and this handler's *own doc comment* described the skip while the code did the opposite. It skips now; the separator is keyed off what was written rather than the loop index, so a skip cannot leave a doubled comma.
- **`saveHealthWorkout`** resolved `{"id":…,"routeId":""}` when a route stage *failed* — the same shape a successful finish with a nil route produces. A page could not tell "saved with no route id" from "the route did not save", and would file the workout as complete with its locations silently missing. Both stages reject now, as the spec does, and log the workout id rather than fabricating a success around it.

## And the one that was going to be a separate PR

`setBadge` / `clearBadge` now request badge authorization first and reject with `PERMISSION_DENIED` when iOS refuses — the spec's "Badge permission denied". It was skipped originally with a note that it needed a *capturing* block; `bridge_mobile_auth.zig`'s per-slot global blocks (slot index baked in at comptime) are exactly the shape that makes it unnecessary, so it is a second commit here rather than a footnote. Without it Zig answered `true` for a badge an unauthorised app never draws.

## Verification

`zig build test`: 150/150 steps, 2482/2494 passed, 12 skipped, 0 failed (the second commit adds the badge-authorization tests), on Zig `0.17.0-dev.1963`.

