### PR TITLE
fix(ci): stop evaluating `pantry env`, which sometimes re-installs JS deps mid-job

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to Craft! This document provides gui
 
 ### Prerequisites
 
-- **Pantry-managed stable Zig**: run `eval "$(pantry env | sed -n '/^export /,$p')"`, then invoke `zig`
+- **Pantry-managed stable Zig**: run `eval "$(pantry env | sed -n '/^export /,$p')"`, then invoke `zig` (locally only — CI does not: the pantry action already puts `zig` on PATH, and `pantry env` runs a workspace setup that re-installs JS deps with its own `--linker`, rewriting `node_modules` mid-job)
 - **Bun**: Install from [bun.sh](https://bun.sh)
 
 #### Platform-specific Dependencies

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Build binary
         working-directory: packages/zig
         run: |
-          eval "$(pantry env | sed -n '/^export /,$p')" && zig build -Doptimize=ReleaseFast
+          zig build -Doptimize=ReleaseFast
           mkdir -p "$RUNNER_TEMP/bench"
           cp zig-out/bin/craft "$RUNNER_TEMP/bench/craft-head"
 

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Build release binary
         working-directory: packages/zig
         run: |
-          eval "$(pantry env | sed -n '/^export /,$p')" && zig build -Doptimize=ReleaseSafe
+          zig build -Doptimize=ReleaseSafe
 
       - name: Measure binary size
         id: size
@@ -123,7 +123,7 @@ jobs:
           git checkout origin/main -- packages/zig
 
           cd packages/zig
-          eval "$(pantry env | sed -n '/^export /,$p')" && zig build -Doptimize=ReleaseSafe
+          zig build -Doptimize=ReleaseSafe
 
           if [ -f "zig-out/bin/craft" ]; then
             BASELINE=$(wc -c < "zig-out/bin/craft" | tr -d ' ')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         uses: pantry-pm/pantry/packages/action@235036fa0f48bae99b2293df5a3dc35c809b1777 # pinned: last SHA whose bundled typescript resolves on linux-x64
 
       - name: Verify Zig installation
-        run: eval "$(pantry env | sed -n '/^export /,$p')" && zig version
+        run: zig version
 
       - name: Cache Zig artifacts
         uses: actions/cache@v5
@@ -58,14 +58,14 @@ jobs:
 
       - name: Build Zig core
         working-directory: packages/zig
-        run: eval "$(pantry env | sed -n '/^export /,$p')" && zig build
+        run: zig build
 
       - name: First-party Zig dependencies
         uses: ./.github/actions/first-party-zig-deps
 
       - name: Test Zig core
         working-directory: packages/zig
-        run: eval "$(pantry env | sed -n '/^export /,$p')" && zig build test
+        run: zig build test
 
       - name: Check binary size
         if: runner.os == 'Linux'
@@ -163,7 +163,7 @@ jobs:
 
       - name: Check Zig formatting
         working-directory: packages/zig
-        run: eval "$(pantry env | sed -n '/^export /,$p')" && zig fmt --check src/ build.zig
+        run: zig fmt --check src/ build.zig
 
       - name: Audit Zig C imports
         run: bun run verify:cimports
@@ -194,7 +194,7 @@ jobs:
 
       - name: Build Zig core
         working-directory: packages/zig
-        run: eval "$(pantry env | sed -n '/^export /,$p')" && zig build
+        run: zig build
 
       - name: Build TypeScript SDK
         working-directory: packages/typescript

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           # Build iOS simulator static libraries using dedicated build step
           # (not the default target which builds macOS executables)
-          eval "$(pantry env | sed -n '/^export /,$p')" && zig build build-ios-simulator -Doptimize=ReleaseSafe -Dmacos-sdk="$(xcrun --sdk iphonesimulator --show-sdk-path)"
+          zig build build-ios-simulator -Doptimize=ReleaseSafe -Dmacos-sdk="$(xcrun --sdk iphonesimulator --show-sdk-path)"
 
       - name: First-party Zig dependencies
         uses: ./.github/actions/first-party-zig-deps
@@ -85,7 +85,7 @@ jobs:
           # `zig build test` reports through its exit code. The old form piped
           # it to a file and grepped for "mobile"/"ios", which fails under
           # `set -e` whenever the run is clean and the file is therefore empty.
-          eval "$(pantry env | sed -n '/^export /,$p')" && zig build test
+          zig build test
 
       - name: Build iOS test app
         if: hashFiles('packages/ios/TestApp/TestApp.xcodeproj') != ''
@@ -176,7 +176,7 @@ jobs:
           # builds the desktop binaries — and since an android triple reports
           # os_tag == .linux, that links GTK3/WebKit2GTK against a sysroot that
           # does not exist for Android.
-          eval "$(pantry env | sed -n '/^export /,$p')" && zig build build-android -Doptimize=ReleaseSafe
+          zig build build-android -Doptimize=ReleaseSafe
 
       - name: First-party Zig dependencies
         uses: ./.github/actions/first-party-zig-deps
@@ -187,7 +187,7 @@ jobs:
           # `zig build test` reports through its exit code. The old form piped
           # it to a file and grepped for "mobile"/"android", which fails under
           # `set -e` whenever the run is clean and the file is therefore empty.
-          eval "$(pantry env | sed -n '/^export /,$p')" && zig build test
+          zig build test
 
       - name: Enable KVM
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
           mkdir -p zig-out/cross
 
           echo "::group::Cross-compile darwin-x64"
-          eval "$(pantry env | sed -n '/^export /,$p')" && zig build -Doptimize=ReleaseSafe -Dversion="$VERSION" -Dtarget="$X64_TARGET" -Dmacos-sdk="$SDK_PATH"
+          zig build -Doptimize=ReleaseSafe -Dversion="$VERSION" -Dtarget="$X64_TARGET" -Dmacos-sdk="$SDK_PATH"
           mkdir -p zig-out/cross/darwin-x64 && cp zig-out/bin/craft zig-out/cross/darwin-x64/craft
           echo "::endgroup::"
 
@@ -87,7 +87,7 @@ jobs:
           # cross-compilation mode, where it stops looking for the system SDK
           # on its own and every `-framework Cocoa` fails to resolve.
           rm -rf zig-out/bin
-          eval "$(pantry env | sed -n '/^export /,$p')" && zig build -Doptimize=ReleaseSafe -Dversion="$VERSION" -Dtarget="$ARM64_TARGET" -Dmacos-sdk="$SDK_PATH"
+          zig build -Doptimize=ReleaseSafe -Dversion="$VERSION" -Dtarget="$ARM64_TARGET" -Dmacos-sdk="$SDK_PATH"
 
       # AppKit decides how it draws a window's controls from the SDK recorded
       # in LC_BUILD_VERSION, so that it can restyle them without restyling
@@ -144,7 +144,6 @@ jobs:
             "x86_64-windows:windows-x64:craft.exe"; do
             IFS=: read -r zig_target dir_name bin_name <<< "$target_spec"
             echo "::group::Cross-compile $dir_name"
-            eval "$(pantry env | sed -n '/^export /,$p')"
             zig build -Doptimize=ReleaseSafe -Dversion="$VERSION" -Dtarget="$zig_target"
             mkdir -p "zig-out/cross/$dir_name" && cp "zig-out/bin/$bin_name" "zig-out/cross/$dir_name/$bin_name"
             echo "Built $dir_name"
@@ -157,7 +156,7 @@ jobs:
           # so craft-linux-x64.zip shipped a Windows PE binary alongside the
           # Linux one.
           rm -rf zig-out/bin
-          eval "$(pantry env | sed -n '/^export /,$p')" && zig build -Doptimize=ReleaseSafe -Dversion="$VERSION"
+          zig build -Doptimize=ReleaseSafe -Dversion="$VERSION"
 
       # ── macOS Code Signing & Notarization ──────────────────────────
       # The signing credentials live encrypted in `.env.production`, not as


### PR DESCRIPTION
`integration` failed on #106 at "Build TypeScript SDK" with `Cannot find package 'typescript'`, while `typescript-sdk` — same commit, same runner, same command, same shim — passed. The difference is one step earlier: `integration` runs `eval "$(pantry env …)" && zig build`, and in that run the log shows pantry running a **workspace setup** inside the eval — installing its own `typescript@7.1.0-dev` (not what the lockfile names), then its own `bun install` with an explicit `--linker` (`js_delegate.zig:208`) that overrides `bunfig.toml`'s `hoisted`. The explicit install step had produced 351 packages; this produced 683, and root `node_modules/typescript` was gone.

## It is intermittent, and that is the argument for this PR

`main` is currently **green**, including `integration`, without this change. Same workflow, same cache key, same pantry version — the setup simply did not fire:

| | pantry cache | `Installing JS deps` | result |
|---|---|---|---|
| #106 run `33776563410` | hit | **yes** — 683 packages, `typescript@7.1.0-dev` | integration **fail** |
| main run `33779108264` | hit | no | integration **pass** |

pantry skips the install when it decides deps are already in sync (`js_delegate.zig:33`), so whether `node_modules` gets rewritten mid-job depends on runner state rather than on anything in this repo. That is worse than a deterministic break: it fails a job that nothing in the diff touched, and it passes on retry.

So this is not a fix for a red `main` — `main` is green. It removes the nondeterminism.

## The eval was never load-bearing

`pantry env` exports only `PANTRY_*` variables (0.10.3 exports none), and no workflow reads them. `zig` is on PATH because the pantry action already puts every installed bin there (`packages/action/src/index.ts:852–912`) — which is why `bun install` runs with no eval at all, and why zig-js's CI uses the same action with bare `zig build`.

Removed from all 16 sites across five workflows. The Apple signing gate in `release.yml` is untouched.

## Verification

All 9 checks green on this PR, including `zig-core` on both platforms (proving `zig` resolves without the eval) and `integration` (proving the shim survives).