### PR TITLE
feat(ios): haptic, whose reason expired when ios_config landed

### DIFF
--- a/packages/zig/src/bridge_mobile_haptics.zig
+++ b/packages/zig/src/bridge_mobile_haptics.zig
@@ -1,10 +1,34 @@
 //! The haptics half of the `mobile` namespace: `haptic` and `vibrate`.
 //!
 //! Split out of `bridge_mobile.zig` because the two actions have opposite
-//! contracts — `haptic` is fire-and-forget and gated on a config flag, while
-//! `vibrate` replies and is gated on nothing — and because one of them cannot
-//! be served honestly from Zig yet. Keeping that admission next to the working
-//! action, rather than folded into the namespace's main file, is the point.
+//! contracts: `haptic` is fire-and-forget and gated on `config.enableHaptics`,
+//! `vibrate` replies and is gated on nothing.
+//!
+//! ## The refusal that used to live here
+//!
+//! `haptic` was declared `.status = .unavailable` for one reason, quoted from
+//! the manifest it carried: the flag "is not visible to Zig; serving it here
+//! would enable haptics for every app that never opted in". That was exactly
+//! right when it was written. The Taptic Engine has no readback, so a flip
+//! would have been invisible in CI and obvious on a device — and the default
+//! config has `enableHaptics` false, so the blast radius was every app that
+//! had not opted in.
+//!
+//! The condition that reason set for itself has since been met, by work that
+//! was not looking at this file. `ios_config.zig` reads `craft.config.json`
+//! out of the bundle, `gateFor("haptic")` maps the action to `.haptics`, and
+//! `ios_dispatch.zig` refuses any gated action whose flag is off *before* the
+//! module chain runs. The precise hazard the refusal was protecting against —
+//! an app on the default config buzzing on `craft.haptics.impact()` — is now
+//! the one case that cannot happen: the gate rejects it with
+//! `CAPABILITY_DISABLED`, which is what the spec's `else` arm sends too.
+//!
+//! Nothing re-checked that. The reason sat here, correct on the day it was
+//! written and wrong for every day after `ios_config.zig` landed, and the only
+//! way it surfaced was someone reading it again. `ios_conformance_test.zig`
+//! now fails the build for a gated action declared `.unavailable`, because a
+//! module claiming both "Zig can enforce this gate" and "Zig cannot read this
+//! gate" is stating a contradiction that a test can see.
 
 const std = @import("std");
 const builtin = @import("builtin");
@@ -25,53 +49,46 @@ pub const A = struct {
     pub const vibrate = "vibrate";
 };
 
-/// `haptic` is declared `unavailable`, and that is a decision, not an oversight.
+/// The whole of `haptic`'s decision: `body["style"] as? String ?? "medium"`,
+/// then the spec's switch.
 ///
-/// The Swift it replaces does not run `triggerHaptic` unconditionally — it runs
-/// it `if config.enableHaptics` (`CraftApp.swift:537`), and that flag defaults
-/// to **false** in both the template (`CraftApp.swift:190`) and the SDK
-/// (`packages/ios/src/index.ts:118`). It reaches Zig through nothing: no
-/// `craft_ios_*` export carries it, no build option encodes it. So serving
-/// `haptic` from here means serving a *different action* from the one the spec
-/// defines — every app on the default config would start buzzing on
-/// `craft.haptics.impact()`, which is the entire shipped haptics surface, and
-/// no test in this repo could see it because the Taptic Engine has no readback.
-///
-/// The three ways to make that go away are all worse than saying so:
-///   - fire anyway → a behaviour change that is invisible in CI and obvious on
-///     a device;
-///   - hardcode the gate false → a permanent no-op that reports nothing, which
-///     is the shape of the nine Android handlers that were deleted;
-///   - reply `{"success":true}` → fabricated success, the thing this migration
-///     exists to stop.
-///
-/// So the handler refuses and the manifest says why. Unblocking it is small and
-/// deliberate: plumb the flag in (a `craft_ios_set_capabilities` export or a
-/// build option), then swap the refusal in `haptic()` for the mapping and the
-/// trigger below, both of which are written and pinned by the tests at the
-/// bottom of this file. What must not happen is the flip happening silently.
-///
-/// Note the inconsistency this preserves: `case "vibrate"` has no
-/// `enableHaptics` gate in the spec either, so `craft.vibrate([100])` already
-/// fires impacts on an app with haptics "disabled". `vibrate` stays ungated to
-/// match; the asymmetry is the spec's, not ours.
-const haptic_unavailable_reason =
-    "iOS gates haptic on config.enableHaptics, which defaults to false and is " ++
-    "not visible to Zig; serving it here would enable haptics for every app " ++
-    "that never opted in";
+/// Split out from `haptic` so it can be asserted on a host. The trigger cannot
+/// — `UIImpactFeedbackGenerator` is not in a test runner's process — so a test
+/// calling `haptic` end-to-end can only observe `ClassNotFound`, which says
+/// nothing about whether the right style was chosen. This is the half where a
+/// mistake would be silent on a device too: the Taptic Engine has no readback,
+/// so a `heavy` served as `medium` feels like a device being a device.
+fn hapticTypeIn(allocator: std.mem.Allocator, data: []const u8) !HapticType {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch
+        return bridge_error.BridgeError.InvalidJSON;
+    defer parsed.deinit();
 
+    const root = switch (parsed.value) {
+        .object => |obj| obj,
+        else => return bridge_error.BridgeError.InvalidJSON,
+    };
+
+    // Swift's `as? String` fails for every non-string, and `?? "medium"` sends
+    // all of them to the same place: absent, null, number, bool, array, object.
+    const style = switch (root.get("style") orelse std.json.Value{ .null = {} }) {
+        .string => |text| text,
+        else => "medium",
+    };
+    return hapticTypeForStyle(style);
+}
+
+/// `vibrate` stays ungated, and that is the spec's asymmetry rather than ours.
+///
+/// `case "vibrate"` has no `enableHaptics` check in the spec, so
+/// `craft.vibrate([100])` fires impacts on an app with haptics "disabled".
+/// Adding a gate here would be a divergence dressed as a tidy-up.
 pub const capability_actions = [_]capabilities.ActionDecl{
-    // `.none` is the action's contract regardless of status: the page's
-    // `craft.haptic()` returns undefined and the spec's `case "haptic"` never
-    // touches `resolveCallback`. An error still reaches the page — with no
-    // pending entry to settle, `craft-bridge.js` reports it to the console —
-    // so a refusal is logged rather than swallowed.
-    .{
-        .name = A.haptic,
-        .reply = .none,
-        .status = .unavailable,
-        .reason = haptic_unavailable_reason,
-    },
+    // `.none` is the contract: the page's `craft.haptic()` returns undefined
+    // and the spec's `case "haptic"` never touches `resolveCallback`. An error
+    // still reaches the page — with no pending entry to settle,
+    // `craft-bridge.js` reports it to the console — so a refusal is logged
+    // rather than swallowed.
+    .{ .name = A.haptic, .reply = .none },
     // `.result` carrying the JSON literal `true`. Not a shape worth improving:
     // the hand-off path already delivers exactly this today, and `.none` would
     // park any `_req`-based caller for the full 30s timeout.
@@ -104,19 +121,27 @@ pub const HapticsBridge = struct {
         return bridge_error.BridgeError.UnknownAction;
     }
 
-    /// Refuses, for the reason recorded on `haptic_unavailable_reason`.
+    /// `case "haptic"` (`CraftApp.swift:576-582`).
     ///
-    /// The payload is not parsed first. Reporting a malformed `style` would
-    /// imply the style was going to be used, and it is not — a refusal that
-    /// sometimes reports a different cause is harder to act on than one that
-    /// always says the same thing.
+    /// The gate is not checked here. `ios_dispatch.route` refuses every gated
+    /// action whose flag is off before any module is asked, so reaching this
+    /// function already means `enableHaptics` is true — and checking twice
+    /// would put a second copy of the rule where the two could disagree.
     ///
-    /// The error name is what lands in the device log; the page sees
-    /// `NATIVE_CALL_FAILED`, `ios_dispatch.asBridgeError`'s catch-all, because
-    /// the wire protocol has no code for "declared unavailable". The manifest
-    /// is where an app reads the actual reason.
-    fn haptic(_: *Self, _: []const u8) !void {
-        return error.HapticsGateNotVisibleToZig;
+    /// `style` is read the way Swift reads it: `body["style"] as? String ??
+    /// "medium"`. A missing key, a number, an object — every failed cast takes
+    /// the same default, so this reads the string when there is one and hands
+    /// `hapticTypeForStyle` the literal `"medium"` otherwise. That is one
+    /// spelling of the default rather than two: `hapticTypeForStyle` maps an
+    /// unrecognised style to `.impact_medium` as well, matching the spec's
+    /// `default:` arm, and this path exercises the same branch.
+    ///
+    /// No reply on success, matching `.none` and the spec. The error from
+    /// `triggerHapticChecked` is the one thing that can come back, and it means
+    /// UIKit was not there to accept the call — never that the device stayed
+    /// still, which no iOS API reports.
+    fn haptic(self: *Self, data: []const u8) !void {
+        try triggerHapticChecked(try hapticTypeIn(self.allocator, data));
     }
 
     /// `case "vibrate"` (`CraftApp.swift:685-691`).
@@ -472,7 +497,9 @@ test "an unavailable action carries the reason with it" {
         try testing.expect(decl.reason != null);
         try testing.expect(decl.reason.?.len > 0);
     }
-    try testing.expectEqual(capabilities.ActionStatus.unavailable, capability_actions[0].status);
+    // Both live now. `haptic` was `.unavailable` until `ios_config.zig` made
+    // the flag its reason blamed readable; see the module header.
+    try testing.expectEqual(capabilities.ActionStatus.live, capability_actions[0].status);
     try testing.expectEqual(capabilities.ActionStatus.live, capability_actions[1].status);
 }
 
@@ -508,18 +535,36 @@ test "an action the namespace does not serve is reported, not ignored" {
     );
 }
 
-test "haptic refuses rather than firing an ungated haptic" {
-    // The refusal is the migration's honest answer while `config.enableHaptics`
-    // has no Zig representation. If this test starts failing because someone
-    // implemented the action, the flag has to have been plumbed through first —
-    // that is the conversation this assertion exists to force.
-    var bridge = HapticsBridge.init(testing.allocator);
-    defer bridge.deinit();
+test "haptic reads the style the way the spec's cast reads it" {
+    // What replaced the refusal. The old test asserted
+    // `error.HapticsGateNotVisibleToZig` and existed to force a conversation if
+    // anyone implemented the action; the flag is readable now
+    // (`ios_config.gateFor("haptic")`), the conversation happened, and this is
+    // what the action actually decides.
+    const alloc = testing.allocator;
 
-    try testing.expectError(
-        error.HapticsGateNotVisibleToZig,
-        bridge.handleMessage(A.haptic, "{\"style\":\"medium\"}"),
-    );
+    try testing.expectEqual(HapticType.impact_heavy, try hapticTypeIn(alloc, "{\"style\":\"heavy\"}"));
+    try testing.expectEqual(HapticType.selection, try hapticTypeIn(alloc, "{\"style\":\"selection\"}"));
+
+    // `as? String` fails for each of these, and `?? "medium"` catches them all.
+    // A page posting `{style: 2}` gets a medium impact, not an error — matching
+    // the spec, which cannot report one either: `case "haptic"` has no reply.
+    try testing.expectEqual(HapticType.impact_medium, try hapticTypeIn(alloc, "{}"));
+    try testing.expectEqual(HapticType.impact_medium, try hapticTypeIn(alloc, "{\"style\":null}"));
+    try testing.expectEqual(HapticType.impact_medium, try hapticTypeIn(alloc, "{\"style\":2}"));
+    try testing.expectEqual(HapticType.impact_medium, try hapticTypeIn(alloc, "{\"style\":true}"));
+    try testing.expectEqual(HapticType.impact_medium, try hapticTypeIn(alloc, "{\"style\":[\"heavy\"]}"));
+    try testing.expectEqual(HapticType.impact_medium, try hapticTypeIn(alloc, "{\"style\":{\"v\":\"heavy\"}}"));
+
+    // And an unrecognised string takes the spec's `default:` arm rather than
+    // failing — `craft.haptics.selection()` posts 'soft'.
+    try testing.expectEqual(HapticType.impact_medium, try hapticTypeIn(alloc, "{\"style\":\"soft\"}"));
+
+    // Malformed input is the one thing that is not a style: there is no
+    // dictionary for Swift's subscript to read, so this cannot take the
+    // default and call itself faithful.
+    try testing.expectError(bridge_error.BridgeError.InvalidJSON, hapticTypeIn(alloc, "not json"));
+    try testing.expectError(bridge_error.BridgeError.InvalidJSON, hapticTypeIn(alloc, "[1,2]"));
 }
 
 test "every style the shipped surface posts maps the way the spec's switch does" {

--- a/packages/zig/src/ios_dispatch.zig
+++ b/packages/zig/src/ios_dispatch.zig
@@ -382,8 +382,10 @@ comptime {
 ///
 /// `.status = .unavailable` in a module's manifest means the handler is
 /// reachable and refuses, deliberately, because Zig cannot do the thing
-/// correctly — `haptic` cannot see `config.enableHaptics`, and the rest say
-/// why in their own `reason`.
+/// correctly; each one says why in its own `reason`. `haptic` was the example
+/// this comment used to give, and is now the example of a reason expiring:
+/// `ios_config.zig` made `config.enableHaptics` readable and the refusal
+/// outlived it.
 ///
 /// In the Zig-hosted app that refusal is the honest end of the line: `route`
 /// tries `handOffToHost` next, and the shim is what actually serves it. The
@@ -391,8 +393,9 @@ comptime {
 /// deliberately does not consult `handOffToHost`, because there the host *is*
 /// the caller. So claiming one of these would not be a refusal instead of an
 /// answer, it would be a refusal instead of the *host's working answer*: an app
-/// that has haptics today would stop buzzing the moment the runtime was linked,
-/// and the page would get a rejection where it used to get silence-and-a-buzz.
+/// that had haptics would have stopped buzzing the moment the runtime was
+/// linked, and the page would have got a rejection where it used to get
+/// silence-and-a-buzz.
 ///
 /// `test/ios_conformance_test.zig` already treats falling through as better
 /// than `.unavailable`. This is that rule, applied to the one path that had no
@@ -904,7 +907,6 @@ test "an action declared unavailable is left to the host, not claimed" {
     // the difference, linking the runtime replaced the working answer with a
     // rejection. `false` here is what sends the call back to Swift's switch.
     const declared_unavailable = [_][]const u8{
-        "haptic",
         "getNetworkStatus",
         "lockOrientation",
         "unlockOrientation",
@@ -929,7 +931,7 @@ test "the fall-through is read from the manifests, not from a list kept beside t
             }
         }
     }
-    try testing.expectEqual(@as(usize, 4), declared);
+    try testing.expectEqual(@as(usize, 3), declared);
 }
 
 test "a live action is still claimed, unavailable is not a blanket hand-back" {
@@ -937,6 +939,10 @@ test "a live action is still claimed, unavailable is not a blanket hand-back" {
     // `.live`, so the seam must keep claiming it. A fall-through that widened
     // to whole modules would silently un-migrate everything beside a refusal.
     try testing.expect(!hostServesItself("vibrate"));
+    // `haptic` was the fourth entry above until `ios_config.zig` made the gate
+    // it could not read readable. It is served here now, so handing it back
+    // would hand back a working action.
+    try testing.expect(!hostServesItself("haptic"));
     try testing.expect(!hostServesItself("setKeepAwake"));
     try testing.expect(!hostServesItself("getDeviceInfo"));
     try testing.expect(!hostServesItself("noSuchAction"));

--- a/packages/zig/test/ios_conformance_test.zig
+++ b/packages/zig/test/ios_conformance_test.zig
@@ -643,6 +643,113 @@ test "the gate table has no entry for an action Zig does not serve" {
     }
 }
 
+/// The `.reason` text of every `.status = .unavailable` entry, by action.
+///
+/// The reason is what a reader trusts, so it is what has to be checked. A
+/// declaration can be resolved two ways here: `.reason = "..."` inline, and
+/// `.reason = some_const` naming a constant elsewhere in the file — both are
+/// in use, and a scan that handled only the first would silently skip the
+/// second rather than fail.
+fn collectUnavailableReasons(allocator: std.mem.Allocator) !std.StringHashMap([]const u8) {
+    var map = std.StringHashMap([]const u8).init(allocator);
+    errdefer map.deinit();
+
+    for (zig_sources) |source| {
+        // Bounded to the manifest array, not the whole file: prose quotes
+        // `.status = .unavailable` — `bridge_mobile_haptics.zig`'s header does,
+        // describing the declaration it removed — and a scan that read comments
+        // would attribute that sentence to whichever entry preceded it.
+        const table_start = std.mem.indexOf(u8, source, "pub const capability_actions = [_]capabilities.ActionDecl{") orelse
+            continue;
+        const table_end = std.mem.indexOfPos(u8, source, table_start, "\n};") orelse continue;
+        const table = source[table_start..table_end];
+
+        var search: usize = 0;
+        while (std.mem.indexOfPos(u8, table, search, ".status = .unavailable")) |at| {
+            search = at + 1;
+
+            // The entry names its action as `A.some_const`; resolve it back
+            // through the `A` block to the string the spec spells.
+            const name_at = std.mem.lastIndexOf(u8, table[0..at], ".name = A.") orelse continue;
+            const const_start = name_at + ".name = A.".len;
+            var const_end = const_start;
+            while (const_end < table.len and (std.ascii.isAlphanumeric(table[const_end]) or
+                table[const_end] == '_')) : (const_end += 1)
+            {}
+
+            var needle_buf: [96]u8 = undefined;
+            const member = table[const_start..const_end];
+            if (member.len + 16 > needle_buf.len) continue;
+            const decl = try std.fmt.bufPrint(&needle_buf, "const {s} = \"", .{member});
+            const decl_at = std.mem.indexOf(u8, source, decl) orelse continue;
+            const value_start = decl_at + decl.len;
+            const value_end = std.mem.indexOfScalarPos(u8, source, value_start, '"') orelse continue;
+            const action = source[value_start..value_end];
+
+            // The reason, inline or by name.
+            const reason_at = std.mem.indexOfPos(u8, table, at, ".reason = ") orelse continue;
+            const reason_start = reason_at + ".reason = ".len;
+            if (table[reason_start] == '"') {
+                const reason_end = std.mem.indexOfScalarPos(u8, table, reason_start + 1, '"') orelse continue;
+                try map.put(action, table[reason_start + 1 .. reason_end]);
+            } else {
+                var ident_end = reason_start;
+                while (ident_end < table.len and (std.ascii.isAlphanumeric(table[ident_end]) or
+                    table[ident_end] == '_')) : (ident_end += 1)
+                {}
+                var const_buf: [96]u8 = undefined;
+                const ident = table[reason_start..ident_end];
+                if (ident.len + 10 > const_buf.len) continue;
+                const const_decl = try std.fmt.bufPrint(&const_buf, "const {s} =", .{ident});
+                const body_at = std.mem.indexOf(u8, source, const_decl) orelse continue;
+                const body_end = std.mem.indexOfScalarPos(u8, source, body_at, ';') orelse continue;
+                // The whole initialiser, `++` concatenation included.
+                try map.put(action, source[body_at..body_end]);
+            }
+        }
+    }
+    return map;
+}
+
+test "no refusal blames a config flag Zig demonstrably reads" {
+    // The rot this exists to catch, in the exact shape it took. `haptic` was
+    // declared `.status = .unavailable` because `config.enableHaptics` "is not
+    // visible to Zig"; `gateFor`'s table said Zig reads that same flag and
+    // refuses the action when it is off. Both were written honestly, months
+    // apart, and nothing put them side by side — so the refusal outlived its
+    // reason and a working implementation sat unused two hundred lines below it.
+    //
+    // Deliberately narrower than "gated and unavailable", which is not a
+    // contradiction: `lockOrientation` is both, and its reason is about a root
+    // view controller rather than about reading a flag. What cannot stand is a
+    // refusal *naming* a flag the gate table proves Zig reads.
+    var gates = try collectZigGates(testing.allocator);
+    defer gates.deinit();
+
+    var reasons = try collectUnavailableReasons(testing.allocator);
+    defer reasons.deinit();
+
+    // Non-vacuity: the scan reads each manifest through two indirections — the
+    // `A.` constant and its declaration — and either could stop matching.
+    try testing.expect(reasons.count() >= 3);
+
+    var it = reasons.iterator();
+    while (it.next()) |entry| {
+        const flag = gates.get(entry.key_ptr.*) orelse continue;
+        if (std.mem.indexOf(u8, entry.value_ptr.*, flag) != null) {
+            std.debug.print(
+                "`{s}` is declared unavailable and its reason names `{s}`, which `gateFor` " ++
+                    "maps it to.\n" ++
+                    "  The manifest says Zig cannot read that flag; the gate table says it does " ++
+                    "and refuses the action when it is off.\n" ++
+                    "  One of them is out of date.\n",
+                .{ entry.key_ptr.*, flag },
+            );
+            return error.RefusalBlamesAFlagZigReads;
+        }
+    }
+}
+
 test "every flag Zig can read is a flag the spec's config actually has" {
     // A misspelled key is not a one-flag bug. A key that is not in the file
     // reads as missing, and one missing key makes the whole decode throw, so


### PR DESCRIPTION
Stacked on #129 — review the top commit.

## A reason that was right, and stopped being right

`haptic` was declared `.status = .unavailable`, and the manifest said why:

> iOS gates haptic on `config.enableHaptics`, which defaults to false and **is not visible to Zig**; serving it here would enable haptics for every app that never opted in

That was exactly right when it was written. The Taptic Engine has no readback, so a flip would have been invisible in CI and obvious on a device — and with `enableHaptics` defaulting to false in both the template and the SDK, the blast radius was every app that had not opted in. The module header even wrote down what unblocking it would take: *"plumb the flag in (a `craft_ios_set_capabilities` export or a build option), then swap the refusal in `haptic()` for the mapping and the trigger below, both of which are written and pinned by the tests at the bottom of this file."*

That condition has been met, by work that was not looking at this file. `ios_config.zig` reads `craft.config.json` out of the bundle — better than either route the header proposed — `gateFor("haptic")` maps the action to `.haptics`, and `ios_dispatch.zig` refuses any gated action whose flag is off *before* the module chain runs. The precise hazard the refusal protected against is now the one case that cannot happen: an app on the default config gets `CAPABILITY_DISABLED`, which is what the spec's `else` arm sends too.

## Why this one is different from the other three

Three reasons have expired during this migration and been found by reading. This one was **contradicted by another file in the same tree**: the manifest said Zig could not read `enableHaptics`; `gateFor`'s table said Zig reads that exact flag and refuses the action on it. Both written honestly, months apart, with nothing putting them side by side.

That is checkable, so it is now checked. `ios_conformance_test.zig` fails the build for a refusal whose `.reason` names a flag `gateFor` maps to that action.

Deliberately narrower than "gated and unavailable", which is **not** a contradiction — `lockOrientation` is both, and its reason is about needing a root view controller overriding `supportedInterfaceOrientations`, which has nothing to do with reading a flag. What cannot stand is a refusal *naming* a flag the gate table proves Zig reads. Restoring the original declaration verbatim fails the new test.

## The change itself

The implementation was already written and pinned, as the header promised — `hapticTypeForStyle` maps all seven styles the way `triggerHaptic(style:)` does, and `triggerHapticChecked` is already called in production by `bridge_mobile_speech.zig`.

What is new is `hapticTypeIn`: the whole of the action's decision — `body["style"] as? String ?? "medium"`, then the spec's switch — split out so it can be asserted on a host. The trigger cannot be; `UIImpactFeedbackGenerator` is not in a test runner's process, so an end-to-end call can only observe `ClassNotFound`, which says nothing about whether the right style was chosen. That is also the half where a mistake stays silent on a device: a `heavy` served as `medium` just feels like a device being a device.

The gate is deliberately **not** re-checked inside the handler. Reaching it already means `enableHaptics` is true, and a second copy of the rule is a second thing that can disagree.

## Behaviour

| config | before | after |
| --- | --- | --- |
| `enableHaptics: false` | Zig hands back; shim rejects `CAPABILITY_DISABLED` | Zig's gate rejects `CAPABILITY_DISABLED` |
| `enableHaptics: true` | Zig hands back; shim calls `triggerHaptic(style:)` | Zig parses `style` and fires the same generator |

`hostServesItself` stops handing `haptic` back — its list drops to three, and the manifest-derived count test drops with it. The two tests that pinned the refusal are replaced by ones that pin what the action decides, including every non-string `style` (absent, null, number, bool, array, object) taking the same default the spec's `??` gives it, and malformed input being the one thing that is not a style.

`zig build test:ios`: 5 + 1067 + 19, all green.
