### PR TITLE
test(ios): check the event channel, the half nothing was checking

### DIFF
--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -405,6 +405,9 @@ pub fn build(b: *std.Build) void {
     ios_conformance_tests.root_module.addAnonymousImport("src/ios_config.zig", .{
         .root_source_file = b.path("src/ios_config.zig"),
     });
+    ios_conformance_tests.root_module.addAnonymousImport("src/ios_events.zig", .{
+        .root_source_file = b.path("src/ios_events.zig"),
+    });
     ios_conformance_tests.root_module.addAnonymousImport("src/bridge_mobile_vision.zig", .{
         .root_source_file = b.path("src/bridge_mobile_vision.zig"),
     });

--- a/packages/zig/src/bridge_mobile_shortcuts.zig
+++ b/packages/zig/src/bridge_mobile_shortcuts.zig
@@ -67,6 +67,13 @@
 //! equivalent, so nothing ever dispatches that event. Tapping launches or
 //! foregrounds the app and stops there. Pre-existing, identical under the
 //! Swift shim, and outside these two actions' scope.
+//!
+//! That paragraph was the only record of it for several phases, which is the
+//! problem with recording a gap in the header of the one module that noticed:
+//! nothing else can see it and nothing re-checks it. `craftShortcut` is now a
+//! row in `ios_conformance_test.zig`'s `dead_subscriptions`, alongside three
+//! more of the same shape found by looking — the build fails if it quietly
+//! gains an emitter, and fails if a fifth appears. Tracked in issue #127.
 
 const std = @import("std");
 const builtin = @import("builtin");

--- a/packages/zig/src/ios_events.zig
+++ b/packages/zig/src/ios_events.zig
@@ -45,6 +45,15 @@ const compat_mutex = @import("compat_mutex.zig");
 /// `packages/ios/templates/CraftApp.swift` — that is the contract, and a page
 /// written against the Swift app must keep working when Zig serves the same
 /// action. `eventName` is what lands in the `CustomEvent` constructor.
+///
+/// "Copied" was the whole of the guarantee until
+/// `ios_conformance_test.zig`'s event scans landed. A wrong character here
+/// costs nothing at compile time and produces a `CustomEvent` no page is
+/// listening for: no rejected promise, no timeout, no log line — the stream
+/// simply never starts, which from the page's side is what a device with
+/// nothing to report looks like. That test now reads these arms and fails
+/// the build for a name the spec does not dispatch, so the list is checked
+/// against its source rather than trusted to have been transcribed once.
 pub const Event = enum {
     location_update,
     location_error,

--- a/packages/zig/test/ios_conformance_test.zig
+++ b/packages/zig/test/ios_conformance_test.zig
@@ -828,3 +828,264 @@ test "getDeviceInfo answers every field the spec answers" {
     // A shape change that silently matched nothing would otherwise pass.
     try testing.expectEqual(@as(usize, 14), checked);
 }
+
+// ---------------------------------------------------------------------------
+// The event channel
+//
+// Everything above this line is about the *call* channel: the page asks, native
+// answers. The other half of the contract runs the other way — native talks
+// first, and the page hears it as a `CustomEvent` on `window`. Nothing checked
+// that half, and it carries the same two failure modes the action scans exist
+// to catch, in a form that is quieter still:
+//
+//   * A name Zig emits that nothing subscribes to. `craftLocationUpate` for
+//     `craftLocationUpdate` compiles, dispatches, and reaches no one. There is
+//     no promise to hang and no error to log — the stream simply never starts,
+//     which is indistinguishable from a device that has nothing to report.
+//     `ios_events.zig`'s own header records this hazard and calls the names
+//     "copied from a `sendToWeb` call"; copied, and then never re-checked.
+//
+//   * A name the page subscribes to that nothing dispatches. This is exactly
+//     the `ota*` bug — a surface that reads as implemented and is not — and
+//     the OTA surface is where it still lives: when the five unhandled
+//     `ota*` methods were fixed to reject through `_unavailable`, the two
+//     *subscription* methods beside them were left as they were, because the
+//     scan that found them only knew about actions.
+//
+// Both scans are textual and carry the usual hazard, so both have floors.
+// ---------------------------------------------------------------------------
+
+const zig_events_source = @embedFile("src/ios_events.zig");
+
+/// Extract single-or-double-quoted event names following `needle`, keeping
+/// only the `craft`-prefixed identifiers.
+///
+/// The filter is doing real work rather than tidying. `sendToWeb` is also
+/// called through an interpolation — `CustomEvent('\(event)'` in the sink
+/// itself — and `addEventListener` is used for `loadend` and
+/// `visibilitychange`, neither of which is a bridge event. Restricting to
+/// `craft`-prefixed identifiers drops all three, and the prefix is not an
+/// assumption: the test below asserts every dispatched name has it.
+fn collectQuotedEvents(
+    allocator: std.mem.Allocator,
+    needle: []const u8,
+    quote: u8,
+) !std.StringHashMap(void) {
+    var set = std.StringHashMap(void).init(allocator);
+    errdefer set.deinit();
+
+    var search: usize = 0;
+    while (std.mem.indexOfPos(u8, swift_spec, search, needle)) |at| {
+        const start = at + needle.len;
+        const end = std.mem.indexOfScalarPos(u8, swift_spec, start, quote) orelse break;
+        search = end;
+
+        const name = swift_spec[start..end];
+        if (!std.mem.startsWith(u8, name, "craft")) continue;
+        var ok = true;
+        for (name) |c| {
+            if (!std.ascii.isAlphanumeric(c)) ok = false;
+        }
+        if (ok) try set.put(name, {});
+    }
+    return set;
+}
+
+/// Every event the spec dispatches: `sendToWeb("craftX", ...)` from native,
+/// plus the `CustomEvent('craftX'` literals — one in Swift's deep-link path
+/// and two inside the injected JavaScript, which dispatches `craftError` and
+/// `craftReady` itself.
+fn collectSpecDispatchedEvents(allocator: std.mem.Allocator) !std.StringHashMap(void) {
+    var set = try collectQuotedEvents(allocator, "sendToWeb(\"", '"');
+    errdefer set.deinit();
+
+    var literal = try collectQuotedEvents(allocator, "CustomEvent('", '\'');
+    defer literal.deinit();
+
+    var it = literal.keyIterator();
+    while (it.next()) |name| try set.put(name.*, {});
+    return set;
+}
+
+/// Every event the injected JavaScript subscribes to on the page's behalf.
+fn collectSpecSubscribedEvents(allocator: std.mem.Allocator) !std.StringHashMap(void) {
+    return collectQuotedEvents(allocator, "addEventListener('", '\'');
+}
+
+/// The `.member => "craftX",` arms of `ios_events.Event.eventName`.
+fn collectZigEventNames(allocator: std.mem.Allocator) !std.StringHashMap(void) {
+    var set = std.StringHashMap(void).init(allocator);
+    errdefer set.deinit();
+
+    const start = std.mem.indexOf(u8, zig_events_source, "pub fn eventName(") orelse
+        return error.EventNameFnNotFound;
+    const body = zig_events_source[start..];
+    // `eventName` is a method on the enum, so it closes at four-space indent.
+    const end = std.mem.indexOf(u8, body, "\n    }") orelse return error.EventNameFnNotFound;
+
+    var it = std.mem.splitScalar(u8, body[0..end], '\n');
+    while (it.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, " \t\r");
+        if (!std.mem.startsWith(u8, trimmed, ".")) continue;
+        const arrow = std.mem.indexOf(u8, trimmed, " => \"") orelse continue;
+        const name_start = arrow + " => \"".len;
+        const name_end = std.mem.indexOfScalarPos(u8, trimmed, name_start, '"') orelse continue;
+        try set.put(trimmed[name_start..name_end], {});
+    }
+    return set;
+}
+
+const DeadSubscription = struct {
+    event: []const u8,
+    reason: []const u8,
+};
+
+/// Events the injected JavaScript subscribes to that nothing in this repository
+/// ever dispatches — so the callback a page hands to the method beside them is
+/// registered, retained, and never called.
+///
+/// Recorded here for the reason the deferral table above exists: a gap nothing
+/// checks is a gap that outlives its own explanation. All four are the same
+/// shape — the *sending* half of a surface whose receiving half shipped — and
+/// none is fixable from Zig alone, which is why they are a table rather than a
+/// commit. Tracked in issue #127.
+const dead_subscriptions = [_]DeadSubscription{
+    // `setShortcuts` really does install home-screen items; tapping one
+    // launches the app and stops there. No template implements
+    // `application(_:performActionFor:completionHandler:)` or a scene-delegate
+    // equivalent, so the `UIApplicationShortcutItem` never reaches the page.
+    // `bridge_mobile_shortcuts.zig` documents this from the other side.
+    .{ .event = "craftShortcut", .reason = "nothing implements performActionFor:, so a tapped shortcut only launches the app" },
+
+    // `donateSiriShortcut` donates an `NSUserActivity` typed
+    // `{{BUNDLE_ID}}.<action>`. The only `onContinueUserActivity` in the
+    // template is bound to `NSUserActivityTypeBrowsingWeb` and routes to
+    // `DeepLinkManager`, so an invocation of a donated shortcut relaunches the
+    // app and is dropped.
+    .{ .event = "craftSiriShortcut", .reason = "the only onContinueUserActivity handles browsing-web activities, so a donated shortcut's invocation is dropped" },
+
+    // The `ota*` half-fix. `checkForUpdate`, `downloadUpdate`, `applyUpdate`
+    // and `rollback` were changed to reject through `_unavailable`; these two
+    // register a callback against a name no OTA implementation exists to
+    // dispatch, and were missed because the scan that found the others only
+    // looked at actions.
+    .{ .event = "craftOTAProgress", .reason = "the OTA surface is _unavailable; its two subscription methods were left behind" },
+    .{ .event = "craftOTAStatus", .reason = "the OTA surface is _unavailable; its two subscription methods were left behind" },
+};
+
+test "the event scans find both halves of the channel" {
+    // Non-vacuity. Every assertion below is a membership check, and a needle
+    // that stopped matching would satisfy all of them at once.
+    var dispatched = try collectSpecDispatchedEvents(testing.allocator);
+    defer dispatched.deinit();
+    try testing.expect(dispatched.count() >= 17);
+
+    var subscribed = try collectSpecSubscribedEvents(testing.allocator);
+    defer subscribed.deinit();
+    try testing.expect(subscribed.count() >= 10);
+
+    var zig = try collectZigEventNames(testing.allocator);
+    defer zig.deinit();
+    try testing.expect(zig.count() >= 13);
+
+    // The prefix the two filters rely on, checked rather than assumed.
+    var it = dispatched.keyIterator();
+    while (it.next()) |name| try testing.expect(std.mem.startsWith(u8, name.*, "craft"));
+}
+
+test "every event Zig emits is one the spec dispatches" {
+    // The typo guard, and the direction that matters most: `ios_events.Event`
+    // is a fixed vocabulary transcribed by hand from the spec's `sendToWeb`
+    // call sites, and a single wrong character produces a `CustomEvent` with
+    // no subscriber. Nothing fails, nothing logs; the page just never hears
+    // from the device.
+    //
+    // The spec is never edited to remove an arm a Zig module has taken over —
+    // `CraftApp.swift` stays the specification and the shim — so Zig's
+    // vocabulary being a subset of the spec's is a property that holds for as
+    // long as this migration runs.
+    var dispatched = try collectSpecDispatchedEvents(testing.allocator);
+    defer dispatched.deinit();
+
+    var zig = try collectZigEventNames(testing.allocator);
+    defer zig.deinit();
+
+    var it = zig.keyIterator();
+    while (it.next()) |name| {
+        if (!dispatched.contains(name.*)) {
+            std.debug.print(
+                "ios_events.Event spells '{s}', which the spec never dispatches.\n" ++
+                    "  A page written against the Swift app is listening for a different name.\n",
+                .{name.*},
+            );
+            return error.ZigEmitsAnEventTheSpecDoesNotHave;
+        }
+    }
+}
+
+test "every event the page subscribes to is one something dispatches" {
+    // The `ota*` check, on the other channel. A subscription with no emitter
+    // is quieter than a promise with no handler — there is nothing to await,
+    // so the page reports no error and simply behaves as if the device were
+    // idle — which makes it likelier to ship and likelier to survive.
+    //
+    // Zig's emitters are not consulted here on purpose: the test above pins
+    // `ios_events.Event` as a subset of what the spec dispatches, so a union
+    // with it could not admit a name this set lacks. Adding one anyway would
+    // read as though Zig could rescue a dead subscription, and it cannot.
+    var dispatched = try collectSpecDispatchedEvents(testing.allocator);
+    defer dispatched.deinit();
+
+    var subscribed = try collectSpecSubscribedEvents(testing.allocator);
+    defer subscribed.deinit();
+
+    var recorded = std.StringHashMap(void).init(testing.allocator);
+    defer recorded.deinit();
+    for (dead_subscriptions) |d| try recorded.put(d.event, {});
+
+    var it = subscribed.keyIterator();
+    while (it.next()) |name| {
+        if (dispatched.contains(name.*)) continue;
+        if (recorded.contains(name.*)) continue;
+        std.debug.print(
+            "the injected JS subscribes to '{s}', which nothing dispatches.\n" ++
+                "  The callback a page registers for it can never be called.\n",
+            .{name.*},
+        );
+        return error.PageSubscribesToAnEventNothingEmits;
+    }
+}
+
+test "every recorded dead subscription is real, and still dead" {
+    // The anti-rot half, in the shape the deferral table already uses. A row
+    // that has grown an emitter must fail here rather than sit in a list
+    // telling the next reader the surface is broken when it works.
+    var dispatched = try collectSpecDispatchedEvents(testing.allocator);
+    defer dispatched.deinit();
+
+    var subscribed = try collectSpecSubscribedEvents(testing.allocator);
+    defer subscribed.deinit();
+
+    for (dead_subscriptions) |d| {
+        if (!subscribed.contains(d.event)) {
+            std.debug.print(
+                "'{s}' is recorded as a dead subscription, but the injected JS no longer subscribes to it — " ++
+                    "delete the row.\n",
+                .{d.event},
+            );
+            return error.DeadSubscriptionNoLongerSubscribed;
+        }
+        if (dispatched.contains(d.event)) {
+            std.debug.print(
+                "'{s}' is recorded as having no emitter, and something dispatches it now — " ++
+                    "delete the row, its reason is spent.\n",
+                .{d.event},
+            );
+            return error.DeadSubscriptionIsAliveNow;
+        }
+        try testing.expect(d.reason.len > 0);
+    }
+
+    // Non-vacuity: the loop above is satisfied by an empty table.
+    try testing.expect(dead_subscriptions.len >= 4);
+}


### PR DESCRIPTION
## The half that had no check

`ios_conformance_test.zig` covers one direction of the iOS page contract: the page calls an action, native answers. Every action the spec handles is served by Zig or explicitly owed, the count only goes down, and a page-callable method with nothing behind it fails the build.

The other direction had nothing. Native talks first, the page hears a `CustomEvent` on `window`, and no test in the repo looked at that channel at all — despite it carrying the same two failure modes, in a form that is quieter and therefore likelier to ship.

## Zig → spec: the typo guard

`ios_events.Event` is thirteen string literals transcribed by hand from the spec's `sendToWeb` call sites. Its own header says as much and calls them "copied from a `sendToWeb` call" — copied once, then never re-checked.

`craftLocationUpate` for `craftLocationUpdate` compiles, dispatches, and reaches nobody. There is no promise to hang and no error to log; the stream simply never starts, which from the page's side looks exactly like a device with nothing to report. The new test reads the arms out of `eventName` and fails the build for a name the spec does not dispatch.

## Page → emitter: the `ota*` bug, on the other channel

Four events the injected JavaScript subscribes to are dispatched by nothing in this repository. The callback a page hands to each is stored, retained, and never called.

| event | subscriber | why nothing dispatches it |
| --- | --- | --- |
| `craftShortcut` | `craft.shortcuts.onShortcut` | No template implements `application(_:performActionFor:completionHandler:)`. `setShortcuts` installs real home-screen items; tapping one launches the app and stops there. |
| `craftSiriShortcut` | `craft.siri.onInvoke` | `donateSiriShortcut` donates an `NSUserActivity` typed `{{BUNDLE_ID}}.<action>`; the only `onContinueUserActivity` is bound to `NSUserActivityTypeBrowsingWeb` and routes to `DeepLinkManager`. |
| `craftOTAProgress` | `craft.ota.onProgress` | The OTA surface is unavailable. |
| `craftOTAStatus` | `craft.ota.onStatusChange` | Same. |

The OTA pair is the sharpest of the four: when the five unhandled `ota*` methods were fixed to reject through `_unavailable`, the two *subscription* methods sitting beside them were left exactly as they were — because the scan that found the others only knew about actions. Half a surface fixed, and the shape of the check is why the other half stayed broken.

`craftShortcut` was already known, written into `bridge_mobile_shortcuts.zig`'s header: prose, in the one module that happened to notice, that nothing verified and no other module could see. That is the shape of every deferral reason that had rotted before this migration started checking them. The note now points at the row instead of standing in for it.

All four are recorded in `dead_subscriptions` with the anti-rot guards the deferral table already uses — a row that stops being subscribed fails the build, a row that grows an emitter fails the build, and a *fifth* dead subscription fails immediately. None is fixable from Zig: the missing half is an app-delegate callback in the Swift template, and for OTA there is no implementation to report progress from even in principle. Tracked in #127.

## What was checked, and how

Seven mutations, each expected to bite one guard, each verified to:

| mutation | result |
| --- | --- |
| typo in a Zig event name | `ZigEmitsAnEventTheSpecDoesNotHave` |
| a row deleted from the table | `PageSubscribesToAnEventNothingEmits` + the floor |
| a row naming an event nothing subscribes to | `DeadSubscriptionNoLongerSubscribed` |
| a brand-new dead subscription in the spec | `PageSubscribesToAnEventNothingEmits` |
| a dead subscription gains a `sendToWeb` | `DeadSubscriptionIsAliveNow` |
| the `addEventListener('` needle broken | the scan floor |
| the `sendToWeb("` needle broken | the scan floor |

Both scans are textual and carry the usual hazard — a needle that stops matching turns a real check into a vacuous one — so both have explicit floors, and the `craft` prefix the filters rely on is asserted rather than assumed.

`zig build test:ios`: 15/15. No production behaviour changes; this is a test, two header notes, and one `addAnonymousImport`.

## What this does not claim

Zig's emitters are deliberately not consulted in the page → emitter check. The Zig → spec test already pins `ios_events.Event` as a subset of what the spec dispatches, so a union with it could not admit a name the spec's set lacks — including it anyway would read as though Zig could rescue a dead subscription, and it cannot.
