### PR TITLE
fix(ios): no gated dispatcher arm can hang the page any more (58 → 0)

### DIFF
--- a/packages/ios/templates/CraftApp.swift
+++ b/packages/ios/templates/CraftApp.swift
@@ -568,6 +568,8 @@ struct CraftWebView: UIViewRepresentable {
                 if config.enableHaptics {
                     let style = body["style"] as? String ?? "medium"
                     triggerHaptic(style: style)
+                } else {
+                    rejectCallback(callbackId, error: "Haptics is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "share":
                 if config.enableShare {
@@ -585,20 +587,28 @@ struct CraftWebView: UIViewRepresentable {
                 if config.enableCamera {
                     pendingCallbackId = callbackId
                     openCamera()
+                } else {
+                    rejectCallback(callbackId, error: "Camera is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "pickImage":
                 if config.enableCamera {
                     pendingCallbackId = callbackId
                     pickImage()
+                } else {
+                    rejectCallback(callbackId, error: "Camera is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "authenticate":
                 if config.enableBiometric {
                     let reason = body["reason"] as? String ?? "Authenticate to continue"
                     authenticate(reason: reason, callbackId: callbackId)
+                } else {
+                    rejectCallback(callbackId, error: "Biometric authentication is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "registerPush":
                 if config.enablePushNotifications {
                     registerPushNotifications(callbackId: callbackId)
+                } else {
+                    rejectCallback(callbackId, error: "Push notifications are disabled", code: "CAPABILITY_DISABLED")
                 }
             case "secureSet":
                 if config.enableSecureStorage,
@@ -688,6 +698,8 @@ struct CraftWebView: UIViewRepresentable {
                 if config.enableClipboard {
                     let text = UIPasteboard.general.string ?? ""
                     resolveCallback(callbackId, result: text)
+                } else {
+                    rejectCallback(callbackId, error: "Clipboard is disabled", code: "CAPABILITY_DISABLED")
                 }
             // Device Info
             case "getDeviceInfo":
@@ -735,6 +747,8 @@ struct CraftWebView: UIViewRepresentable {
             case "getContacts":
                 if config.enableContacts {
                     getContacts(callbackId: callbackId)
+                } else {
+                    rejectCallback(callbackId, error: "Contacts access is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "addContact":
                 if config.enableContacts,
@@ -748,6 +762,8 @@ struct CraftWebView: UIViewRepresentable {
                     let startDate = body["startDate"] as? Double
                     let endDate = body["endDate"] as? Double
                     getCalendarEvents(startDate: startDate, endDate: endDate, callbackId: callbackId)
+                } else {
+                    rejectCallback(callbackId, error: "Calendar access is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "createCalendarEvent":
                 if config.enableCalendar,
@@ -774,10 +790,14 @@ struct CraftWebView: UIViewRepresentable {
             case "cancelAllNotifications":
                 if config.enableLocalNotifications {
                     cancelAllLocalNotifications(callbackId: callbackId)
+                } else {
+                    rejectCallback(callbackId, error: "Local notifications are disabled", code: "CAPABILITY_DISABLED")
                 }
             case "getPendingNotifications":
                 if config.enableLocalNotifications {
                     getPendingNotifications(callbackId: callbackId)
+                } else {
+                    rejectCallback(callbackId, error: "Local notifications are disabled", code: "CAPABILITY_DISABLED")
                 }
 
             // MARK: - Deep Links
@@ -785,6 +805,8 @@ struct CraftWebView: UIViewRepresentable {
                 if config.enableDeepLinks {
                     // Handler is registered in JS
                     resolveCallback(callbackId, result: true)
+                } else {
+                    rejectCallback(callbackId, error: "Deep links are disabled", code: "CAPABILITY_DISABLED")
                 }
             case "getInitialURL":
                 if config.enableDeepLinks {
@@ -799,6 +821,8 @@ struct CraftWebView: UIViewRepresentable {
                     } else {
                         resolveCallback(callbackId, result: NSNull())
                     }
+                } else {
+                    rejectCallback(callbackId, error: "Deep links are disabled", code: "CAPABILITY_DISABLED")
                 }
 
             // MARK: - In-App Purchase
@@ -815,6 +839,8 @@ struct CraftWebView: UIViewRepresentable {
             case "restorePurchases":
                 if config.enableInAppPurchase {
                     restorePurchases(callbackId: callbackId)
+                } else {
+                    rejectCallback(callbackId, error: "In-app purchase is disabled", code: "CAPABILITY_DISABLED")
                 }
 
             // MARK: - Keep Awake
@@ -833,12 +859,16 @@ struct CraftWebView: UIViewRepresentable {
             case "unlockOrientation":
                 if config.enableOrientationLock {
                     unlockOrientation(callbackId: callbackId)
+                } else {
+                    rejectCallback(callbackId, error: "Orientation lock is disabled", code: "CAPABILITY_DISABLED")
                 }
 
             // MARK: - QR/Barcode Scanner
             case "scanQRCode":
                 if config.enableQRScanner {
                     scanQRCode(callbackId: callbackId)
+                } else {
+                    rejectCallback(callbackId, error: "QR scanning is disabled", code: "CAPABILITY_DISABLED")
                 }
 
             // MARK: - File Picker
@@ -846,6 +876,8 @@ struct CraftWebView: UIViewRepresentable {
                 if config.enableFilePicker {
                     let types = body["types"] as? [String]
                     pickFile(types: types, callbackId: callbackId)
+                } else {
+                    rejectCallback(callbackId, error: "File picker is disabled", code: "CAPABILITY_DISABLED")
                 }
 
             // MARK: - File Download
@@ -866,22 +898,30 @@ struct CraftWebView: UIViewRepresentable {
             case "signInWithApple":
                 if config.enableSocialAuth {
                     signInWithApple(callbackId: callbackId)
+                } else {
+                    rejectCallback(callbackId, error: "Social sign-in is disabled", code: "CAPABILITY_DISABLED")
                 }
 
             // MARK: - Audio Recording
             case "startAudioRecording":
                 if config.enableAudioRecording {
                     startAudioRecording(callbackId: callbackId)
+                } else {
+                    rejectCallback(callbackId, error: "Audio recording is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "stopAudioRecording":
                 if config.enableAudioRecording {
                     stopAudioRecording(callbackId: callbackId)
+                } else {
+                    rejectCallback(callbackId, error: "Audio recording is disabled", code: "CAPABILITY_DISABLED")
                 }
 
             // MARK: - Video Recording
             case "startVideoRecording":
                 if config.enableVideoRecording {
                     startVideoRecording(callbackId: callbackId)
+                } else {
+                    rejectCallback(callbackId, error: "Video recording is disabled", code: "CAPABILITY_DISABLED")
                 }
 
             // MARK: - Motion Sensors
@@ -889,6 +929,8 @@ struct CraftWebView: UIViewRepresentable {
                 if config.enableMotionSensors {
                     let interval = body["interval"] as? Double ?? 100
                     startMotionUpdates(interval: interval, callbackId: callbackId)
+                } else {
+                    rejectCallback(callbackId, error: "Motion sensors are disabled", code: "CAPABILITY_DISABLED")
                 }
             case "stopMotionUpdates":
                 stopMotionUpdates()
@@ -912,6 +954,8 @@ struct CraftWebView: UIViewRepresentable {
             case "startBluetoothScan":
                 if config.enableBluetooth {
                     startBluetoothScan(callbackId: callbackId)
+                } else {
+                    rejectCallback(callbackId, error: "Bluetooth is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "stopBluetoothScan":
                 stopBluetoothScan()
@@ -921,6 +965,8 @@ struct CraftWebView: UIViewRepresentable {
             case "scanNFC":
                 if config.enableNFC {
                     scanNFC(callbackId: callbackId)
+                } else {
+                    rejectCallback(callbackId, error: "NFC is disabled", code: "CAPABILITY_DISABLED")
                 }
 
             // MARK: - Health
@@ -928,6 +974,8 @@ struct CraftWebView: UIViewRepresentable {
                 if config.enableHealthKit {
                     let types = body["types"] as? [String] ?? []
                     requestHealthAuthorization(types: types, callbackId: callbackId)
+                } else {
+                    rejectCallback(callbackId, error: "HealthKit is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "getHealthData":
                 if config.enableHealthKit,
@@ -959,6 +1007,8 @@ struct CraftWebView: UIViewRepresentable {
             case "takeScreenshot":
                 if config.enableScreenCapture {
                     takeScreenshot(callbackId: callbackId)
+                } else {
+                    rejectCallback(callbackId, error: "Screen capture is disabled", code: "CAPABILITY_DISABLED")
                 }
 
             // MARK: - Background Tasks
@@ -983,6 +1033,8 @@ struct CraftWebView: UIViewRepresentable {
             case "cancelAllBackgroundTasks":
                 if config.enableBackgroundTasks {
                     cancelAllBackgroundTasks(callbackId: callbackId)
+                } else {
+                    rejectCallback(callbackId, error: "Background tasks are disabled", code: "CAPABILITY_DISABLED")
                 }
 
             // MARK: - PDF Viewer
@@ -1000,6 +1052,8 @@ struct CraftWebView: UIViewRepresentable {
                 if config.enableContacts {
                     let multiple = body["multiple"] as? Bool ?? false
                     pickContact(multiple: multiple, callbackId: callbackId)
+                } else {
+                    rejectCallback(callbackId, error: "Contacts access is disabled", code: "CAPABILITY_DISABLED")
                 }
 
             // MARK: - App Shortcuts
@@ -1044,10 +1098,14 @@ struct CraftWebView: UIViewRepresentable {
                 if config.enableAR {
                     let options = body["options"] as? [String: Any] ?? [:]
                     startAR(options: options, callbackId: callbackId)
+                } else {
+                    rejectCallback(callbackId, error: "AR is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "stopAR":
                 if config.enableAR {
                     stopAR(callbackId: callbackId)
+                } else {
+                    rejectCallback(callbackId, error: "AR is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "placeARObject":
                 if config.enableAR,
@@ -1063,6 +1121,8 @@ struct CraftWebView: UIViewRepresentable {
             case "getARPlanes":
                 if config.enableAR {
                     getARPlanes(callbackId: callbackId)
+                } else {
+                    rejectCallback(callbackId, error: "AR is disabled", code: "CAPABILITY_DISABLED")
                 }
 
             // MARK: - ML (Core ML / Vision)

--- a/packages/ios/templates/CraftApp.swift
+++ b/packages/ios/templates/CraftApp.swift
@@ -561,7 +561,11 @@ struct CraftWebView: UIViewRepresentable {
         func dispatch(action: String, body: [String: Any], callbackId: String?) {
             switch action {
             case "startListening":
-                if config.enableSpeechRecognition { startSpeechRecognition() }
+                if config.enableSpeechRecognition {
+                    startSpeechRecognition()
+                } else {
+                    rejectCallback(callbackId, error: "Speech recognition is disabled", code: "CAPABILITY_DISABLED")
+                }
             case "stopListening":
                 stopSpeechRecognition()
             case "haptic":
@@ -611,23 +615,38 @@ struct CraftWebView: UIViewRepresentable {
                     rejectCallback(callbackId, error: "Push notifications are disabled", code: "CAPABILITY_DISABLED")
                 }
             case "secureSet":
-                if config.enableSecureStorage,
-                   let key = body["key"] as? String,
-                   let value = body["value"] as? String {
-                    let success = secureStore(key: key, value: value)
-                    resolveCallback(callbackId, result: success)
+                if config.enableSecureStorage {
+                    if let key = body["key"] as? String,
+                       let value = body["value"] as? String {
+                        let success = secureStore(key: key, value: value)
+                        resolveCallback(callbackId, result: success)
+                    } else {
+                        rejectCallback(callbackId, error: "secureSet was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+                } else {
+                    rejectCallback(callbackId, error: "Secure storage is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "secureGet":
-                if config.enableSecureStorage,
-                   let key = body["key"] as? String {
-                    let value = secureRetrieve(key: key)
-                    resolveCallback(callbackId, result: value as Any)
+                if config.enableSecureStorage {
+                    if let key = body["key"] as? String {
+                        let value = secureRetrieve(key: key)
+                        resolveCallback(callbackId, result: value as Any)
+                    } else {
+                        rejectCallback(callbackId, error: "secureGet was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+                } else {
+                    rejectCallback(callbackId, error: "Secure storage is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "secureRemove":
-                if config.enableSecureStorage,
-                   let key = body["key"] as? String {
-                    let success = secureRemove(key: key)
-                    resolveCallback(callbackId, result: success)
+                if config.enableSecureStorage {
+                    if let key = body["key"] as? String {
+                        let success = secureRemove(key: key)
+                        resolveCallback(callbackId, result: success)
+                    } else {
+                        rejectCallback(callbackId, error: "secureRemove was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+                } else {
+                    rejectCallback(callbackId, error: "Secure storage is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "secureClear":
                 if config.enableSecureStorage {
@@ -690,10 +709,16 @@ struct CraftWebView: UIViewRepresentable {
                 readLocationRecording(callbackId: callbackId)
             // Clipboard
             case "clipboardWrite":
-                if config.enableClipboard, let text = body["text"] as? String {
-                    UIPasteboard.general.string = text
-                    resolveCallback(callbackId, result: true)
-                }
+            if config.enableClipboard {
+                    if let text = body["text"] as? String {
+                            UIPasteboard.general.string = text
+                            resolveCallback(callbackId, result: true)
+                    } else {
+                        rejectCallback(callbackId, error: "clipboardWrite was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+            } else {
+                rejectCallback(callbackId, error: "Clipboard is disabled", code: "CAPABILITY_DISABLED")
+            }
             case "clipboardRead":
                 if config.enableClipboard {
                     let text = UIPasteboard.general.string ?? ""
@@ -751,11 +776,15 @@ struct CraftWebView: UIViewRepresentable {
                     rejectCallback(callbackId, error: "Contacts access is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "addContact":
-                if config.enableContacts,
-                   let contactData = body["contact"] as? [String: Any] {
-                    addContact(contactData, callbackId: callbackId)
+                if config.enableContacts {
+                    if let contactData = body["contact"] as? [String: Any] {
+                        addContact(contactData, callbackId: callbackId)
+                    } else {
+                        rejectCallback(callbackId, error: "addContact was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+                } else {
+                    rejectCallback(callbackId, error: "Contacts access is disabled", code: "CAPABILITY_DISABLED")
                 }
-
             // MARK: - Calendar
             case "getCalendarEvents":
                 if config.enableCalendar {
@@ -766,26 +795,45 @@ struct CraftWebView: UIViewRepresentable {
                     rejectCallback(callbackId, error: "Calendar access is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "createCalendarEvent":
-                if config.enableCalendar,
-                   let eventData = body["event"] as? [String: Any] {
-                    createCalendarEvent(eventData, callbackId: callbackId)
+                if config.enableCalendar {
+                    if let eventData = body["event"] as? [String: Any] {
+                        createCalendarEvent(eventData, callbackId: callbackId)
+                    } else {
+                        rejectCallback(callbackId, error: "createCalendarEvent was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+                } else {
+                    rejectCallback(callbackId, error: "Calendar access is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "deleteCalendarEvent":
-                if config.enableCalendar,
-                   let eventId = body["eventId"] as? String {
-                    deleteCalendarEvent(eventId, callbackId: callbackId)
+                if config.enableCalendar {
+                    if let eventId = body["eventId"] as? String {
+                        deleteCalendarEvent(eventId, callbackId: callbackId)
+                    } else {
+                        rejectCallback(callbackId, error: "deleteCalendarEvent was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+                } else {
+                    rejectCallback(callbackId, error: "Calendar access is disabled", code: "CAPABILITY_DISABLED")
                 }
-
             // MARK: - Local Notifications
             case "scheduleNotification":
-                if config.enableLocalNotifications,
-                   let notifData = body["notification"] as? [String: Any] {
-                    scheduleLocalNotification(notifData, callbackId: callbackId)
+                if config.enableLocalNotifications {
+                    if let notifData = body["notification"] as? [String: Any] {
+                        scheduleLocalNotification(notifData, callbackId: callbackId)
+                    } else {
+                        rejectCallback(callbackId, error: "scheduleNotification was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+                } else {
+                    rejectCallback(callbackId, error: "Local notifications are disabled", code: "CAPABILITY_DISABLED")
                 }
             case "cancelNotification":
-                if config.enableLocalNotifications,
-                   let notifId = body["id"] as? String {
-                    cancelLocalNotification(notifId, callbackId: callbackId)
+                if config.enableLocalNotifications {
+                    if let notifId = body["id"] as? String {
+                        cancelLocalNotification(notifId, callbackId: callbackId)
+                    } else {
+                        rejectCallback(callbackId, error: "cancelNotification was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+                } else {
+                    rejectCallback(callbackId, error: "Local notifications are disabled", code: "CAPABILITY_DISABLED")
                 }
             case "cancelAllNotifications":
                 if config.enableLocalNotifications {
@@ -827,14 +875,24 @@ struct CraftWebView: UIViewRepresentable {
 
             // MARK: - In-App Purchase
             case "getProducts":
-                if config.enableInAppPurchase,
-                   let productIds = body["productIds"] as? [String] {
-                    getProducts(productIds, callbackId: callbackId)
+                if config.enableInAppPurchase {
+                    if let productIds = body["productIds"] as? [String] {
+                        getProducts(productIds, callbackId: callbackId)
+                    } else {
+                        rejectCallback(callbackId, error: "getProducts was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+                } else {
+                    rejectCallback(callbackId, error: "In-app purchase is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "purchase":
-                if config.enableInAppPurchase,
-                   let productId = body["productId"] as? String {
-                    purchaseProduct(productId, callbackId: callbackId)
+                if config.enableInAppPurchase {
+                    if let productId = body["productId"] as? String {
+                        purchaseProduct(productId, callbackId: callbackId)
+                    } else {
+                        rejectCallback(callbackId, error: "purchase was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+                } else {
+                    rejectCallback(callbackId, error: "In-app purchase is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "restorePurchases":
                 if config.enableInAppPurchase {
@@ -845,16 +903,25 @@ struct CraftWebView: UIViewRepresentable {
 
             // MARK: - Keep Awake
             case "setKeepAwake":
-                if config.enableKeepAwake,
-                   let enabled = body["enabled"] as? Bool {
-                    setKeepAwake(enabled, callbackId: callbackId)
+                if config.enableKeepAwake {
+                    if let enabled = body["enabled"] as? Bool {
+                        setKeepAwake(enabled, callbackId: callbackId)
+                    } else {
+                        rejectCallback(callbackId, error: "setKeepAwake was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+                } else {
+                    rejectCallback(callbackId, error: "Keep awake is disabled", code: "CAPABILITY_DISABLED")
                 }
-
             // MARK: - Orientation Lock
             case "lockOrientation":
-                if config.enableOrientationLock,
-                   let orientation = body["orientation"] as? String {
-                    lockOrientation(orientation, callbackId: callbackId)
+                if config.enableOrientationLock {
+                    if let orientation = body["orientation"] as? String {
+                        lockOrientation(orientation, callbackId: callbackId)
+                    } else {
+                        rejectCallback(callbackId, error: "lockOrientation was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+                } else {
+                    rejectCallback(callbackId, error: "Orientation lock is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "unlockOrientation":
                 if config.enableOrientationLock {
@@ -882,18 +949,25 @@ struct CraftWebView: UIViewRepresentable {
 
             // MARK: - File Download
             case "downloadFile":
-                if config.enableFileDownload,
-                   let url = body["url"] as? String,
-                   let filename = body["filename"] as? String {
-                    downloadFile(url: url, filename: filename, callbackId: callbackId)
-                }
+            if config.enableFileDownload {
+                    if let url = body["url"] as? String, let filename = body["filename"] as? String {
+                            downloadFile(url: url, filename: filename, callbackId: callbackId)
+                    } else {
+                        rejectCallback(callbackId, error: "downloadFile was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+            } else {
+                rejectCallback(callbackId, error: "File download is disabled", code: "CAPABILITY_DISABLED")
+            }
             case "saveFile":
-                if config.enableFileDownload,
-                   let data = body["data"] as? String,
-                   let filename = body["filename"] as? String {
-                    saveFile(data: data, filename: filename, callbackId: callbackId)
-                }
-
+            if config.enableFileDownload {
+                    if let data = body["data"] as? String, let filename = body["filename"] as? String {
+                            saveFile(data: data, filename: filename, callbackId: callbackId)
+                    } else {
+                        rejectCallback(callbackId, error: "saveFile was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+            } else {
+                rejectCallback(callbackId, error: "File download is disabled", code: "CAPABILITY_DISABLED")
+            }
             // MARK: - Social Auth
             case "signInWithApple":
                 if config.enableSocialAuth {
@@ -938,18 +1012,27 @@ struct CraftWebView: UIViewRepresentable {
 
             // MARK: - Local Database
             case "dbExecute":
-                if config.enableLocalDatabase,
-                   let sql = body["sql"] as? String {
-                    let params = body["params"] as? [Any]
-                    dbExecute(sql: sql, params: params, callbackId: callbackId)
+                if config.enableLocalDatabase {
+                    if let sql = body["sql"] as? String {
+                        let params = body["params"] as? [Any]
+                        dbExecute(sql: sql, params: params, callbackId: callbackId)
+                    } else {
+                        rejectCallback(callbackId, error: "dbExecute was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+                } else {
+                    rejectCallback(callbackId, error: "Local database is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "dbQuery":
-                if config.enableLocalDatabase,
-                   let sql = body["sql"] as? String {
-                    let params = body["params"] as? [Any]
-                    dbQuery(sql: sql, params: params, callbackId: callbackId)
+                if config.enableLocalDatabase {
+                    if let sql = body["sql"] as? String {
+                        let params = body["params"] as? [Any]
+                        dbQuery(sql: sql, params: params, callbackId: callbackId)
+                    } else {
+                        rejectCallback(callbackId, error: "dbQuery was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+                } else {
+                    rejectCallback(callbackId, error: "Local database is disabled", code: "CAPABILITY_DISABLED")
                 }
-
             // MARK: - Bluetooth
             case "startBluetoothScan":
                 if config.enableBluetooth {
@@ -978,11 +1061,16 @@ struct CraftWebView: UIViewRepresentable {
                     rejectCallback(callbackId, error: "HealthKit is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "getHealthData":
-                if config.enableHealthKit,
-                   let dataType = body["type"] as? String {
-                    let startDate = body["startDate"] as? Double
-                    let endDate = body["endDate"] as? Double
-                    getHealthData(type: dataType, startDate: startDate, endDate: endDate, callbackId: callbackId)
+                if config.enableHealthKit {
+                    if let dataType = body["type"] as? String {
+                        let startDate = body["startDate"] as? Double
+                        let endDate = body["endDate"] as? Double
+                        getHealthData(type: dataType, startDate: startDate, endDate: endDate, callbackId: callbackId)
+                    } else {
+                        rejectCallback(callbackId, error: "getHealthData was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+                } else {
+                    rejectCallback(callbackId, error: "HealthKit is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "saveHealthWorkout":
                 if config.enableHealthKit {
@@ -1013,22 +1101,37 @@ struct CraftWebView: UIViewRepresentable {
 
             // MARK: - Background Tasks
             case "registerBackgroundTask":
-                if config.enableBackgroundTasks,
-                   let taskId = body["taskId"] as? String {
-                    registerBackgroundTask(taskId: taskId, callbackId: callbackId)
+                if config.enableBackgroundTasks {
+                    if let taskId = body["taskId"] as? String {
+                        registerBackgroundTask(taskId: taskId, callbackId: callbackId)
+                    } else {
+                        rejectCallback(callbackId, error: "registerBackgroundTask was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+                } else {
+                    rejectCallback(callbackId, error: "Background tasks are disabled", code: "CAPABILITY_DISABLED")
                 }
             case "scheduleBackgroundTask":
-                if config.enableBackgroundTasks,
-                   let taskId = body["taskId"] as? String {
-                    let delay = body["delay"] as? Double ?? 900 // 15 minutes default
-                    let requiresNetwork = body["requiresNetwork"] as? Bool ?? false
-                    let requiresCharging = body["requiresCharging"] as? Bool ?? false
-                    scheduleBackgroundTask(taskId: taskId, delay: delay, requiresNetwork: requiresNetwork, requiresCharging: requiresCharging, callbackId: callbackId)
+                if config.enableBackgroundTasks {
+                    if let taskId = body["taskId"] as? String {
+                        let delay = body["delay"] as? Double ?? 900 // 15 minutes default
+                        let requiresNetwork = body["requiresNetwork"] as? Bool ?? false
+                        let requiresCharging = body["requiresCharging"] as? Bool ?? false
+                        scheduleBackgroundTask(taskId: taskId, delay: delay, requiresNetwork: requiresNetwork, requiresCharging: requiresCharging, callbackId: callbackId)
+                    } else {
+                        rejectCallback(callbackId, error: "scheduleBackgroundTask was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+                } else {
+                    rejectCallback(callbackId, error: "Background tasks are disabled", code: "CAPABILITY_DISABLED")
                 }
             case "cancelBackgroundTask":
-                if config.enableBackgroundTasks,
-                   let taskId = body["taskId"] as? String {
-                    cancelBackgroundTask(taskId: taskId, callbackId: callbackId)
+                if config.enableBackgroundTasks {
+                    if let taskId = body["taskId"] as? String {
+                        cancelBackgroundTask(taskId: taskId, callbackId: callbackId)
+                    } else {
+                        rejectCallback(callbackId, error: "cancelBackgroundTask was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+                } else {
+                    rejectCallback(callbackId, error: "Background tasks are disabled", code: "CAPABILITY_DISABLED")
                 }
             case "cancelAllBackgroundTasks":
                 if config.enableBackgroundTasks {
@@ -1039,10 +1142,15 @@ struct CraftWebView: UIViewRepresentable {
 
             // MARK: - PDF Viewer
             case "openPDF":
-                if config.enablePDFViewer,
-                   let source = body["source"] as? String {
-                    let page = body["page"] as? Int ?? 0
-                    openPDF(source: source, page: page, callbackId: callbackId)
+                if config.enablePDFViewer {
+                    if let source = body["source"] as? String {
+                        let page = body["page"] as? Int ?? 0
+                        openPDF(source: source, page: page, callbackId: callbackId)
+                    } else {
+                        rejectCallback(callbackId, error: "openPDF was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+                } else {
+                    rejectCallback(callbackId, error: "PDF viewing is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "closePDF":
                 closePDF(callbackId: callbackId)
@@ -1108,15 +1216,25 @@ struct CraftWebView: UIViewRepresentable {
                     rejectCallback(callbackId, error: "AR is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "placeARObject":
-                if config.enableAR,
-                   let model = body["model"] as? String {
-                    let position = body["position"] as? [String: Double]
-                    placeARObject(model: model, position: position, callbackId: callbackId)
+                if config.enableAR {
+                    if let model = body["model"] as? String {
+                        let position = body["position"] as? [String: Double]
+                        placeARObject(model: model, position: position, callbackId: callbackId)
+                    } else {
+                        rejectCallback(callbackId, error: "placeARObject was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+                } else {
+                    rejectCallback(callbackId, error: "AR is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "removeARObject":
-                if config.enableAR,
-                   let objectId = body["objectId"] as? String {
-                    removeARObject(objectId: objectId, callbackId: callbackId)
+                if config.enableAR {
+                    if let objectId = body["objectId"] as? String {
+                        removeARObject(objectId: objectId, callbackId: callbackId)
+                    } else {
+                        rejectCallback(callbackId, error: "removeARObject was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+                } else {
+                    rejectCallback(callbackId, error: "AR is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "getARPlanes":
                 if config.enableAR {
@@ -1127,21 +1245,35 @@ struct CraftWebView: UIViewRepresentable {
 
             // MARK: - ML (Core ML / Vision)
             case "classifyImage":
-                if config.enableMLKit,
-                   let imageBase64 = body["image"] as? String {
-                    classifyImage(imageBase64: imageBase64, callbackId: callbackId)
+                if config.enableMLKit {
+                    if let imageBase64 = body["image"] as? String {
+                        classifyImage(imageBase64: imageBase64, callbackId: callbackId)
+                    } else {
+                        rejectCallback(callbackId, error: "classifyImage was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+                } else {
+                    rejectCallback(callbackId, error: "Vision is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "detectObjects":
-                if config.enableMLKit,
-                   let imageBase64 = body["image"] as? String {
-                    detectObjects(imageBase64: imageBase64, callbackId: callbackId)
+                if config.enableMLKit {
+                    if let imageBase64 = body["image"] as? String {
+                        detectObjects(imageBase64: imageBase64, callbackId: callbackId)
+                    } else {
+                        rejectCallback(callbackId, error: "detectObjects was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+                } else {
+                    rejectCallback(callbackId, error: "Vision is disabled", code: "CAPABILITY_DISABLED")
                 }
             case "recognizeText":
-                if config.enableMLKit,
-                   let imageBase64 = body["image"] as? String {
-                    recognizeText(imageBase64: imageBase64, callbackId: callbackId)
+                if config.enableMLKit {
+                    if let imageBase64 = body["image"] as? String {
+                        recognizeText(imageBase64: imageBase64, callbackId: callbackId)
+                    } else {
+                        rejectCallback(callbackId, error: "recognizeText was called without the values it needs", code: "INVALID_ARGUMENT")
+                    }
+                } else {
+                    rejectCallback(callbackId, error: "Vision is disabled", code: "CAPABILITY_DISABLED")
                 }
-
             // MARK: - Widget
             case "updateWidget":
                 if let data = body["data"] as? [String: Any] {


### PR DESCRIPTION
Closes #116. **58 gated dispatcher arms could leave the page's promise unsettled. Zero can now.**

An arm shaped like this settles nothing when its gate is off:

```swift
case "openCamera":
    if config.enableCamera {
        pendingCallbackId = callbackId
        openCamera()
    }
```

Not a slow rejection — these wrappers do not all carry the 30-second timeout, so the promise never settles at all. `enableCamera` and friends default to `false`, so this is the *default* path for any capability the app has not opted into.

## The count was wrong twice before it was right

| | |
|---|---|
| inherited estimate | "~60 of 65" |
| first measurement | 57 hang / 8 correct |
| after brace-tracking | **58 hang / 7 correct** |

The first pass counted an *inner* `else` (a payload check) as handling the gate. `share` has both and is genuinely correct; others have only the inner one and still hang.

## Two commits

**30 gate-only arms** get the `else` the seven correct arms already use — `secureClear` and `share` are the models, and `CAPABILITY_DISABLED` is the code Zig's own capability gate answers, so both arms agree for an action served either way.

**28 arms that bind payload inside the gate** need the gate split out first, because one `else` cannot distinguish "turn this on in craft.config.json" from "you sent the wrong payload":

```swift
if config.enableSecureStorage {
    if let key = …, let value = … {
        …
    } else {
        rejectCallback(callbackId, error: "…", code: "INVALID_ARGUMENT")
    }
} else {
    rejectCallback(callbackId, error: "Secure storage is disabled", code: "CAPABILITY_DISABLED")
}
```

Four were done by hand: `startListening` (body on the brace line), `clipboardWrite` (gate and binding on one line), and `downloadFile`/`saveFile` (an `enableFileDownload` flag the message table missed).

## Two mistakes the sweep made, caught before commit

- Deriving messages from flag names produced **"Secure storage is disabled is disabled"** — 17 of them — because the phrase already carried the suffix. It also turned `enableAR` into "A r" and `enableNFC` into "N f c", so all 30 messages are written out rather than generated.
- The arm-range walk **swallowed six `// MARK:` section comments**. They are duplicated elsewhere in the file, so a naive presence check said they were fine; only comparing occurrence *counts* against HEAD found it. All 96 are restored.

## Verification

- `git diff -w` removes nothing but the `if config.enable…,` and `let … {` lines being restructured — no behaviour line lost.
- The generated app typechecks against the iphonesimulator SDK: **0 errors**, and exactly the same 4 warnings as HEAD (I compared by stashing and regenerating, because my first "8 → 4" reading was a raw line count, not distinct warnings).
- `zig build test` green — the conformance test reads this file.

Related: #115 is a different silent-failure shape in the same file.
