### PR TITLE
docs(ios): retire three refusal notes that outlived their refusals

### DIFF
--- a/packages/zig/src/bridge_mobile_display.zig
+++ b/packages/zig/src/bridge_mobile_display.zig
@@ -600,9 +600,10 @@ fn applyBadge(count: i64) !i64 {
 /// what happened rather than swallowing it.
 ///
 /// The completion handler is `nullable` in the header, so nil is legal and no
-/// block is needed. Note that `requestAuthorizationWithOptions:`, which Swift
-/// also calls, is *not* nullable there — passing nil to that one crashes, which
-/// is part of why authorization is not attempted here.
+/// block is needed. `requestAuthorizationWithOptions:`, which the spec also
+/// calls, is *not* nullable there — passing nil to that one crashes, which is
+/// why it needs a real block. It has one now: `requestBadgeAuthorization`
+/// above asks before this writes, so this function no longer runs unasked.
 fn setBadgeThroughNotificationCenter(count: c_long) bool {
     const UNCenterClass = objc.objc_getClass("UNUserNotificationCenter") orelse return false;
     const sel_current = objc.sel_registerName("currentNotificationCenter") orelse return false;

--- a/packages/zig/src/bridge_mobile_permissions.zig
+++ b/packages/zig/src/bridge_mobile_permissions.zig
@@ -65,8 +65,10 @@
 //! those took actions *away* from the shim because the shim's answers were
 //! fabricated or broken; these shim answers are real, and taking them away
 //! would trade working behaviour for a tidier table. The cost is that the
-//! conformance ratchet keeps counting `openSettings` as not-yet-migrated —
-//! which is the truth.
+//! conformance ratchet keeps counting the payload values above — location,
+//! photos, contacts, calendar, reminders — against `requestPermission`, which
+//! is the truth. It no longer applies to `openSettings`: that one is claimed,
+//! and the ratchet counts it as migrated.
 //!
 //! ## What is carried across exactly
 //!
@@ -123,10 +125,12 @@ const Id = ?*anyopaque;
 
 /// The action names, spelled exactly as the Swift `case` labels spell them.
 ///
-/// `openSettings` is deliberately absent — see the module comment. Adding it
-/// here without first giving `ios_async` a boolean-literal reply would ship
-/// the truthy-`"denied"` bug, and the conformance scan would count the action
-/// as migrated while the shim was still the only honest server of it.
+/// All three are claimed. `openSettings` was not, and this comment said so
+/// long after it stopped being true — the module comment above records both
+/// the original objection and why a module-owned global block answered it.
+/// A doc comment that contradicts the `A` block three lines below it is worse
+/// than none: `scheduleNotification` sat with the shim for days after its
+/// blocker was fixed because nobody re-read the note that described it.
 pub const A = struct {
     pub const check_permission = "checkPermission";
     pub const request_permission = "requestPermission";


### PR DESCRIPTION
`scheduleNotification` (#110) sat with the Swift shim for days after the thing blocking it was fixed, because the note describing the blocker was still there and nobody re-read it. I swept for the same shape and found three more.

## `bridge_mobile_permissions.zig` contradicted itself

Its module header already says `openSettings` "**is** claimed now". The doc comment three lines above the `A` block still called it *"deliberately absent"* and warned against adding it — while `A` has declared it since `bdfa2ae`, and `routeFor`, `capability_actions` and the handler all serve it.

The header also said the ratchet "keeps counting `openSettings` as not-yet-migrated". That stopped being true when it was declared; the extraction confirms `openSettings` is not among the 25. What the ratchet *does* still count is the payload values `requestPermission` leaves to the shim — location, photos, contacts, calendar, reminders — so the sentence names those instead.

## `bridge_mobile_display.zig` described a gap I had already closed

It said badge authorization "is not attempted here". `requestBadgeAuthorization` asks before the badge is written, as of #105. That note was mine, left behind in the very commit that added the ask.

## Checked and kept

`bgtasks`' `registerBackgroundTask` note is still accurate: `BGTaskScheduler.register` must run before the app finishes launching, so a page-triggered call is late by construction and raises an uncatchable `NSInternalInconsistencyException`. Genuinely still blocked, note stays.

## Why this is worth a commit

No behaviour changes. But a note describing a limitation the code no longer has reads exactly like one describing a current limitation, and the only way to tell them apart is to re-derive the whole argument from scratch. That cost is measurable here rather than theoretical — it is the reason an action stayed on the shim through several passes that each read the note and believed it.

`zig build test`: 150/150 steps, 0 failures.
