### PR TITLE
feat(ios): location recording moves to the manager it always shared — ratchet 23 -> 18

### DIFF
--- a/packages/ios/templates/CraftApp.swift
+++ b/packages/ios/templates/CraftApp.swift
@@ -457,7 +457,12 @@ struct CraftWebView: UIViewRepresentable {
                 locationManager?.desiredAccuracy = kCLLocationAccuracyBest
                 locationManager?.activityType = .fitness
                 locationManager?.pausesLocationUpdatesAutomatically = false
-                restoreLocationRecordingState()
+                // Zig owns the recorder when it is linked, including the
+                // relaunch restore — see `CraftZigRuntime.adoptLocationRecording`.
+                // Running both would leave two managers appending to one track.
+                if !CraftZigRuntime.adoptLocationRecording() {
+                    restoreLocationRecordingState()
+                }
             }
             if config.enableContacts {
                 contactStore = CNContactStore()
@@ -5465,6 +5470,7 @@ final class CraftZigRuntime: NSObject {
     private typealias HandleActionFn = @convention(c) (
         UnsafePointer<CChar>, UInt, UnsafePointer<CChar>, UInt, Int64
     ) -> Bool
+    private typealias AdoptLocationRecordingFn = @convention(c) () -> Bool
 
     private static let image: UnsafeMutableRawPointer? = dlopen(nil, RTLD_NOW)
 
@@ -5483,6 +5489,11 @@ final class CraftZigRuntime: NSObject {
         return unsafeBitCast(sym, to: HandleActionFn.self)
     }()
 
+    private static let adoptLocationRecordingFn: AdoptLocationRecordingFn? = {
+        guard let sym = dlsym(image, "craft_ios_adopt_location_recording") else { return nil }
+        return unsafeBitCast(sym, to: AdoptLocationRecordingFn.self)
+    }()
+
     /// Whether this build has a Zig runtime at all. Read by nothing here; kept
     /// because "is Zig linked" is the first question to ask when an action
     /// behaves like the Swift one after a migration was supposed to move it.
@@ -5495,6 +5506,24 @@ final class CraftZigRuntime: NSObject {
     /// nothing to break it.
     static func attach(_ webView: WKWebView) {
         setWebViewFn?(Unmanaged.passUnretained(webView).toOpaque())
+    }
+
+    /// Hand a recording that outlived the last launch to whichever runtime owns
+    /// the recorder.
+    ///
+    /// Returns true when Zig took it, and the caller must then *not* run
+    /// `restoreLocationRecordingState()`. This is the one place the usual
+    /// "offer it to Zig, fall back on false" pattern cannot be used through
+    /// `handleAction`: there is no page message at launch, and the restore
+    /// happens in `Coordinator.init` — before `attach`, because SwiftUI builds
+    /// the coordinator before the view. Whoever restores first owns the
+    /// `CLLocationManager` for the rest of the launch, so the decision has to
+    /// be made here rather than at the first `stopLocationRecording`.
+    ///
+    /// False in a build with no Zig runtime, which is exactly when Swift's own
+    /// restore is still the right thing to run.
+    static func adoptLocationRecording() -> Bool {
+        adoptLocationRecordingFn?() ?? false
     }
 
     /// Forget this webview, if Zig is still holding it.

--- a/packages/zig/src/bridge_mobile_location.zig
+++ b/packages/zig/src/bridge_mobile_location.zig
@@ -285,6 +285,8 @@ const bridge_error = @import("bridge_error.zig");
 const objc_runtime = @import("objc_runtime.zig");
 const ios_async = @import("ios_async.zig");
 const ios_events = @import("ios_events.zig");
+const locrec = @import("bridge_mobile_locrecording.zig");
+const compat = @import("compat.zig");
 const compat_mutex = @import("compat_mutex.zig");
 
 const objc = objc_runtime.objc;
@@ -310,6 +312,11 @@ pub const A = struct {
     pub const get_current_position = "getCurrentPosition";
     pub const watch_position = "watchPosition";
     pub const clear_watch = "clearWatch";
+    pub const start_location_recording = "startLocationRecording";
+    pub const pause_location_recording = "pauseLocationRecording";
+    pub const resume_location_recording = "resumeLocationRecording";
+    pub const stop_location_recording = "stopLocationRecording";
+    pub const get_location_recording_state = "getLocationRecordingState";
 };
 
 /// `.result`: the Swift path terminates in exactly one `resolveCallback` (from
@@ -332,6 +339,21 @@ pub const capability_actions = [_]capabilities.ActionDecl{
     .{ .name = A.get_current_position, .reply = .result },
     .{ .name = A.watch_position, .reply = .result },
     .{ .name = A.clear_watch, .reply = .result },
+
+    // The recorder. Every one of the five ends in exactly one `resolveCallback`
+    // or one `rejectCallback`, so `.result` throughout; none of them is
+    // `.unavailable`, because each does the thing rather than refusing it.
+    //
+    // Only `startLocationRecording` is gated in the spec — `ios_config.gateFor`
+    // carries that one entry and not the other four, because `CraftApp.swift`
+    // guards that case alone. Stopping or reading a recording an app already
+    // made is not a geolocation capability, and refusing it would strand a
+    // route on disk with no action able to reach it.
+    .{ .name = A.start_location_recording, .reply = .result },
+    .{ .name = A.pause_location_recording, .reply = .result },
+    .{ .name = A.resume_location_recording, .reply = .result },
+    .{ .name = A.stop_location_recording, .reply = .result },
+    .{ .name = A.get_location_recording_state, .reply = .result },
 };
 
 /// The reply `watchPosition` and `clearWatch` send.
@@ -345,12 +367,26 @@ const true_fragment = "true";
 /// Which handler an action selects, split out from `handleMessage` so the
 /// table-versus-dispatch agreement is assertable on a host without touching
 /// CoreLocation.
-const Route = enum { current_position, watch_position, clear_watch };
+const Route = enum {
+    current_position,
+    watch_position,
+    clear_watch,
+    start_recording,
+    pause_recording,
+    resume_recording,
+    stop_recording,
+    recording_state,
+};
 
 fn routeFor(action: []const u8) ?Route {
     if (std.mem.eql(u8, action, A.get_current_position)) return .current_position;
     if (std.mem.eql(u8, action, A.watch_position)) return .watch_position;
     if (std.mem.eql(u8, action, A.clear_watch)) return .clear_watch;
+    if (std.mem.eql(u8, action, A.start_location_recording)) return .start_recording;
+    if (std.mem.eql(u8, action, A.pause_location_recording)) return .pause_recording;
+    if (std.mem.eql(u8, action, A.resume_location_recording)) return .resume_recording;
+    if (std.mem.eql(u8, action, A.stop_location_recording)) return .stop_recording;
+    if (std.mem.eql(u8, action, A.get_location_recording_state)) return .recording_state;
     return null;
 }
 
@@ -372,6 +408,11 @@ pub const LocationBridge = struct {
             .current_position => self.getCurrentPosition(data),
             .watch_position => self.watchPosition(data),
             .clear_watch => self.clearWatch(data),
+            .start_recording => self.startRecording(data),
+            .pause_recording => self.pauseRecording(data),
+            .resume_recording => self.resumeRecording(data),
+            .stop_recording => self.stopRecording(data),
+            .recording_state => self.recordingState(data),
         };
     }
 
@@ -457,42 +498,16 @@ pub const LocationBridge = struct {
 
         const authorization = try resolveAuthorization();
         const sels = try Sels.resolve();
+        const updates = try UpdateSelectors.resolve(authorization);
         const background = try backgroundLocationDeclared();
         const mgr = try ensureManager();
 
-        const auth_selector_name: [*:0]const u8 = switch (authorization) {
-            .always => "requestAlwaysAuthorization",
-            .when_in_use => "requestWhenInUseAuthorization",
-        };
-        const sel_authorize = try selector(auth_selector_name);
-        const sel_start = try selector("startUpdatingLocation");
-        const sel_responds = try selector("respondsToSelector:");
-        const sel_allows_background = try selector("setAllowsBackgroundLocationUpdates:");
-        const sel_shows_indicator = try selector("setShowsBackgroundLocationIndicator:");
-
         publishWatch(sels);
 
-        objc.msgSend(mgr, sel_authorize);
-
-        if (background) {
-            // `configureBackgroundLocationIfNeeded()`, under the guard that
-            // makes it safe. Both properties take the same value in Swift, and
-            // both are set to it here.
-            if (!setBoolIfSupported(mgr, sel_responds, sel_allows_background, true)) {
-                std.log.warn(
-                    "watchPosition: this CLLocationManager has no " ++
-                        "allowsBackgroundLocationUpdates; the watch will stop when the app " ++
-                        "is backgrounded even though UIBackgroundModes declares location",
-                    .{},
-                );
-            }
-            // Purely the status-bar indicator. A manager without it is an OS too
-            // old for the property, not a broken subscription, so it is not
-            // worth a warning of its own.
-            _ = setBoolIfSupported(mgr, sel_responds, sel_shows_indicator, true);
-        }
-
-        objc.msgSend(mgr, sel_start);
+        // The same lines `startLocationRecording` and `resumeLocationRecording`
+        // run. They share a manager, so they had better share the sequence that
+        // configures it.
+        applyUpdates(mgr, updates, background, .request);
 
         bridge_error.sendResultToJS(self.allocator, A.watch_position, true_fragment);
     }
@@ -558,6 +573,20 @@ pub const LocationBridge = struct {
             return bridge_error.BridgeError.NativeCallFailed;
         };
 
+        // `stopWatchingPosition()` is `isWatchingLocation = false` and then
+        // `if !isRecordingLocation { stopUpdatingLocation(); … }`. Before the
+        // recorder moved here that guard could never fail, because Swift owned
+        // every recording; now it can, and stopping the manager would silently
+        // end a route the page never asked to stop.
+        if (recordingHoldsTheManager()) {
+            std.log.info(
+                "clearWatch: the watch is stopped, but a recording is still using this manager; leaving it updating",
+                .{},
+            );
+            bridge_error.sendResultToJS(self.allocator, A.clear_watch, true_fragment);
+            return;
+        }
+
         objc.msgSend(mgr, sel_stop);
         // Mirrors `stopWatchingPosition()`'s `allowsBackgroundLocationUpdates =
         // false`. Setting it to NO is safe in any process — only YES can raise.
@@ -565,7 +594,497 @@ pub const LocationBridge = struct {
 
         bridge_error.sendResultToJS(self.allocator, A.clear_watch, true_fragment);
     }
+
+    // =========================================================================
+    // The recorder.
+    //
+    // Five actions over one flag and two files. They share the manager with the
+    // watch, which is the whole reason they belong in this file rather than
+    // beside the track reader: `CraftWebView.Coordinator` runs one
+    // `CLLocationManager` for all of `getCurrentPosition`, `watchPosition` and
+    // the recorder, and two managers feeding one event name is the duplication
+    // this migration removes.
+    //
+    // Swift keeps no guard against starting a recording while one is running —
+    // `startLocationRecording` overwrites the track and the id unconditionally
+    // — and neither does this. It is a restart, and the page asked for one.
+    // =========================================================================
+
+    /// Begin a route, replacing whatever the last one left behind.
+    ///
+    /// The order differs from Swift's in one place, deliberately. Swift sets its
+    /// four variables, then calls `persistLocationRecordingState()`, which
+    /// catches its own write failure and prints. Memory and disk can therefore
+    /// disagree from the first sample onward, with the page told the recording
+    /// started. Here the state reaches disk *first*, and a failure refuses the
+    /// start: a recording the page is told is running is one that will still be
+    /// there after a relaunch.
+    fn startRecording(self: *Self, data: []const u8) !void {
+        _ = data;
+        if (!is_darwin) return error.UnsupportedPlatform;
+
+        // Everything that can fail, resolved before the track is cleared. A
+        // refusal after `resetTrack` would have destroyed the previous route to
+        // serve a call that then answers an error.
+        const authorization = try resolveAuthorization();
+        const sels = try Sels.resolve();
+        const updates = try UpdateSelectors.resolve(authorization);
+        const background = try backgroundLocationDeclared();
+        const mgr = try ensureManager();
+
+        // `commitRecording` copies it, so this frame owns it either way.
+        const id = try newRecordingId(recording_allocator);
+        defer recording_allocator.free(id);
+
+        const started_at = nowMillis();
+        const next: locrec.State = .{
+            .active = true,
+            .paused = false,
+            .id = id,
+            .started_at = started_at,
+        };
+
+        // `try Data().write(to:…, options:.atomic)`: a fresh, empty track. A
+        // storage failure refuses the start rather than appending this route on
+        // to the last one — `RECORDING_STORAGE_ERROR` in Swift, and the nearest
+        // `BridgeError` here, with the cause logged by the writer.
+        try locrec.resetTrack(self.allocator);
+        try locrec.writeState(self.allocator, next);
+
+        try commitRecording(next, sels);
+        applyUpdates(mgr, updates, background, .request);
+
+        try self.replySummary(A.start_location_recording, .none);
+    }
+
+    /// Stop collecting without ending the route.
+    ///
+    /// `guard isRecordingLocation else { reject("No active location recording") }`.
+    /// Paused is a state of a live recording, so a paused one still answers
+    /// `pause` — Swift's guard is on `isRecordingLocation` alone, not on
+    /// `!isLocationRecordingPaused`, and pausing twice is not an error.
+    fn pauseRecording(self: *Self, data: []const u8) !void {
+        _ = data;
+        if (!is_darwin) return error.UnsupportedPlatform;
+
+        var snapshot = try snapshotRecording(self.allocator);
+        defer snapshot.deinit(self.allocator);
+
+        if (!snapshot.active) return noActiveRecording();
+
+        const next: locrec.State = .{
+            .active = true,
+            .paused = true,
+            .id = snapshot.id,
+            .started_at = snapshot.started_at,
+        };
+        try locrec.writeState(self.allocator, next);
+        try commitRecording(next, null);
+
+        // `if !isWatchingLocation { locationManager?.stopUpdatingLocation() }`.
+        // The watch keeps the manager alive when it is the other user of it.
+        stopUpdatesUnlessWatched("pauseLocationRecording", .keep_background);
+
+        try self.replySummary(A.pause_location_recording, .none);
+    }
+
+    /// Collect again on a route that was paused.
+    fn resumeRecording(self: *Self, data: []const u8) !void {
+        _ = data;
+        if (!is_darwin) return error.UnsupportedPlatform;
+
+        const authorization = try resolveAuthorization();
+        const sels = try Sels.resolve();
+        const updates = try UpdateSelectors.resolve(authorization);
+        const background = try backgroundLocationDeclared();
+        const mgr = try ensureManager();
+
+        var snapshot = try snapshotRecording(self.allocator);
+        defer snapshot.deinit(self.allocator);
+
+        if (!snapshot.active) return noActiveRecording();
+
+        const next: locrec.State = .{
+            .active = true,
+            .paused = false,
+            .id = snapshot.id,
+            .started_at = snapshot.started_at,
+        };
+        try locrec.writeState(self.allocator, next);
+        try commitRecording(next, sels);
+
+        applyUpdates(mgr, updates, background, .request);
+
+        try self.replySummary(A.resume_location_recording, .none);
+    }
+
+    /// End the route and hand back everything it collected.
+    ///
+    /// No guard: `stopLocationRecording` has none in Swift either, so stopping
+    /// a recording that is not running answers the summary of a stopped
+    /// recording rather than an error. "There is no recording" and "the
+    /// recording is now stopped" are the same state to a caller.
+    ///
+    /// `id` and `startedAt` are deliberately **not** cleared, matching Swift —
+    /// which is why a stop-then-read in one launch still reports them, and a
+    /// relaunch does not.
+    fn stopRecording(self: *Self, data: []const u8) !void {
+        _ = data;
+        if (!is_darwin) return error.UnsupportedPlatform;
+
+        var snapshot = try snapshotRecording(self.allocator);
+        defer snapshot.deinit(self.allocator);
+
+        const next: locrec.State = .{
+            .active = false,
+            .paused = false,
+            .id = snapshot.id,
+            .started_at = snapshot.started_at,
+        };
+        try locrec.writeState(self.allocator, next);
+        try commitRecording(next, null);
+
+        stopUpdatesUnlessWatched("stopLocationRecording", .drop_background);
+
+        try self.replySummary(A.stop_location_recording, .with_locations);
+    }
+
+    /// The summary, plus how many samples are on disk.
+    fn recordingState(self: *Self, data: []const u8) !void {
+        _ = data;
+        try self.replySummary(A.get_location_recording_state, .with_sample_count);
+    }
+
+    /// What the four summary actions reply, in Swift's key order.
+    ///
+    /// `locationRecordingSummary()` is `id`, `active`, `paused`, `startedAt`;
+    /// `stopLocationRecording` adds `locations` and `getLocationRecordingState`
+    /// adds `sampleCount`, and no other action carries either.
+    fn replySummary(self: *Self, comptime action: []const u8, extra: SummaryExtra) !void {
+        var snapshot = try snapshotRecording(self.allocator);
+        defer snapshot.deinit(self.allocator);
+
+        var out: std.ArrayListUnmanaged(u8) = .empty;
+        defer out.deinit(self.allocator);
+
+        try out.appendSlice(self.allocator, "{\"id\":");
+        if (snapshot.id) |id| {
+            try out.append(self.allocator, '"');
+            try bridge_error.appendJsonEscaped(self.allocator, &out, id);
+            try out.append(self.allocator, '"');
+        } else {
+            try out.appendSlice(self.allocator, "null");
+        }
+        try out.appendSlice(self.allocator, ",\"active\":");
+        try out.appendSlice(self.allocator, if (snapshot.active) "true" else "false");
+        try out.appendSlice(self.allocator, ",\"paused\":");
+        try out.appendSlice(self.allocator, if (snapshot.paused) "true" else "false");
+        try out.appendSlice(self.allocator, ",\"startedAt\":");
+        if (snapshot.started_at) |started| {
+            const rendered = try std.fmt.allocPrint(self.allocator, "{d}", .{started});
+            defer self.allocator.free(rendered);
+            try out.appendSlice(self.allocator, rendered);
+        } else {
+            try out.appendSlice(self.allocator, "null");
+        }
+
+        switch (extra) {
+            .none => {},
+            .with_locations => {
+                const locations = try locrec.readTrackArray(self.allocator);
+                defer self.allocator.free(locations);
+                try out.appendSlice(self.allocator, ",\"locations\":");
+                try out.appendSlice(self.allocator, locations);
+            },
+            .with_sample_count => {
+                const count = try locrec.sampleCount(self.allocator);
+                var buf: [32]u8 = undefined;
+                const rendered = try std.fmt.bufPrint(&buf, "{d}", .{count});
+                try out.appendSlice(self.allocator, ",\"sampleCount\":");
+                try out.appendSlice(self.allocator, rendered);
+            },
+        }
+
+        try out.append(self.allocator, '}');
+
+        bridge_error.sendResultToJS(self.allocator, action, out.items);
+    }
 };
+
+
+// =============================================================================
+// The recorder's shared machinery: the manager hand-off, the state commit, and
+// the two values Swift takes from Foundation.
+// =============================================================================
+
+/// Re-adopt a recording that outlived the last launch.
+///
+/// `restoreLocationRecordingState()`, moved to the runtime that owns the
+/// recorder. Swift calls this instead of its own restore, and the reason it has
+/// to is an ordering it cannot change: SwiftUI runs `makeCoordinator()` before
+/// `makeUIView`, so `Coordinator.init` — where the restore lives — happens
+/// before `CraftZigRuntime.attach` has told Zig anything at all. Whoever
+/// restores first owns the `CLLocationManager` for the rest of the launch, and
+/// a Zig-owned `stop` cannot stop a recording Swift restored into its own
+/// state. That ordering was the deferral's whole reason (#124); this is the
+/// hook that settles it.
+///
+/// Returns **true when Zig has taken responsibility for the recorder**, which
+/// is whenever this function ran at all — the caller's `dlsym` finding the
+/// symbol is itself the proof. It is deliberately not "a recording was found":
+/// a launch with no recording still leaves Zig owning the next `start`, and a
+/// Swift restore under it would be a second owner of the same file.
+///
+/// Not gated here. The call site is inside Swift's `if config.enableGeolocation`,
+/// exactly where `restoreLocationRecordingState()` was, so the flag is honoured
+/// by placement rather than by a second, drifting copy of the check.
+pub fn adoptRecording() bool {
+    if (!is_darwin) return false;
+
+    const allocator = recording_allocator;
+
+    var state = locrec.readState(allocator) catch |err| {
+        // The state file is the only record of a recording in progress, and
+        // Swift would be reading the same bytes. Reporting ownership anyway is
+        // the honest answer: falling back would not recover the route, it would
+        // just add a second reader of a file neither can parse.
+        std.log.warn(
+            "location recording: could not read the persisted state at launch ({}); no recording is adopted",
+            .{err},
+        );
+        return true;
+    };
+    defer state.deinit(allocator);
+
+    // `guard … state["active"] as? Bool == true else { return }` already
+    // applied by `readState`, so this is Swift's early return.
+    if (!state.active) return true;
+
+    const sels = Sels.resolve() catch |err| {
+        std.log.err("location recording: cannot adopt the recording at launch ({}); its samples will not resume", .{err});
+        return true;
+    };
+
+    commitRecording(state, sels) catch |err| {
+        std.log.err("location recording: cannot take the recording into memory at launch ({})", .{err});
+        return true;
+    };
+
+    // `if !isLocationRecordingPaused { … startUpdatingLocation() }`. A paused
+    // recording is restored into memory and left alone, so `resume` finds it.
+    if (state.paused) return true;
+
+    const authorization = resolveAuthorization() catch |err| {
+        std.log.err("location recording: adopted the recording but cannot resolve authorization ({}); it will not collect until resumed", .{err});
+        return true;
+    };
+    const updates = UpdateSelectors.resolve(authorization) catch |err| {
+        std.log.err("location recording: adopted the recording but cannot resolve its selectors ({})", .{err});
+        return true;
+    };
+    const background = backgroundLocationDeclared() catch false;
+    const mgr = ensureManager() catch |err| {
+        std.log.err("location recording: adopted the recording but cannot build a CLLocationManager ({})", .{err});
+        return true;
+    };
+
+    // `.skip`: Swift's restore does not re-request authorization, and a
+    // permission prompt at launch is not something the page asked for.
+    applyUpdates(mgr, updates, background, .skip);
+    return true;
+}
+
+/// What a summary reply carries beyond the four common keys.
+const SummaryExtra = enum { none, with_locations, with_sample_count };
+
+/// The selectors `startUpdatingLocation` needs, plus the authorization request
+/// that precedes it.
+///
+/// Resolved as a set before any state changes, so the sequence that actually
+/// turns GPS on cannot fail halfway. `watchPosition` and the two recorder
+/// actions that start collecting all run the same four lines; keeping one copy
+/// is how they stay the same four lines.
+const UpdateSelectors = struct {
+    authorize: Id,
+    start: Id,
+    responds: Id,
+    allows_background: Id,
+    shows_indicator: Id,
+
+    fn resolve(authorization: Authorization) !UpdateSelectors {
+        const auth_selector_name: [*:0]const u8 = switch (authorization) {
+            .always => "requestAlwaysAuthorization",
+            .when_in_use => "requestWhenInUseAuthorization",
+        };
+        return .{
+            .authorize = try selector(auth_selector_name),
+            .start = try selector("startUpdatingLocation"),
+            .responds = try selector("respondsToSelector:"),
+            .allows_background = try selector("setAllowsBackgroundLocationUpdates:"),
+            .shows_indicator = try selector("setShowsBackgroundLocationIndicator:"),
+        };
+    }
+};
+
+/// Request authorization, configure background updates, and start the stream.
+///
+/// Infallible by construction: every selector was resolved by
+/// `UpdateSelectors.resolve` while an error was still deliverable.
+/// Whether the authorization prompt is part of the sequence.
+///
+/// Every page-initiated start requests it; `restoreLocationRecordingState` does
+/// not, because a recording being re-adopted was authorized when it started and
+/// a prompt at launch would be one the page never asked for.
+const Authorize = enum { request, skip };
+
+fn applyUpdates(mgr: *anyopaque, sels: UpdateSelectors, background: bool, authorize: Authorize) void {
+    if (authorize == .request) objc.msgSend(mgr, sels.authorize);
+
+    if (background) {
+        // `configureBackgroundLocationIfNeeded()`, under the guard that makes
+        // it safe. Both properties take the same value in Swift, and both are
+        // set to it here.
+        if (!setBoolIfSupported(mgr, sels.responds, sels.allows_background, true)) {
+            std.log.warn(
+                "location: this CLLocationManager has no allowsBackgroundLocationUpdates; " ++
+                    "updates will stop when the app is backgrounded even though UIBackgroundModes declares location",
+                .{},
+            );
+        }
+        // Purely the status-bar indicator. A manager without it is an OS too
+        // old for the property, not a broken subscription, so it is not worth a
+        // warning of its own.
+        _ = setBoolIfSupported(mgr, sels.responds, sels.shows_indicator, true);
+    }
+
+    objc.msgSend(mgr, sels.start);
+}
+
+/// Whether `stopUpdatingLocation` also clears `allowsBackgroundLocationUpdates`.
+///
+/// `pauseLocationRecording` stops the stream and leaves the property alone;
+/// `stopLocationRecording` and `stopWatchingPosition` clear it. Swift makes the
+/// same distinction, and it matters: a pause that dropped the property would
+/// need the app to be foregrounded to resume.
+const BackgroundOnStop = enum { keep_background, drop_background };
+
+/// Stop the shared manager, unless the watch is still using it.
+///
+/// The recorder's half of the arbitration `clearWatch` does in the other
+/// direction. Swift writes it as `if !isWatchingLocation { … }` in both
+/// `pauseLocationRecording` and `stopLocationRecording`.
+fn stopUpdatesUnlessWatched(comptime who: []const u8, mode: BackgroundOnStop) void {
+    if (!is_darwin) return;
+
+    if (watchHoldsTheManager()) {
+        std.log.info(
+            who ++ ": a watch is still using this manager; leaving it updating",
+            .{},
+        );
+        return;
+    }
+
+    const mgr = manager orelse return;
+
+    const sel_stop = selector("stopUpdatingLocation") catch return;
+    objc.msgSend(mgr, sel_stop);
+
+    if (mode == .drop_background) {
+        const sel_responds = selector("respondsToSelector:") catch return;
+        const sel_allows_background = selector("setAllowsBackgroundLocationUpdates:") catch return;
+        // Setting it to NO is safe in any process — only YES can raise.
+        _ = setBoolIfSupported(mgr, sel_responds, sel_allows_background, false);
+    }
+}
+
+/// Replace the recorder's state and its subscription in one lock.
+///
+/// `next.id` is **copied**, not adopted: callers hold their own snapshot for
+/// the reply, and an ownership hand-off across a mutex is the kind of detail
+/// that reads fine and frees twice.
+///
+/// The subscription follows the state rather than being set separately —
+/// collecting is exactly `active and !paused`, which is
+/// `appendRecordedLocation`'s guard — so there is no arrangement of these two
+/// variables in which the track and the summary disagree.
+fn commitRecording(next: locrec.State, sels: ?Sels) !void {
+    const collecting = next.active and !next.paused;
+    std.debug.assert(!collecting or sels != null);
+
+    const copy: ?[]const u8 = if (next.id) |id| try recording_allocator.dupe(u8, id) else null;
+    errdefer if (copy) |c| recording_allocator.free(c);
+
+    state_mutex.lock();
+    defer state_mutex.unlock();
+
+    if (recording.id) |old| recording_allocator.free(old);
+    recording = .{
+        .active = next.active,
+        .paused = next.paused,
+        .id = copy,
+        .started_at = next.started_at,
+    };
+    recording_sels = if (collecting) sels else null;
+}
+
+/// A copy of the recorder's state that outlives the lock.
+fn snapshotRecording(allocator: std.mem.Allocator) !locrec.State {
+    state_mutex.lock();
+    defer state_mutex.unlock();
+
+    return .{
+        .active = recording.active,
+        .paused = recording.paused,
+        .id = if (recording.id) |id| try allocator.dupe(u8, id) else null,
+        .started_at = recording.started_at,
+    };
+}
+
+/// `rejectCallback(callbackId, error: "No active location recording", code: "NO_ACTIVE_RECORDING")`.
+///
+/// The text and the code are both lost on the way through `BridgeError`, which
+/// carries an enum rather than a free-text channel — the same trade
+/// `bridge_mobile_misc.zig` and `bridge_mobile_watch.zig` document.
+/// `InvalidParameter` is the migration notes' designated stand-in, so the page
+/// gets `INVALID_PARAMETER` where Swift sent `NO_ACTIVE_RECORDING`. The
+/// rejection itself, which is the part a promise needs, is not lost.
+fn noActiveRecording() bridge_error.BridgeError {
+    std.log.warn(
+        "location recording: no active recording to pause or resume; rejecting, as Swift's NO_ACTIVE_RECORDING does",
+        .{},
+    );
+    return bridge_error.BridgeError.InvalidParameter;
+}
+
+/// `UUID().uuidString`, through `NSUUID` rather than a hand-rolled generator.
+///
+/// The id is opaque to the page — it is compared, not parsed — so what matters
+/// is that it is unique and that it comes from the same source Swift's does.
+/// Caller owns the result.
+fn newRecordingId(allocator: std.mem.Allocator) ![]u8 {
+    if (!is_darwin) return error.UnsupportedPlatform;
+
+    const NSUUID = objc.objc_getClass("NSUUID") orelse return error.ClassNotFound;
+    const sel_uuid = try selector("UUID");
+    const uuid = objc.msgSendId(NSUUID, sel_uuid) orelse return error.NativeCallFailed;
+
+    const text = readNSString(uuid, "UUIDString") orelse return error.NativeCallFailed;
+    return allocator.dupe(u8, text);
+}
+
+/// `Date().timeIntervalSince1970 * 1000`.
+///
+/// Milliseconds since the epoch as an `f64`, which is what the page compares
+/// against its own `Date.now()`. The wall clock, not the monotonic one, for the
+/// same reason Swift's is: it is a timestamp, not a duration.
+///
+/// `compat.milliTimestamp` rather than `std.time.milliTimestamp`, which 0.17
+/// removed — `bridge_mobile_biometric.zig` takes the same route. Swift's value
+/// carries sub-millisecond precision that this drops; the page compares it
+/// against `Date.now()`, whose resolution is coarser still.
+fn nowMillis() f64 {
+    return @floatFromInt(compat.milliTimestamp());
+}
 
 /// The answer for a full block pool, copied from `bridge_mobile_permissions`:
 /// `BridgeError` has no "Busy", INVALID_PARAMETER is the migration notes'
@@ -1116,6 +1635,32 @@ var watch_sels: ?Sels = null;
 /// not a guard.
 var state_mutex: compat_mutex.Mutex = .{};
 
+/// The recorder's four fields, kept where Swift keeps them.
+///
+/// `CraftWebView.Coordinator` holds `isRecordingLocation`,
+/// `isLocationRecordingPaused`, `locationRecordingId` and
+/// `locationRecordingStartedAt` in memory and mirrors them to disk on every
+/// transition; the file is read back only at launch. Answering
+/// `getLocationRecordingState` from memory rather than from the file is what
+/// makes a stop-then-read in one launch report the stopped recording's id,
+/// where a relaunch reports null — the divergence #124 records, reproduced here
+/// by keeping Swift's arrangement instead of improving on it.
+///
+/// `id` is owned, allocated from `std.heap.c_allocator`, and freed whenever it
+/// is replaced.
+var recording: locrec.State = .{};
+
+/// Non-null exactly while fixes belong in the track: active, and not paused.
+///
+/// The same shape `watch_sels` uses — the presence of the selectors *is* the
+/// subscription — so `didUpdateLocations` asks one question to learn both
+/// whether to append and which names to shape with.
+var recording_sels: ?Sels = null;
+
+/// The allocator behind `recording.id`. Module-level state outlives every
+/// dispatch frame, so it cannot borrow a bridge's allocator.
+const recording_allocator = std.heap.c_allocator;
+
 /// Record the call the delegate will answer, returning whatever it displaced so
 /// the caller can reject that one rather than drop it.
 fn publishPendingFix(ticket: ios_async.Ticket, sels: Sels) ?PendingFix {
@@ -1152,6 +1697,11 @@ const DelegateWork = struct {
     /// until `clearWatch` stops it. Clearing it here would deliver one event
     /// and then go silent with the page's callback still registered.
     watch: ?Sels,
+    /// Read and not cleared, for the same reason: a recording takes every fix
+    /// until it is paused or stopped. Null while paused, which is how
+    /// `appendRecordedLocation`'s `guard isRecordingLocation && !isLocationRecordingPaused`
+    /// is spelled here.
+    recording: ?Sels,
 };
 
 fn takeDelegateWork() DelegateWork {
@@ -1159,7 +1709,26 @@ fn takeDelegateWork() DelegateWork {
     defer state_mutex.unlock();
     const call = pending_fix;
     pending_fix = null;
-    return .{ .pending = call, .watch = watch_sels };
+    return .{ .pending = call, .watch = watch_sels, .recording = recording_sels };
+}
+
+/// Whether a recording is collecting right now.
+///
+/// `stopWatchingPosition`'s `if !isRecordingLocation` guard, which is the reason
+/// `clearWatch` cannot simply stop the manager any more: the recorder and the
+/// watch share one `CLLocationManager`, so whichever stops second is the one
+/// that stops it.
+fn recordingHoldsTheManager() bool {
+    state_mutex.lock();
+    defer state_mutex.unlock();
+    return recording_sels != null;
+}
+
+/// Whether a watch is running, for the recorder's half of the same guard.
+fn watchHoldsTheManager() bool {
+    state_mutex.lock();
+    defer state_mutex.unlock();
+    return watch_sels != null;
 }
 
 /// What `clearWatch` is stopping.
@@ -1219,9 +1788,11 @@ fn didUpdateLocations(_: Id, _: Id, _: Id, locations: Id) callconv(.c) void {
     const sels = blk: {
         if (work.pending) |call| break :blk call.sels;
         if (work.watch) |watching| break :blk watching;
+        if (work.recording) |collecting| break :blk collecting;
         // A fix for a call already answered, or one that arrived after the
-        // watch stopped. Nothing to reply to and nobody subscribed.
-        std.log.info("location: a fix arrived with no call waiting and no watch running; ignored", .{});
+        // watch stopped. Nothing to reply to, nobody subscribed, and no
+        // recording to write it to.
+        std.log.info("location: a fix arrived with no call waiting, no watch running and no recording; ignored", .{});
         return;
     };
 
@@ -1246,7 +1817,25 @@ fn didUpdateLocations(_: Id, _: Id, _: Id, locations: Id) callconv(.c) void {
     // to both. A page reading `e.detail.accuracy` and a page reading
     // `position.accuracy` are reading the same eight keys.
     if (work.pending) |call| ios_async.deliverJson(call.ticket, json);
-    if (work.watch != null) ios_events.emit(.location_update, json);
+
+    // Swift's order: `resolveCallback`, then `appendRecordedLocation(data)`,
+    // then the event. The track gets the same bytes the event carries, because
+    // Swift hands one dictionary to both — so a sample read back later is
+    // exactly the fix the page saw live.
+    //
+    // A failed append is logged inside and dropped here, which is
+    // `appendRecordedLocation`'s own `catch { print(…) }`. One lost sample must
+    // not cost the watch its event or the caller its reply.
+    if (work.recording != null) {
+        locrec.appendSample(allocator, json) catch {};
+    }
+
+    // `if isWatchingLocation || isRecordingLocation`, exactly. This is the
+    // guard that made a recording emit `craftLocationUpdate` even with no watch
+    // running — and, while the recorder lived in Swift and the watch lived
+    // here, the guard that fired *twice* for a page doing both. One manager
+    // again, one event per fix.
+    if (work.watch != null or work.recording != null) ios_events.emit(.location_update, json);
 }
 
 fn didFailWithError(_: Id, _: Id, _: Id, err_object: Id) callconv(.c) void {
@@ -1427,10 +2016,15 @@ fn readNSInteger(object: Id, comptime name: [*:0]const u8) c_long {
 const testing = std.testing;
 
 test "the declared actions are the ones the handler serves" {
-    try testing.expectEqual(@as(usize, 3), capability_actions.len);
+    try testing.expectEqual(@as(usize, 8), capability_actions.len);
     try testing.expectEqualStrings(A.get_current_position, capability_actions[0].name);
     try testing.expectEqualStrings(A.watch_position, capability_actions[1].name);
     try testing.expectEqualStrings(A.clear_watch, capability_actions[2].name);
+    try testing.expectEqualStrings(A.start_location_recording, capability_actions[3].name);
+    try testing.expectEqualStrings(A.pause_location_recording, capability_actions[4].name);
+    try testing.expectEqualStrings(A.resume_location_recording, capability_actions[5].name);
+    try testing.expectEqualStrings(A.stop_location_recording, capability_actions[6].name);
+    try testing.expectEqualStrings(A.get_location_recording_state, capability_actions[7].name);
 
     for (capability_actions) |decl| {
         // A `.result` whose handler never replies parks the caller on an untimed
@@ -1438,7 +2032,8 @@ test "the declared actions are the ones the handler serves" {
         // nothing. Both failure modes are invisible from the page. Swift
         // resolves all three of these, so all three are `.result` — including
         // `watchPosition`, whose `true` is about the subscribe having started,
-        // not about a fix having arrived.
+        // not about a fix having arrived, and the five recorder actions, each
+        // of which ends in exactly one `resolveCallback` or `rejectCallback`.
         try testing.expectEqual(capabilities.Reply.result, decl.reply);
         try testing.expectEqual(capabilities.ActionStatus.live, decl.status);
         // `.live` with a reason would be a contradiction the manifest shows to apps.
@@ -1561,15 +2156,12 @@ test "an action the namespace does not serve is reported, not ignored" {
         bridge_error.BridgeError.UnknownAction,
         bridge.handleMessage("getcurrentposition", "{}"),
     );
-    // The neighbouring recording actions belong to another module; two modules
-    // answering one action would make `ios_dispatch`'s first-match routing
-    // order-dependent.
+    // `readLocationRecording` is the one recording action that stays with
+    // `bridge_mobile_locrecording.zig`: it reads the track and touches neither
+    // the manager nor the lifecycle. Two modules answering one action would
+    // make `ios_dispatch`'s first-match routing order-dependent, so the split
+    // is asserted from this side as well as that one.
     for ([_][]const u8{
-        "startLocationRecording",
-        "pauseLocationRecording",
-        "resumeLocationRecording",
-        "stopLocationRecording",
-        "getLocationRecordingState",
         "readLocationRecording",
     }) |action| {
         try testing.expectError(

--- a/packages/zig/src/bridge_mobile_location.zig
+++ b/packages/zig/src/bridge_mobile_location.zig
@@ -792,7 +792,6 @@ pub const LocationBridge = struct {
     }
 };
 
-
 // =============================================================================
 // The recorder's shared machinery: the manager hand-off, the state commit, and
 // the two values Swift takes from Foundation.

--- a/packages/zig/src/bridge_mobile_location.zig
+++ b/packages/zig/src/bridge_mobile_location.zig
@@ -94,26 +94,26 @@
 //! running. A watch that hits an error has no reply left to reject — its
 //! `true` went out when it started — so the event is the only channel it has.
 //!
-//! **The recording side effect.** Swift's `didUpdateLocations` calls
+//! **The recording side effect, restored.** Swift's `didUpdateLocations` calls
 //! `appendRecordedLocation(data)` for *every* fix, including a one-shot
-//! `requestLocation`, so calling `getCurrentPosition` during an active
-//! recording appends one extra sample to the track that `readLocationRecording`
-//! later returns. This module has its own `CLLocationManager`, so that sample
-//! is no longer added. Arguably the more correct behaviour — a one-shot query
-//! is not part of a route — but it *is* a behaviour change, and a page counting
-//! samples will see one fewer.
+//! `requestLocation`, so a `getCurrentPosition` during an active recording
+//! appends one extra sample to the track. While the recorder was on the shim
+//! and this module had a manager of its own, that sample was no longer added —
+//! a behaviour change a page counting samples could see. The recorder now runs
+//! on this manager, so the one-shot's fix reaches the track again, exactly as
+//! it does in the spec.
 //!
-//! **One `craftLocationUpdate` per manager while a recording is running.** The
-//! six `*LocationRecording` actions stay with the shim
-//! (`bridge_mobile_locrecording.zig` serves only `readLocationRecording`), so a
-//! recording runs Swift's manager and Swift's `didUpdateLocations`, which fires
-//! `craftLocationUpdate` for every fix whenever `isRecordingLocation` is true —
-//! watch or no watch. A page that records *and* watches therefore has two
-//! managers feeding one event name, and its watch callback runs roughly twice
-//! as often as it did under a single shared manager. Every one of those events
-//! carries a real fix; none is fabricated and none is dropped. It is a
-//! duplication, it is visible to a page that counts samples, and it disappears
-//! when the recording actions migrate.
+//! **One `craftLocationUpdate` per fix, again.** A paragraph here used to
+//! record a duplication: the six `*LocationRecording` actions stayed with the
+//! shim, so a recording ran Swift's manager and Swift's `didUpdateLocations`,
+//! which fires `craftLocationUpdate` whenever `isRecordingLocation` is true —
+//! watch or no watch. A page that recorded *and* watched therefore had two
+//! managers feeding one event name and saw roughly two events per fix. It
+//! ended, as that paragraph predicted, when the recording actions migrated:
+//! five of the six now live in this file, on this manager, and the sixth reads
+//! a file. The emit guard below is Swift's own,
+//! `if isWatchingLocation || isRecordingLocation`, and one manager satisfies
+//! it once.
 //!
 //! The converse loss is gone rather than added to: a `getCurrentPosition`
 //! issued while *this* module's watch is running is broadcast to the watch
@@ -767,26 +767,7 @@ pub const LocationBridge = struct {
         var out: std.ArrayListUnmanaged(u8) = .empty;
         defer out.deinit(self.allocator);
 
-        try out.appendSlice(self.allocator, "{\"id\":");
-        if (snapshot.id) |id| {
-            try out.append(self.allocator, '"');
-            try bridge_error.appendJsonEscaped(self.allocator, &out, id);
-            try out.append(self.allocator, '"');
-        } else {
-            try out.appendSlice(self.allocator, "null");
-        }
-        try out.appendSlice(self.allocator, ",\"active\":");
-        try out.appendSlice(self.allocator, if (snapshot.active) "true" else "false");
-        try out.appendSlice(self.allocator, ",\"paused\":");
-        try out.appendSlice(self.allocator, if (snapshot.paused) "true" else "false");
-        try out.appendSlice(self.allocator, ",\"startedAt\":");
-        if (snapshot.started_at) |started| {
-            const rendered = try std.fmt.allocPrint(self.allocator, "{d}", .{started});
-            defer self.allocator.free(rendered);
-            try out.appendSlice(self.allocator, rendered);
-        } else {
-            try out.appendSlice(self.allocator, "null");
-        }
+        try appendSummaryFields(self.allocator, &out, snapshot);
 
         switch (extra) {
             .none => {},
@@ -892,6 +873,43 @@ pub fn adoptRecording() bool {
     // permission prompt at launch is not something the page asked for.
     applyUpdates(mgr, updates, background, .skip);
     return true;
+}
+
+/// `locationRecordingSummary()`: the four keys, in Swift's order.
+///
+/// Split out from the reply so the shape is pinnable without a
+/// `CLLocationManager` — the keys, their order, and the two that are `NSNull`
+/// on the wire rather than empty strings or zeroes.
+///
+/// Writes the opening brace and the four keys, and **leaves the object open**:
+/// `stopLocationRecording` and `getLocationRecordingState` each add one more
+/// key, and the caller closes it.
+fn appendSummaryFields(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    state: locrec.State,
+) !void {
+    try out.appendSlice(allocator, "{\"id\":");
+    if (state.id) |id| {
+        // `appendJsonEscaped` writes no delimiters; the quotes are the caller's.
+        try out.append(allocator, '"');
+        try bridge_error.appendJsonEscaped(allocator, out, id);
+        try out.append(allocator, '"');
+    } else {
+        try out.appendSlice(allocator, "null");
+    }
+    try out.appendSlice(allocator, ",\"active\":");
+    try out.appendSlice(allocator, if (state.active) "true" else "false");
+    try out.appendSlice(allocator, ",\"paused\":");
+    try out.appendSlice(allocator, if (state.paused) "true" else "false");
+    try out.appendSlice(allocator, ",\"startedAt\":");
+    if (state.started_at) |started| {
+        const rendered = try std.fmt.allocPrint(allocator, "{d}", .{started});
+        defer allocator.free(rendered);
+        try out.appendSlice(allocator, rendered);
+    } else {
+        try out.appendSlice(allocator, "null");
+    }
 }
 
 /// What a summary reply carries beyond the four common keys.
@@ -2857,4 +2875,139 @@ test "the delegate class registers under its own name, idempotently" {
     const sel_auth = objc.sel_registerName("locationManagerDidChangeAuthorization:") orelse
         return error.SelectorNotFound;
     try testing.expect(!responds(first, sel_responds, sel_auth));
+}
+
+// =============================================================================
+// The recorder.
+//
+// Two claims are worth pinning without a CLLocationManager: the summary's
+// shape, which is what every one of the five replies with, and the arbitration
+// between the watch and the recorder, which is the pair of guards that stop one
+// from ending the other's stream.
+// =============================================================================
+
+/// Leave the module-level recorder state as the tests found it.
+///
+/// These tests mutate process-wide state that the delegate also reads, so each
+/// one puts it back — an escaped `active` recording would make a later test's
+/// `didUpdateLocations` try to append to a track that is not there.
+fn resetRecordingForTest() void {
+    commitRecording(.{}, null) catch {};
+    state_mutex.lock();
+    defer state_mutex.unlock();
+    watch_sels = null;
+}
+
+test "the summary is the four keys in Swift's order" {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(testing.allocator);
+
+    try appendSummaryFields(testing.allocator, &out, .{
+        .active = true,
+        .paused = false,
+        .id = "ABC-123",
+        .started_at = 1756900000000,
+    });
+
+    // No closing brace: `stopLocationRecording` and `getLocationRecordingState`
+    // add a fifth key after these four, so the caller closes the object.
+    try testing.expectEqualStrings(
+        \\{"id":"ABC-123","active":true,"paused":false,"startedAt":1756900000000
+    , out.items);
+}
+
+test "a recording that never started reports nulls, not empty strings or zeroes" {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    defer out.deinit(testing.allocator);
+
+    // `locationRecordingSummary()` puts `NSNull` in both slots, and
+    // `resolveCallback` serialises that as `null`. A page testing
+    // `state.id === null` has to keep working.
+    try appendSummaryFields(testing.allocator, &out, .{});
+
+    try testing.expectEqualStrings(
+        \\{"id":null,"active":false,"paused":false,"startedAt":null
+    , out.items);
+}
+
+test "the subscription follows the state, so the track and the summary cannot disagree" {
+    defer resetRecordingForTest();
+
+    // Collecting is exactly `active and !paused` — `appendRecordedLocation`'s
+    // own guard — and `recording_sels` is how `didUpdateLocations` reads it.
+    const sels = Sels.resolve() catch return error.SkipZigTest;
+
+    try commitRecording(.{ .active = true, .paused = false, .id = "r1" }, sels);
+    try testing.expect(recordingHoldsTheManager());
+
+    try commitRecording(.{ .active = true, .paused = true, .id = "r1" }, null);
+    try testing.expect(!recordingHoldsTheManager());
+
+    try commitRecording(.{ .active = false, .paused = false, .id = "r1" }, null);
+    try testing.expect(!recordingHoldsTheManager());
+}
+
+test "a stop keeps the id and startedAt, which is why a relaunch differs from a stop" {
+    defer resetRecordingForTest();
+
+    const sels = Sels.resolve() catch return error.SkipZigTest;
+    try commitRecording(.{ .active = true, .id = "r1", .started_at = 42 }, sels);
+
+    // `stopLocationRecording` clears neither, so a read in the same launch
+    // still reports them. Only a relaunch — where `readState`'s guard runs —
+    // answers null. The two halves of #124's third blocker, from this side.
+    try commitRecording(.{ .active = false, .id = "r1", .started_at = 42 }, null);
+
+    var snapshot = try snapshotRecording(testing.allocator);
+    defer snapshot.deinit(testing.allocator);
+
+    try testing.expect(!snapshot.active);
+    try testing.expectEqualStrings("r1", snapshot.id.?);
+    try testing.expectEqual(@as(f64, 42), snapshot.started_at.?);
+}
+
+test "the watch and the recorder each hold the shared manager against the other" {
+    defer resetRecordingForTest();
+
+    const sels = Sels.resolve() catch return error.SkipZigTest;
+
+    // `stopWatchingPosition`'s `if !isRecordingLocation`, and its mirror in
+    // `pauseLocationRecording` / `stopLocationRecording`. Before the recorder
+    // moved here neither guard could fail, because the two runtimes owned
+    // different managers; now one manager serves both and whichever finishes
+    // second must not end the other's stream.
+    try testing.expect(!recordingHoldsTheManager());
+    try testing.expect(!watchHoldsTheManager());
+
+    try commitRecording(.{ .active = true, .id = "r1" }, sels);
+    publishWatch(sels);
+    try testing.expect(recordingHoldsTheManager());
+    try testing.expect(watchHoldsTheManager());
+
+    // The watch stops: the recorder is still collecting, so the manager stays.
+    _ = takeWatchAndPending();
+    try testing.expect(!watchHoldsTheManager());
+    try testing.expect(recordingHoldsTheManager());
+
+    // And the recorder stops last, with nothing left holding it.
+    try commitRecording(.{ .active = false, .id = "r1" }, null);
+    try testing.expect(!recordingHoldsTheManager());
+}
+
+test "a paused recording is not a consumer, so its fixes are not written" {
+    defer resetRecordingForTest();
+
+    const sels = Sels.resolve() catch return error.SkipZigTest;
+    try commitRecording(.{ .active = true, .paused = true, .id = "r1" }, null);
+
+    // `didUpdateLocations` reads one thing to decide both whether to append and
+    // which names to shape with. A paused recording must not appear in it.
+    const work = takeDelegateWork();
+    try testing.expect(work.recording == null);
+    try testing.expect(work.watch == null);
+    try testing.expect(work.pending == null);
+
+    // And resuming puts it back.
+    try commitRecording(.{ .active = true, .paused = false, .id = "r1" }, sels);
+    try testing.expect(takeDelegateWork().recording != null);
 }

--- a/packages/zig/src/bridge_mobile_locrecording.zig
+++ b/packages/zig/src/bridge_mobile_locrecording.zig
@@ -852,6 +852,24 @@ fn appendSampleTo(allocator: std.mem.Allocator, path: []const u8, sample_json: [
     };
 }
 
+/// Every sample as the bare JSON array `readLocationRecording` resolves.
+///
+/// `stopLocationRecording` puts this same array under a `locations` key
+/// (`CraftApp.swift:3264-3267`), so the two actions cannot disagree about which
+/// lines survive: they call the same reader.
+///
+/// Caller owns the result. A missing track is `[]`.
+pub fn readTrackArray(allocator: std.mem.Allocator) ![]u8 {
+    const path = try trackFilePath(allocator);
+    defer allocator.free(path);
+
+    const text = try readTrackBytes(allocator, path) orelse
+        return allocator.dupe(u8, empty_array);
+    defer allocator.free(text);
+
+    return shapeRecording(allocator, text);
+}
+
 /// How many samples `readLocationRecording` would return.
 ///
 /// `getLocationRecordingState` reports `loadRecordedLocations().count`

--- a/packages/zig/src/bridge_mobile_locrecording.zig
+++ b/packages/zig/src/bridge_mobile_locrecording.zig
@@ -589,6 +589,485 @@ fn readTrackBytes(allocator: std.mem.Allocator, path: []const u8) !?[]u8 {
 }
 
 // =============================================================================
+// The on-disk format of a recording.
+//
+// `bridge_mobile_location.zig` owns the `CLLocationManager`, the delegate and
+// the lifecycle; it calls in here for every byte that reaches the disk. The
+// dependency runs one way — nothing in this file imports that one — because a
+// recording really is what `CraftWebView.Coordinator` makes it: a flag on the
+// shared delegate plus two files. This is the half with a format to get wrong.
+//
+// Both files keep Swift's names, Swift's location and Swift's key spellings, so
+// a build with the Zig recorder removed reads back a recording this one wrote.
+// That is not hypothetical tidiness: `restoreLocationRecordingState` is still
+// in the template and still runs whenever the adoption export is absent.
+// =============================================================================
+
+/// The lifecycle mirror, beside the track. `CraftApp.swift:3156-3159`.
+const state_file_name = "craft-location-recording-state.json";
+
+/// The absolute path of `<AppSupport>/craft-location-recording-state.json`.
+fn stateFilePath(allocator: std.mem.Allocator) ![]u8 {
+    const directory = try applicationSupportPath(allocator);
+    defer allocator.free(directory);
+
+    return std.fmt.allocPrint(allocator, "{s}/" ++ state_file_name, .{directory});
+}
+
+/// The largest state file worth reading. The document is four scalars; anything
+/// approaching this is not a state file, and reading it into memory to discover
+/// that is the wrong order.
+const max_state_bytes: u64 = 64 * 1024;
+
+/// What `persistLocationRecordingState` writes and `restoreLocationRecordingState`
+/// reads back, with the same four keys and the same types.
+///
+/// `started_at` is milliseconds — `Date().timeIntervalSince1970 * 1000`
+/// (`CraftApp.swift:3222`) — and stays an `f64` the whole way, because that is
+/// what Swift wrote and rounding it to an integer here would change a value the
+/// page compares against its own `Date.now()`.
+pub const State = struct {
+    active: bool = false,
+    paused: bool = false,
+    /// Owned by the `State`. Null is `NSNull` on the wire, which is what a
+    /// recording that has never started has.
+    id: ?[]const u8 = null,
+    started_at: ?f64 = null,
+
+    pub fn deinit(self: *State, allocator: std.mem.Allocator) void {
+        if (self.id) |id| allocator.free(id);
+        self.id = null;
+    }
+};
+
+/// Read the persisted state, applying `restoreLocationRecordingState`'s own guard.
+///
+/// Swift opens with
+/// `guard … state["active"] as? Bool == true else { return }`
+/// (`CraftApp.swift:3197-3201`), and every `return` there leaves the four
+/// instance variables at their defaults. So a file that says `active:false` —
+/// which is exactly what a *stopped* recording leaves behind, `id` and
+/// `startedAt` still populated — restores as nothing at all.
+///
+/// That guard is the whole reason this returns a `State` rather than the file's
+/// contents. A reader that handed back the stopped recording's `id` would
+/// answer `{"id":"ABC-…"}` where Swift answers `{"id":null}`, which was one of
+/// the three blockers recorded against migrating this recorder (#124). It is a
+/// rule, and this is the rule, ported rather than approximated.
+///
+/// A missing file is `.{}`, not an error: there has never been a recording.
+pub fn readState(allocator: std.mem.Allocator) !State {
+    const path = try stateFilePath(allocator);
+    defer allocator.free(path);
+    return readStateFrom(allocator, path);
+}
+
+/// `readState` against a named file, so the guard above is testable without a
+/// test writing into `~/Library/Application Support`.
+fn readStateFrom(allocator: std.mem.Allocator, path: []const u8) !State {
+    const bytes = (try readSmallFile(allocator, path, max_state_bytes)) orelse return .{};
+    defer allocator.free(bytes);
+
+    // `JSONSerialization.jsonObject` throwing, or the cast to `[String: Any]`
+    // failing, both land on Swift's `else { return }`. Unreadable state is no
+    // state, not an error — the recording is gone either way, and saying so
+    // beats refusing every later call because one file is torn.
+    return decodeState(allocator, bytes) catch |err| {
+        std.log.warn(
+            "location recording: state file at '{s}' is unreadable ({}); treating it as no recording, exactly as restoreLocationRecordingState's guard does",
+            .{ path, err },
+        );
+        return .{};
+    };
+}
+
+/// The guard and the four reads, with no file anywhere near them.
+fn decodeState(allocator: std.mem.Allocator, bytes: []const u8) !State {
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, bytes, .{}) catch {
+        return .{};
+    };
+    defer parsed.deinit();
+
+    const object = switch (parsed.value) {
+        .object => |o| o,
+        else => return .{},
+    };
+
+    // `as? Bool == true`: a missing key, a null, a number, a string all fail
+    // the cast and land on the same `return`.
+    const active = switch (object.get("active") orelse return .{}) {
+        .bool => |b| b,
+        else => return .{},
+    };
+    if (!active) return .{};
+
+    var state: State = .{ .active = true };
+    errdefer state.deinit(allocator);
+
+    // Past the guard, Swift's reads are `as? Bool ?? false` and `as? String` /
+    // `as? TimeInterval`, so a wrong type here is a default rather than a
+    // refusal.
+    if (object.get("paused")) |value| {
+        state.paused = switch (value) {
+            .bool => |b| b,
+            else => false,
+        };
+    }
+    if (object.get("id")) |value| {
+        switch (value) {
+            .string => |s| state.id = try allocator.dupe(u8, s),
+            else => {},
+        }
+    }
+    if (object.get("startedAt")) |value| {
+        state.started_at = switch (value) {
+            .float => |f| f,
+            .integer => |i| @floatFromInt(i),
+            else => null,
+        };
+    }
+
+    return state;
+}
+
+/// Mirror the lifecycle to disk, atomically, then protect the file.
+///
+/// `persistLocationRecordingState` (`CraftApp.swift:3179-3195`) writes all four
+/// keys every time, with `.atomic`, and then re-applies protection. Each of
+/// those three is load-bearing and each is done here.
+///
+/// Unlike Swift, a failure is **returned**. Swift catches and prints, so memory
+/// and file drift with nothing to signal it — a divergence its own recorder
+/// comment calls out. A caller here can refuse the action instead of reporting
+/// a recording that was never persisted.
+pub fn writeState(allocator: std.mem.Allocator, state: State) !void {
+    const path = try stateFilePath(allocator);
+    defer allocator.free(path);
+
+    const bytes = try encodeState(allocator, state);
+    defer allocator.free(bytes);
+
+    try writeFileAtomic(allocator, path, bytes);
+    protectFile(path);
+}
+
+/// The four keys, in `persistLocationRecordingState`'s spelling.
+fn encodeState(allocator: std.mem.Allocator, state: State) ![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(allocator);
+
+    try out.appendSlice(allocator, "{\"active\":");
+    try out.appendSlice(allocator, if (state.active) "true" else "false");
+    try out.appendSlice(allocator, ",\"paused\":");
+    try out.appendSlice(allocator, if (state.paused) "true" else "false");
+    try out.appendSlice(allocator, ",\"id\":");
+    if (state.id) |id| {
+        // `appendJsonEscaped` escapes the contents and writes no delimiters, so
+        // the quotes are this caller's job. Without them an id containing a
+        // quote does not merely look wrong — it tears the document, and the
+        // whole recording reads back as none.
+        try out.append(allocator, '"');
+        try bridge_error.appendJsonEscaped(allocator, &out, id);
+        try out.append(allocator, '"');
+    } else {
+        try out.appendSlice(allocator, "null");
+    }
+    try out.appendSlice(allocator, ",\"startedAt\":");
+    if (state.started_at) |started| {
+        // `allocPrint`, not a stack buffer: an `f64` rendered with `{d}` can
+        // need 347 bytes, and a `NoSpaceLeft` here would lose a live recording
+        // to a formatting detail. Growing the allocation cannot overflow.
+        const rendered = try std.fmt.allocPrint(allocator, "{d}", .{started});
+        defer allocator.free(rendered);
+        try out.appendSlice(allocator, rendered);
+    } else {
+        try out.appendSlice(allocator, "null");
+    }
+    try out.appendSlice(allocator, "}");
+
+    return out.toOwnedSlice(allocator);
+}
+
+/// Start a fresh track, replacing whatever the last recording left.
+///
+/// `startLocationRecording` writes an empty `Data()` with `.atomic` before it
+/// touches any state (`CraftApp.swift:3213-3220`), so a new recording never
+/// inherits the previous route's samples, and a failure refuses the start
+/// rather than recording into the old file.
+pub fn resetTrack(allocator: std.mem.Allocator) !void {
+    const path = try trackFilePath(allocator);
+    defer allocator.free(path);
+
+    try writeFileAtomic(allocator, path, "");
+    protectFile(path);
+}
+
+/// Append one already-shaped sample object, with the newline that separates it.
+///
+/// `appendRecordedLocation` (`CraftApp.swift:3288-3302`) opens the track, seeks
+/// to the end and writes the JSON plus `0x0A`. `length` + `writePositionalAll`
+/// is that pair, and it is the reason this is not a read-modify-write: a route
+/// of 176,000 fixes rewritten once per second is not a recorder.
+///
+/// The sample arrives as bytes that `didUpdateLocations` already shaped for the
+/// page, so the track holds exactly what the event carried. Nothing is
+/// reparsed, and nothing can be rounded on the way in.
+pub fn appendSample(allocator: std.mem.Allocator, sample_json: []const u8) !void {
+    const path = try trackFilePath(allocator);
+    defer allocator.free(path);
+    return appendSampleTo(allocator, path, sample_json);
+}
+
+/// `appendSample` against a named track.
+fn appendSampleTo(allocator: std.mem.Allocator, path: []const u8, sample_json: []const u8) !void {
+    const io = io_context.get();
+
+    // Swift's `FileHandle(forWritingTo:)` throws when the file is not there,
+    // and its `catch` prints and drops the sample. Opening write-only without
+    // creating keeps that: a track that does not exist means no recording is
+    // running, and creating one here would start a route nobody asked for.
+    const file = std.Io.Dir.cwd().openFile(io, path, .{ .mode = .write_only }) catch |err| {
+        std.log.warn(
+            "location recording: could not open the track at '{s}' to append a sample ({}); the fix is lost",
+            .{ path, err },
+        );
+        return bridge_error.BridgeError.NativeCallFailed;
+    };
+    defer file.close(io);
+
+    const end = file.length(io) catch |err| {
+        std.log.warn("location recording: could not measure the track at '{s}' ({})", .{ path, err });
+        return bridge_error.BridgeError.NativeCallFailed;
+    };
+
+    // One write, not two. A sample and its newline that reach the file
+    // separately can be torn apart by a kill between them, and a half-written
+    // line is the one thing the reader has to throw away.
+    const line = try std.fmt.allocPrint(allocator, "{s}\n", .{sample_json});
+    defer allocator.free(line);
+
+    file.writePositionalAll(io, line, end) catch |err| {
+        std.log.warn("location recording: could not append to the track at '{s}' ({})", .{ path, err });
+        return bridge_error.BridgeError.NativeCallFailed;
+    };
+}
+
+/// How many samples `readLocationRecording` would return.
+///
+/// `getLocationRecordingState` reports `loadRecordedLocations().count`
+/// (`CraftApp.swift:3274`), so this has to agree with the reader line for line
+/// — the same blank-line and non-object drops — or the page is told it has a
+/// number of fixes it cannot then read back.
+pub fn sampleCount(allocator: std.mem.Allocator) !usize {
+    const path = try trackFilePath(allocator);
+    defer allocator.free(path);
+    return countSamplesIn(allocator, path);
+}
+
+/// `sampleCount` against a named track.
+fn countSamplesIn(allocator: std.mem.Allocator, path: []const u8) !usize {
+    const bytes = (try readTrackBytes(allocator, path)) orelse return 0;
+    defer allocator.free(bytes);
+
+    var count: usize = 0;
+    var lines = std.mem.splitScalar(u8, bytes, '\n');
+    while (lines.next()) |line| {
+        if (line.len == 0) continue;
+        if (try lineIsJsonObject(allocator, line)) count += 1;
+    }
+    return count;
+}
+
+/// Read a small file whole, or null when it is not there.
+fn readSmallFile(allocator: std.mem.Allocator, path: []const u8, ceiling: u64) !?[]u8 {
+    const io = io_context.get();
+
+    const file = std.Io.Dir.cwd().openFile(io, path, .{}) catch |err| switch (err) {
+        error.FileNotFound => return null,
+        else => {
+            std.log.warn("location recording: could not open '{s}': {}", .{ path, err });
+            return bridge_error.BridgeError.NativeCallFailed;
+        },
+    };
+    defer file.close(io);
+
+    const size = file.length(io) catch |err| {
+        std.log.warn("location recording: could not measure '{s}': {}", .{ path, err });
+        return bridge_error.BridgeError.NativeCallFailed;
+    };
+    if (size > ceiling) {
+        std.log.warn(
+            "location recording: '{s}' is {d} bytes, over the {d}-byte ceiling; refusing to read it",
+            .{ path, size, ceiling },
+        );
+        return bridge_error.BridgeError.NativeCallFailed;
+    }
+
+    const buf = try allocator.alloc(u8, @intCast(size));
+    errdefer allocator.free(buf);
+
+    var read: usize = 0;
+    while (read < buf.len) {
+        const n = file.readStreaming(io, &.{buf[read..]}) catch |err| switch (err) {
+            error.EndOfStream => break,
+            else => {
+                std.log.warn("location recording: could not read '{s}': {}", .{ path, err });
+                return bridge_error.BridgeError.NativeCallFailed;
+            },
+        };
+        if (n == 0) break;
+        read += n;
+    }
+
+    return buf[0..read];
+}
+
+/// Write `bytes` to `path` so that a reader sees either the old file or the
+/// whole new one, never a half-written document.
+///
+/// This is what `Data.write(options: .atomic)` does — a sibling temp file and a
+/// rename — and it matters for the same reason it does there: the state file is
+/// read at launch, and a launch that lands mid-write would restore a torn
+/// recording.
+fn writeFileAtomic(allocator: std.mem.Allocator, path: []const u8, bytes: []const u8) !void {
+    const io = io_context.get();
+
+    const temp_path = try std.fmt.allocPrint(allocator, "{s}.tmp", .{path});
+    defer allocator.free(temp_path);
+
+    {
+        const file = std.Io.Dir.cwd().createFile(io, temp_path, .{}) catch |err| {
+            std.log.warn("location recording: could not create '{s}': {}", .{ temp_path, err });
+            return bridge_error.BridgeError.NativeCallFailed;
+        };
+        defer file.close(io);
+
+        file.writeStreamingAll(io, bytes) catch |err| {
+            std.log.warn("location recording: could not write '{s}': {}", .{ temp_path, err });
+            return bridge_error.BridgeError.NativeCallFailed;
+        };
+    }
+
+    const dir = std.Io.Dir.cwd();
+    std.Io.Dir.rename(dir, temp_path, dir, path, io) catch |err| {
+        std.log.warn("location recording: could not move '{s}' into place at '{s}': {}", .{ temp_path, path, err });
+        // A temp file left behind is litter; a temp file left behind *and*
+        // reported as success is a recording nobody can find.
+        std.Io.Dir.deleteFile(dir, io, temp_path) catch {};
+        return bridge_error.BridgeError.NativeCallFailed;
+    };
+}
+
+/// Apply `protectLocationFile`'s two attributes: data protection, and exclusion
+/// from backup. `CraftApp.swift:3304-3311`.
+///
+/// Best effort, and deliberately so — Swift's are both `try?`. A route that
+/// records is better than a route refused because one attribute would not
+/// stick, and the two failures differ in kind: without protection the file is
+/// readable before first unlock, without the backup flag it leaves the device
+/// in an iCloud backup. Both are logged by name so neither is silent.
+///
+/// Off Darwin this does nothing and says nothing: there is no data protection
+/// to apply, and the host tests write their fixtures into the working
+/// directory.
+fn protectFile(path: []const u8) void {
+    if (!is_darwin) return;
+
+    const ns_path = makeNSString(path) orelse {
+        std.log.warn("location recording: could not make an NSString for '{s}'; file attributes not applied", .{path});
+        return;
+    };
+
+    setProtection(ns_path, path);
+    excludeFromBackup(ns_path, path);
+}
+
+/// `NSFileProtectionKey` → `NSFileProtectionCompleteUntilFirstUserAuthentication`.
+///
+/// Both names are `extern NSString * const`, so their values are not in any
+/// header and are read out of whatever loaded Foundation rather than spelled
+/// out here — the same `dlsym` route `bestAccuracy` takes in
+/// `bridge_mobile_location.zig`.
+fn setProtection(ns_path: Id, path: []const u8) void {
+    const key = nsStringConstant("NSFileProtectionKey") orelse {
+        std.log.warn("location recording: NSFileProtectionKey is not in this process; '{s}' is unprotected", .{path});
+        return;
+    };
+    const value = nsStringConstant("NSFileProtectionCompleteUntilFirstUserAuthentication") orelse {
+        std.log.warn("location recording: NSFileProtectionCompleteUntilFirstUserAuthentication is not in this process; '{s}' is unprotected", .{path});
+        return;
+    };
+
+    const NSDictionary = objc.objc_getClass("NSDictionary") orelse return;
+    const sel_dict = objc.sel_registerName("dictionaryWithObject:forKey:") orelse return;
+    const attributes = objc.msgSendId2(NSDictionary, sel_dict, value, key) orelse return;
+
+    const NSFileManager = objc.objc_getClass("NSFileManager") orelse return;
+    const sel_default = objc.sel_registerName("defaultManager") orelse return;
+    const manager = objc.msgSendId(NSFileManager, sel_default) orelse return;
+
+    const sel_set = objc.sel_registerName("setAttributes:ofItemAtPath:error:") orelse return;
+    const SetFn = *const fn (Id, Id, Id, Id, ?*anyopaque) callconv(.c) bool;
+    const set: SetFn = @ptrCast(&objc.objc_msgSend);
+
+    if (!set(manager, sel_set, attributes, ns_path, null)) {
+        std.log.warn("location recording: setAttributes: refused for '{s}'; the file is readable before first unlock", .{path});
+    }
+}
+
+/// `NSURLIsExcludedFromBackupKey` = YES, via `NSURL`.
+fn excludeFromBackup(ns_path: Id, path: []const u8) void {
+    const key = nsStringConstant("NSURLIsExcludedFromBackupKey") orelse {
+        std.log.warn("location recording: NSURLIsExcludedFromBackupKey is not in this process; '{s}' will be backed up", .{path});
+        return;
+    };
+
+    const NSURL = objc.objc_getClass("NSURL") orelse return;
+    const sel_file_url = objc.sel_registerName("fileURLWithPath:") orelse return;
+    const url = objc.msgSendId1(NSURL, sel_file_url, ns_path) orelse return;
+
+    const NSNumber = objc.objc_getClass("NSNumber") orelse return;
+    const sel_with_bool = objc.sel_registerName("numberWithBool:") orelse return;
+    const WithBoolFn = *const fn (Id, Id, bool) callconv(.c) Id;
+    const with_bool: WithBoolFn = @ptrCast(&objc.objc_msgSend);
+    const yes = with_bool(NSNumber, sel_with_bool, true) orelse return;
+
+    const sel_set = objc.sel_registerName("setResourceValue:forKey:error:") orelse return;
+    const SetFn = *const fn (Id, Id, Id, Id, ?*anyopaque) callconv(.c) bool;
+    const set: SetFn = @ptrCast(&objc.objc_msgSend);
+
+    if (!set(url, sel_set, yes, key, null)) {
+        std.log.warn("location recording: setResourceValue: refused for '{s}'; the recording will be included in backups", .{path});
+    }
+}
+
+/// Read an `extern NSString * const` out of the loaded frameworks.
+///
+/// The symbol is the *cell*, not the string: dereference it to get the object.
+fn nsStringConstant(name: [*:0]const u8) ?Id {
+    const symbol = dlsym(RTLD_DEFAULT, name) orelse return null;
+    const cell: *const Id = @ptrCast(@alignCast(symbol));
+    return cell.*;
+}
+
+extern "c" fn dlsym(handle: ?*anyopaque, symbol: [*:0]const u8) ?*anyopaque;
+
+/// dyld's "search every image" pseudo-handle, (void *)-2 on Darwin.
+const RTLD_DEFAULT: ?*anyopaque = @ptrFromInt(@as(usize, @bitCast(@as(isize, -2))));
+
+/// An autoreleased `NSString` for a Zig slice, via `stringWithUTF8String:`.
+fn makeNSString(text: []const u8) ?Id {
+    var buf: [std.fs.max_path_bytes + 1]u8 = undefined;
+    if (text.len >= buf.len) return null;
+    @memcpy(buf[0..text.len], text);
+    buf[text.len] = 0;
+
+    const NSString = objc.objc_getClass("NSString") orelse return null;
+    const sel = objc.sel_registerName("stringWithUTF8String:") orelse return null;
+    return objc.msgSendId1(NSString, sel, @as([*:0]const u8, @ptrCast(&buf)));
+}
+
+// =============================================================================
 // Tests.
 //
 // Everything that decides what the page sees is pure and pinned here: routing
@@ -1181,4 +1660,228 @@ test "with no recording on the host, the handler answers rather than failing" {
     defer bridge.deinit();
 
     try bridge.handleMessage(A.read_location_recording, "{}");
+}
+
+// =============================================================================
+// The on-disk format.
+//
+// The guard in `decodeState` is the one that closes the third of the three
+// blockers #124 lists, so it is pinned from both sides: a stopped recording's
+// leftovers must read back as nothing, and a live one must read back whole.
+// Everything here runs against bytes or against a file this test owns; nothing
+// touches `~/Library/Application Support`.
+// =============================================================================
+
+const test_state_name = "craft-locrecording-test-state.json";
+
+fn writeTestFile(name: []const u8, contents: []const u8) !void {
+    const io = io_context.get();
+    const file = try std.Io.Dir.cwd().createFile(io, name, .{});
+    defer file.close(io);
+    try file.writeStreamingAll(io, contents);
+}
+
+fn removeTestFile(name: []const u8) void {
+    std.Io.Dir.cwd().deleteFile(io_context.get(), name) catch |err| {
+        std.log.debug("locrecording test file cleanup failed: {}", .{err});
+    };
+}
+
+test "a stopped recording's leftovers read back as no recording at all" {
+    // The exact divergence #124's third blocker names. `stopLocationRecording`
+    // sets `active:false` but leaves `id` and `startedAt` in the file, and
+    // Swift's `guard state["active"] as? Bool == true else { return }` means a
+    // relaunch after a stop restores nothing. A reader that handed back the id
+    // would answer `{"id":"ABC-123"}` where Swift answers `{"id":null}`.
+    var state = try decodeState(
+        testing.allocator,
+        \\{"active":false,"paused":false,"id":"ABC-123","startedAt":1756900000000}
+    );
+    defer state.deinit(testing.allocator);
+
+    try testing.expect(!state.active);
+    try testing.expect(!state.paused);
+    try testing.expect(state.id == null);
+    try testing.expect(state.started_at == null);
+}
+
+test "an active recording restores all four fields" {
+    var state = try decodeState(
+        testing.allocator,
+        \\{"active":true,"paused":true,"id":"ABC-123","startedAt":1756900000000}
+    );
+    defer state.deinit(testing.allocator);
+
+    try testing.expect(state.active);
+    try testing.expect(state.paused);
+    try testing.expectEqualStrings("ABC-123", state.id.?);
+    try testing.expectEqual(@as(f64, 1756900000000), state.started_at.?);
+}
+
+test "the active guard is a Bool cast, not a truthiness test" {
+    // `as? Bool` fails for each of these, and every failure lands on the same
+    // `return`. A JSON reader that coerced would restore a recording Swift
+    // does not.
+    const not_bools = [_][]const u8{
+        \\{"active":"true","id":"ABC","startedAt":1}
+        ,
+        \\{"active":1,"id":"ABC","startedAt":1}
+        ,
+        \\{"active":null,"id":"ABC","startedAt":1}
+        ,
+        \\{"paused":false,"id":"ABC","startedAt":1}
+        ,
+        \\["active",true]
+        ,
+        \\not json at all
+        ,
+    };
+
+    for (not_bools) |document| {
+        var state = try decodeState(testing.allocator, document);
+        defer state.deinit(testing.allocator);
+        try testing.expect(!state.active);
+        try testing.expect(state.id == null);
+        try testing.expect(state.started_at == null);
+    }
+}
+
+test "past the guard a wrong type is a default, not a refusal" {
+    // Swift's remaining reads are `as? Bool ?? false`, `as? String` and
+    // `as? TimeInterval`, all of which degrade rather than throw.
+    var state = try decodeState(
+        testing.allocator,
+        \\{"active":true,"paused":"yes","id":42,"startedAt":"soon"}
+    );
+    defer state.deinit(testing.allocator);
+
+    try testing.expect(state.active);
+    try testing.expect(!state.paused);
+    try testing.expect(state.id == null);
+    try testing.expect(state.started_at == null);
+}
+
+test "the encoded state carries the four keys Swift's decoder looks for" {
+    const encoded = try encodeState(testing.allocator, .{
+        .active = true,
+        .paused = false,
+        .id = "ABC-123",
+        .started_at = 1756900000000,
+    });
+    defer testing.allocator.free(encoded);
+
+    try testing.expectEqualStrings(
+        \\{"active":true,"paused":false,"id":"ABC-123","startedAt":1756900000000}
+    , encoded);
+}
+
+test "a recording that has never started encodes its nulls, not empty strings" {
+    const encoded = try encodeState(testing.allocator, .{});
+    defer testing.allocator.free(encoded);
+
+    try testing.expectEqualStrings(
+        \\{"active":false,"paused":false,"id":null,"startedAt":null}
+    , encoded);
+}
+
+test "state survives a round trip through the encoder and the guard" {
+    const encoded = try encodeState(testing.allocator, .{
+        .active = true,
+        .paused = true,
+        .id = "route-9",
+        .started_at = 1756900123456,
+    });
+    defer testing.allocator.free(encoded);
+
+    var state = try decodeState(testing.allocator, encoded);
+    defer state.deinit(testing.allocator);
+
+    try testing.expect(state.active);
+    try testing.expect(state.paused);
+    try testing.expectEqualStrings("route-9", state.id.?);
+    try testing.expectEqual(@as(f64, 1756900123456), state.started_at.?);
+}
+
+test "an id with quotes in it survives rather than tearing the document" {
+    const encoded = try encodeState(testing.allocator, .{
+        .active = true,
+        .id = "a\"b\\c",
+    });
+    defer testing.allocator.free(encoded);
+
+    var state = try decodeState(testing.allocator, encoded);
+    defer state.deinit(testing.allocator);
+
+    try testing.expectEqualStrings("a\"b\\c", state.id.?);
+}
+
+test "a missing state file is no recording, not an error" {
+    removeTestFile(test_state_name);
+
+    var state = try readStateFrom(testing.allocator, test_state_name);
+    defer state.deinit(testing.allocator);
+
+    try testing.expect(!state.active);
+}
+
+test "appended samples land one per line, byte for byte" {
+    removeTestFile(test_track_name);
+    defer removeTestFile(test_track_name);
+
+    // The track has to exist first: `FileHandle(forWritingTo:)` throws when it
+    // does not, and appending would otherwise start a route nobody asked for.
+    try writeTestFile(test_track_name, "");
+
+    try appendSampleTo(testing.allocator, test_track_name, "{\"latitude\":1.5}");
+    try appendSampleTo(testing.allocator, test_track_name, "{\"latitude\":2.5}");
+
+    const text = try readTrackBytes(testing.allocator, test_track_name) orelse
+        return error.TestExpectedTrack;
+    defer testing.allocator.free(text);
+
+    try testing.expectEqualStrings("{\"latitude\":1.5}\n{\"latitude\":2.5}\n", text);
+}
+
+test "appending to a track that is not there loses the sample rather than creating one" {
+    removeTestFile(test_track_name);
+
+    // No recording is running, so there is no route for this fix to join.
+    // Creating the file here would invent one.
+    try testing.expectError(
+        bridge_error.BridgeError.NativeCallFailed,
+        appendSampleTo(testing.allocator, test_track_name, "{\"latitude\":1.5}"),
+    );
+}
+
+test "the sample count agrees with the reader, drop for drop" {
+    removeTestFile(test_track_name);
+    defer removeTestFile(test_track_name);
+
+    // `getLocationRecordingState` reports `loadRecordedLocations().count`, so a
+    // blank line and a non-object have to be uncounted here exactly as they are
+    // unread there — otherwise the page is told it has fixes it cannot read.
+    try writeTestFile(test_track_name,
+        \\{"latitude":1}
+        \\
+        \\[1,2]
+        \\{"latitude":2}
+        \\torn-half-
+    );
+
+    try testing.expectEqual(@as(usize, 2), try countSamplesIn(testing.allocator, test_track_name));
+
+    const text = try readTrackBytes(testing.allocator, test_track_name) orelse
+        return error.TestExpectedTrack;
+    defer testing.allocator.free(text);
+
+    const shaped = try shapeRecording(testing.allocator, text);
+    defer testing.allocator.free(shaped);
+
+    // Two objects in, two objects out: the count is the reader's own answer.
+    try testing.expectEqualStrings("[{\"latitude\":1},{\"latitude\":2}]", shaped);
+}
+
+test "an absent track counts zero rather than refusing" {
+    removeTestFile(test_track_name);
+    try testing.expectEqual(@as(usize, 0), try countSamplesIn(testing.allocator, test_track_name));
 }

--- a/packages/zig/src/bridge_mobile_locrecording.zig
+++ b/packages/zig/src/bridge_mobile_locrecording.zig
@@ -1,16 +1,15 @@
-//! The one location-recording action of the `mobile` namespace that Zig can
-//! serve honestly: `readLocationRecording`.
+//! The on-disk half of a location recording: the track, the state mirror, and
+//! the one action that only reads them — `readLocationRecording`.
 //!
-//! `startLocationRecording`, `pauseLocationRecording`, `resumeLocationRecording`,
-//! `stopLocationRecording` and `getLocationRecordingState` are deliberately
-//! **absent** from the `A` block — not `.unavailable`, absent — so
-//! `ios_dispatch`'s first-match chain falls through to the Swift shim that
-//! serves all five correctly today. The last two sections give the full
-//! argument; the short version is that the recorder is not a CLLocationManager
-//! plus a buffer, it is a CLLocationManager plus two files that
-//! `CraftWebView.Coordinator.init` re-adopts on every launch, and a Zig-owned
-//! `stop` cannot stop a recording Swift has already restored into its own
-//! process state.
+//! The other five live in `bridge_mobile_location.zig`, with the
+//! `CLLocationManager` they share. That split follows the spec rather than
+//! cutting across it: in `CraftWebView.Coordinator` a recording is not a device
+//! of its own, it is a flag on the one delegate plus these two files, and the
+//! flag belongs next to the delegate while the files belong here.
+//!
+//! This module keeps no manager, registers no Objective-C class and emits on no
+//! channel. It does now *write*, which it did not when it only read the track,
+//! so the format is stated once here and used from both sides.
 //!
 //! One JS surface reaches these six, `CraftApp.swift:2379-2384`:
 //!
@@ -127,86 +126,61 @@
 //!    recording, and the alternative — a track silently cut off at 32 MiB and
 //!    reported as the whole one — is the failure this module exists to avoid.
 //!
-//! ## Why the other five are absent rather than `.unavailable`
+//! ## What it took to move the other five, and what had gone stale
 //!
-//! `CraftWebView.makeCoordinator()` builds the `Coordinator` specifically so
-//! the shim has a host (`CraftSwiftShim.coordinator = coordinator`,
-//! `CraftApp.swift:371`), and `Coordinator.init` calls
-//! `restoreLocationRecordingState()` at line 447 whenever
-//! `config.enableGeolocation`. **That happens on every launch no matter who
-//! serves these actions.** So:
+//! This section used to argue that the five could not move. Two of its three
+//! blockers had already been removed by other work and nothing re-checked them;
+//! the audit is #124, and the short version is worth keeping because the shape
+//! of the mistake is more useful than the conclusion was.
 //!
-//!  - A Zig `start` must persist `{"active":true,…}` or the recording dies at
-//!    app termination while Swift's survives. Having persisted it, the next
-//!    launch has Swift restore it: its own `isRecordingLocation = true`, its
-//!    own manager, its own `startUpdatingLocation()`, appending to the same
-//!    `.jsonl`.
-//!  - A later Zig `stop` can flip the file to `active:false` and stop *Zig's*
-//!    manager. It cannot clear Swift's in-memory `isRecordingLocation` or stop
-//!    Swift's manager: `CraftSwiftShim.coordinator` is a Swift `static weak
-//!    var` with no `@objc` surface, and `ios_dispatch.route` only reaches the
-//!    shim for actions **no** module claims. The page's promise resolves
-//!    `active:false` while GPS keeps running and keeps writing fixes to disk —
-//!    fabricated success on a location-privacy operation, invisible from Zig.
-//!  - Refusing to persist `active:true` avoids the hijack and silently loses
-//!    the recording on termination instead, which is the exact failure the
-//!    feature exists to prevent.
+//!  - **"`enableGeolocation` has no mirror anywhere in `packages/zig/src`."**
+//!    True when written. `ios_config.zig` now reads the same
+//!    `craft.config.json` Swift decodes and exposes that flag, and its own
+//!    header names this note as one of the two it closes. Only
+//!    `startLocationRecording` is gated in the spec, so it is the only one of
+//!    the five in `ios_config.gateFor`.
+//!  - **"It needs an event channel that does not exist."** The paragraph
+//!    checked `capabilities.Channel`, where `.location_update` really is
+//!    `"craft:location:update"` and really is listened for by nothing on iOS.
+//!    But the iOS event path is `ios_events.Event`, whose `.location_update`
+//!    is `"craftLocationUpdate"` — the name the recorder needs — and
+//!    `bridge_mobile_location.zig` was already emitting on it for
+//!    `watchPosition`, one module away.
+//!  - **"`getLocationRecordingState` answers from memory, and a file-reading
+//!    Zig would diverge."** This one was correct, and it is the reason
+//!    `decodeState` exists in the shape it does. Swift's restore guard,
+//!    `state["active"] as? Bool == true`, means a *stopped* recording — whose
+//!    file still carries the old `id` and `startedAt` — restores as nothing at
+//!    all. Ported literally, so a stop-then-read in one launch still reports
+//!    the id and a relaunch still reports null.
 //!
-//! `getLocationRecordingState` has a second, independent blocker: Swift answers
-//! it from **memory**, and `restoreLocationRecordingState`'s
-//! `guard state["active"] as? Bool == true else { return }` leaves
-//! `locationRecordingId`/`startedAt` nil after any relaunch that follows a
-//! stop, while the state file still holds the stopped recording's `id` and
-//! `startedAt`. A file-reading Zig would answer `{"id":"ABC-…","startedAt":169…}`
-//! where Swift answers `{"id":null,"startedAt":null}` — a guaranteed,
-//! reproducible divergence, made worse by `persistLocationRecordingState`
-//! swallowing its own write failures so memory and file can drift with nothing
-//! to signal it.
-//!
-//! And `startLocationRecording` is the only one of the six behind
-//! `config.enableGeolocation` (`CraftApp.swift:635-640`), a flag with no mirror
-//! anywhere in `packages/zig/src` — `ios.zig`'s `AppConfig` has no such field,
-//! the precedent and its consequences being written out at
-//! `bridge_mobile_system.zig:39-43` for `enableShare`. Serving it ungated means
-//! turning on GPS and writing a location track to disk in an app that
-//! explicitly disabled geolocation, which is a materially larger divergence
-//! than an unexpected share sheet.
-//!
-//! Per the migration's standing rule, falling through beats `.unavailable`:
-//! `.unavailable` would make Zig dispatch and *refuse* five actions that work
-//! end-to-end today, including the capability gate, the authorization mode,
-//! background continuation, atomic persistence, file protection, backup
-//! exclusion and relaunch restore. Absence keeps them working.
-//!
-//! Migrating them honestly means deleting the recorder from `CraftApp.swift` in
-//! the same change — the six `case` arms (635-650), the six handlers
-//! (2960-3028), the file helpers (2904-2911, 2927-2958, 3039-3068), the four
-//! state vars (392-395) and the `restoreLocationRecordingState()` call at 447 —
-//! and untangling `isRecordingLocation` from `stopWatchingPosition` and from
-//! `didUpdateLocations`'s emit guard. It also needs an event channel that does
-//! not exist: the recorder's live samples go out as **`craftLocationUpdate`**
-//! (`CraftApp.swift:3090`, listeners at 1648 and 2362), and
-//! `capabilities.Channel` has no member for that name —
-//! `.location_update` is `"craft:location:update"`, which no iOS page listens
-//! for. Any partial split of this state across the two languages reintroduces
-//! the hijack above, so it is not an incremental move.
+//! The fourth obstacle was real and was never written down here: SwiftUI runs
+//! `makeCoordinator()` before `makeUIView`, so `Coordinator.init` — and
+//! `restoreLocationRecordingState()` inside it — ran before
+//! `craft_ios_set_webview` had been called even once. Whichever runtime
+//! restores first owns the manager for the rest of the launch. That is settled
+//! by `craft_ios_adopt_location_recording`, which Swift consults *instead of*
+//! its own restore and falls back from when `dlsym` finds no runtime.
 //!
 //! ## No delegate, no manager, no event, no async
 //!
-//! This module reads one file and replies. It registers no Objective-C class,
+//! This module reads and writes two files. It registers no Objective-C class,
 //! keeps no delegate alive, touches no `CLLocationManager`, emits on no
-//! channel, and takes no `ios_async` ticket: `loadRecordedLocations()` is
-//! synchronous and so is this. `ios_dispatch.handleMessage` runs from
+//! channel, and takes no `ios_async` ticket: every one of these operations is
+//! synchronous, as `loadRecordedLocations()` and
+//! `persistLocationRecordingState()` both are. `ios_dispatch.handleMessage` runs from
 //! `craftDidReceiveScriptMessage`, a `WKScriptMessageHandler` callback WebKit
 //! delivers on the main thread, so the reply is sent from the main thread with
 //! no hop — the reasoning is written out at `bridge_mobile_display.zig`.
 //!
 //! No mutex either, and that is not an oversight. The premise of a
 //! mutex-guarded in-memory buffer does not match this design: the writer is
-//! `appendRecordedLocation`, called from `locationManager(_:didUpdateLocations:)`,
-//! which CoreLocation delivers on the thread that created the manager — the
-//! main thread — and the reader is this dispatch, also on the main thread.
-//! The shared state is a file, and the two never run concurrently.
+//! `appendSample`, called from `didUpdateLocations`, which CoreLocation
+//! delivers on the thread that created the manager — the main thread — and the
+//! readers are dispatches, also on the main thread. The shared state is a file,
+//! and the two never run concurrently. The recorder's *in-memory* state does
+//! take a mutex, and it takes it where it lives, in
+//! `bridge_mobile_location.zig`.
 
 const std = @import("std");
 const builtin = @import("builtin");
@@ -231,10 +205,12 @@ const Id = ?*anyopaque;
 /// `test/ios_conformance_test.zig` matches the two lists by string in both
 /// directions.
 ///
-/// The other five recording actions are absent on purpose — the module
-/// comment's second-to-last section gives the full argument. An action listed
-/// here is an action this module takes away from the Swift shim, and that trade
-/// is only worth making when Zig's answer is at least as good.
+/// The other five are served by `bridge_mobile_location.zig`, which owns the
+/// `CLLocationManager` they share with the watch. They are not absent from the
+/// migration, only from this file — and `bridge_mobile_location.zig`'s own
+/// routing test asserts this module does not answer them, so the split cannot
+/// quietly become an overlap that makes `ios_dispatch`'s first-match order
+/// significant.
 pub const A = struct {
     pub const read_location_recording = "readLocationRecording";
 };
@@ -1159,18 +1135,15 @@ test "every route the dispatcher has is a declared action" {
     }
 }
 
-test "the five stateful recording actions are left to the Swift shim" {
-    // The deliberate omissions, asserted so they cannot be "fixed" by accident.
+test "the five stateful recording actions belong to the manager's module, not this one" {
+    // Not a deferral any more — an ownership boundary, asserted from this side
+    // so it cannot quietly become an overlap.
     //
-    // `ios_dispatch`'s chain treats UnknownAction as "not mine, ask the next"
-    // and any other error as final. So the *only* spelling of "let the shim
-    // keep serving this" is: absent from `A`, absent from `routeFor`, and
-    // UnknownAction out of `handleMessage`. An `.unavailable` declaration would
-    // dispatch and refuse five actions the shim answers correctly today —
-    // including the `enableGeolocation` gate, the authorization mode,
-    // background continuation, atomic persistence, file protection, backup
-    // exclusion and relaunch restore, none of which Zig can reproduce while
-    // `Coordinator.init` still re-adopts the recording on every launch.
+    // `ios_dispatch` routes first-match, so two modules answering one action
+    // would make the answer depend on the order of the module list. The five
+    // lifecycle actions need the `CLLocationManager` and the delegate, which
+    // live in `bridge_mobile_location.zig`; this file owns the two files they
+    // read and write. `bridge_mobile_location.zig` asserts the converse.
     const unserved = [_][]const u8{
         "startLocationRecording",
         "pauseLocationRecording",

--- a/packages/zig/src/bridge_mobile_locrecording.zig
+++ b/packages/zig/src/bridge_mobile_locrecording.zig
@@ -1684,8 +1684,7 @@ test "a stopped recording's leftovers read back as no recording at all" {
     // Swift's `guard state["active"] as? Bool == true else { return }` means a
     // relaunch after a stop restores nothing. A reader that handed back the id
     // would answer `{"id":"ABC-123"}` where Swift answers `{"id":null}`.
-    var state = try decodeState(
-        testing.allocator,
+    var state = try decodeState(testing.allocator,
         \\{"active":false,"paused":false,"id":"ABC-123","startedAt":1756900000000}
     );
     defer state.deinit(testing.allocator);
@@ -1697,8 +1696,7 @@ test "a stopped recording's leftovers read back as no recording at all" {
 }
 
 test "an active recording restores all four fields" {
-    var state = try decodeState(
-        testing.allocator,
+    var state = try decodeState(testing.allocator,
         \\{"active":true,"paused":true,"id":"ABC-123","startedAt":1756900000000}
     );
     defer state.deinit(testing.allocator);
@@ -1740,8 +1738,7 @@ test "the active guard is a Bool cast, not a truthiness test" {
 test "past the guard a wrong type is a default, not a refusal" {
     // Swift's remaining reads are `as? Bool ?? false`, `as? String` and
     // `as? TimeInterval`, all of which degrade rather than throw.
-    var state = try decodeState(
-        testing.allocator,
+    var state = try decodeState(testing.allocator,
         \\{"active":true,"paused":"yes","id":42,"startedAt":"soon"}
     );
     defer state.deinit(testing.allocator);

--- a/packages/zig/src/ios_config.zig
+++ b/packages/zig/src/ios_config.zig
@@ -448,6 +448,12 @@ pub fn gateFor(action: []const u8) ?Feature {
         .{ "takeScreenshot", .screen_capture },
         .{ "unlockOrientation", .orientation_lock },
         .{ "watchPosition", .geolocation },
+        // Only `startLocationRecording` of the six recording actions is gated
+        // in the spec (`CraftApp.swift:694-699`). Pausing, resuming, stopping
+        // and reading a route the app already recorded carry no guard there,
+        // and adding one here would strand a track on disk with no action able
+        // to reach it.
+        .{ "startLocationRecording", .geolocation },
     };
     inline for (table) |entry| {
         if (std.mem.eql(u8, action, entry[0])) return entry[1];

--- a/packages/zig/src/ios_dispatch.zig
+++ b/packages/zig/src/ios_dispatch.zig
@@ -475,6 +475,28 @@ export fn craft_ios_set_webview(webview: ?*anyopaque) callconv(.c) void {
     setWebView(webview);
 }
 
+/// Take over a location recording that outlived the last launch.
+///
+/// The one thing Zig has to do at launch rather than on a page message, and the
+/// reason it needs an export of its own: SwiftUI builds the coordinator before
+/// it builds the view, so `CraftWebView.Coordinator.init` runs — and
+/// `restoreLocationRecordingState()` with it — before `craft_ios_set_webview`
+/// has been called even once. Whichever runtime restores first owns the
+/// `CLLocationManager` for the rest of the launch.
+///
+/// Swift calls this *instead of* its own restore, inside the same
+/// `config.enableGeolocation` guard, and falls back to
+/// `restoreLocationRecordingState()` only when `dlsym` does not find this
+/// symbol — which is exactly the app that has no Zig recorder to take over.
+///
+/// Returns true when Zig has taken responsibility, so the caller must not also
+/// restore. That is not the same as "a recording was found": an app with no
+/// recording in progress still has a Zig-owned recorder for the next `start`,
+/// and a Swift restore under it would be a second owner of one file.
+export fn craft_ios_adopt_location_recording() callconv(.c) bool {
+    return bridge_mobile_location.adoptRecording();
+}
+
 /// Forget the webview, if it is still the one the caller installed.
 ///
 /// The other half of `craft_ios_set_webview`, and the reason it is needed:

--- a/packages/zig/test/ios_conformance_test.zig
+++ b/packages/zig/test/ios_conformance_test.zig
@@ -121,7 +121,7 @@ const dispatch_end = "func webView(";
 /// and `deliverErrorCode` landed the day after that was written. Worth
 /// re-reading the other deferrals for the same reason before assuming they
 /// still hold.
-const max_not_yet_migrated: usize = 23;
+const max_not_yet_migrated: usize = 18;
 
 fn dispatcherRegion() []const u8 {
     const begin = std.mem.indexOf(u8, swift_spec, dispatch_begin) orelse return "";
@@ -305,15 +305,6 @@ const deliberate_deferrals = [_]Deferral{
     // name the spec is free to change.
     .{ .action = "registerPush", .reason = "the device token lands on a SwiftUI-owned app delegate; Zig could only observe a notification Swift posts" },
 
-    // The recorder is a CLLocationManager plus two files that
-    // `CraftWebView.Coordinator.init` re-adopts at launch, so a Zig-owned stop
-    // cannot stop a recording Swift has already restored into its own state.
-    .{ .action = "startLocationRecording", .reason = "Coordinator.init re-adopts recordings at launch; Zig cannot stop what Swift restored" },
-    .{ .action = "stopLocationRecording", .reason = "Coordinator.init re-adopts recordings at launch; Zig cannot stop what Swift restored" },
-    .{ .action = "pauseLocationRecording", .reason = "Coordinator.init re-adopts recordings at launch; Zig cannot stop what Swift restored" },
-    .{ .action = "resumeLocationRecording", .reason = "Coordinator.init re-adopts recordings at launch; Zig cannot stop what Swift restored" },
-    .{ .action = "getLocationRecordingState", .reason = "Coordinator.init re-adopts recordings at launch; Zig cannot stop what Swift restored" },
-
     // VisionKit's `DataScannerViewController` is Swift-only: the framework's
     // Objective-C headers carry DocumentCamera and nothing else, and the
     // delegate callback takes a `RecognizedItem`, a Swift enum with associated
@@ -356,7 +347,7 @@ test "every recorded deferral is real, and still a deferral" {
     }
 
     // Non-vacuity: the loop above is satisfied by an empty table.
-    try testing.expect(deliberate_deferrals.len >= 23);
+    try testing.expect(deliberate_deferrals.len >= 18);
 
     // As of this commit the table happens to cover every unmigrated action,
     // but that is not asserted. Pinning the exact count would make migrating a


### PR DESCRIPTION
Moves the five location-recording lifecycle actions to Zig. Ratchet **23 → 18**,
the largest single step of this migration, and it closes #124.

## The reason had rotted

`bridge_mobile_locrecording.zig`'s module comment spent sixty lines arguing the
five could not move. Two of its three blockers had already been removed by other
work, and nothing re-checked them:

| Stated blocker | Status |
| --- | --- |
| `enableGeolocation` is "a flag with no mirror anywhere in `packages/zig/src`" | **Expired.** `ios_config.zig` reads the same `craft.config.json` Swift decodes, and its own header names this note as one of the two it closes. |
| The recorder "needs an event channel that does not exist" | **Expired, wrong enum.** It checked `capabilities.Channel`; the iOS path is `ios_events.Event`, whose `.location_update` is `"craftLocationUpdate"` — already in use for the shipped `watchPosition`. |
| `getLocationRecordingState` answers from memory, so a file-reading Zig diverges | **Correct.** Ported literally rather than argued with. |

The real obstacle was never written down: SwiftUI runs `makeCoordinator()`
before `makeUIView`, so `Coordinator.init` — and `restoreLocationRecordingState()`
in it — ran before `craft_ios_set_webview` had been called even once. Whichever
runtime restores first owns the `CLLocationManager` for the rest of the launch,
which is exactly why a Zig-owned `stop` could not stop it.

## What it fixes

`bridge_mobile_location.zig` already recorded a live defect against itself:
while a recording ran, Swift's manager *and* Zig's manager both fed
`craftLocationUpdate`, so a page that recorded and watched got roughly two
events per fix. Its own words were "it disappears when the recording actions
migrate". It has.

The fix is the shape, not a patch. In the spec a recording is not a second
`CLLocationManager` — it is a flag on the one delegate plus two files. So the
five lifecycle actions live with the manager in `bridge_mobile_location.zig`,
the file format lives in `bridge_mobile_locrecording.zig`, and
`didUpdateLocations` gains a third consumer that appends before it emits, which
is Swift's own order. The emit guard is now Swift's exactly:
`if isWatchingLocation || isRecordingLocation`, satisfied once by one manager.

Two other things fall out of sharing a manager again:

- **Arbitration.** `clearWatch` gains `stopWatchingPosition`'s
  `if !isRecordingLocation`, and pause/stop gain its mirror. Neither guard could
  fail while the two runtimes owned different managers; now one serves both, and
  whichever finishes second must not end the other's stream.
- **The one-shot's sample returns.** Swift appends every fix to the track,
  including a `getCurrentPosition` during a recording. That sample had stopped
  being written when this module got its own manager; it is written again.

## Deliberate divergences

- **State reaches disk before the page is told the recording started.** Swift
  sets its four variables and then persists, catching its own write failure and
  printing — so memory and file can drift from the first sample, with the page
  told it is recording. Here a persist failure refuses the start.
- **`NO_ACTIVE_RECORDING` becomes `INVALID_PARAMETER`.** `BridgeError` carries
  an enum, not free text — the same trade `bridge_mobile_misc.zig` and
  `bridge_mobile_watch.zig` document. The rejection itself is not lost.
- **`readState` drops a stopped recording's leftovers**, because
  `restoreLocationRecordingState`'s guard does. A stop-then-read in one launch
  still reports the id; a relaunch reports null. That is the third blocker,
  ported.

## The seam

One new export, `craft_ios_adopt_location_recording`. Swift consults it *instead
of* its own restore, inside the same `enableGeolocation` guard, and falls back to
`restoreLocationRecordingState()` when `dlsym` finds no runtime — which is
exactly the app that still needs it. It returns "Zig owns the recorder", not "a
recording was found": a launch with no recording still leaves Zig owning the
next `start`, and a Swift restore under it would be a second owner of one file.

## Verification

- `zig build test:ios` — 7/7 steps, 1066/1078 passed, 12 skipped, 0 failed.
- `swiftc -typecheck` against the iphoneos SDK on the generated app: no errors,
  and the same four warnings as HEAD, compared set-against-set rather than by
  count.
- The conformance guards did the driving: `DeferralAlreadyMigrated` and the
  gated-action test both failed until the table, the ratchet and
  `ios_config.gateFor` agreed with the code.

Closes #124.
