### PR TITLE
chore(ci): pin zig-js at #876, the first revision that builds on Zig 1963

### DIFF
--- a/.github/actions/first-party-zig-deps/pins.env
+++ b/.github/actions/first-party-zig-deps/pins.env
@@ -16,8 +16,14 @@
 # Local development is unaffected: developers build against their own sibling
 # checkouts, and this file is read only by the CI action next to it.
 
-# fix(lexer): size the SIMD identifier scan by lane count, not byte size (#625)
-zig_js=eba3f7cfb8b32d6d84099b10f0e063fa0e0c53c7
+# fix(compat): stop describing ArrayList's layout, and read it instead (#876)
+#
+# The first pin this file needed for a reason other than "a push to main
+# broke us": craft moved to Zig 0.17.0-dev.1963, which appends
+# `pointer_stability` to ArrayList, and every zig-js revision before #876
+# fails to compile against it. #876 is the fix, verified on both 1963 and
+# the 1818 zig-js's own CI pins.
+zig_js=f9c2653e06568cd5bece232a45157e3f252f0a4c
 
 # fix(parser): make class-set construction failure-atomic (#20)
 zig_regex=cfb24da9f1dd9e759cefec7d6e1dfa094998e9d8


### PR DESCRIPTION
`main` has been red on `zig-core` since #104 moved craft to `0.17.0-dev.1963`. Every failure was inside zig-js at the old pin — that toolchain appends `pointer_stability` to `ArrayList`, and zig-js had 27 struct literals plus one JIT layout assertion that named the old shape.

[zig-utils/zig-js#876](https://github.com/zig-utils/zig-js/pull/876) fixes it upstream — 53/53 checks on the 1818 their CI pins, and 2285 passed / 0 failed on 1963. This is the one-line pin.

Verified locally: craft's full `zig build` and `zig build test` with the JS runtime on, against this zig-js content, on 1963 — 153/153 steps, 2519 passed, 0 failed.

Unblocks `integration`, which has been `skipping` behind `zig-core`.