### PR TITLE
fix(sdk): the event map typed one event that never fires and missed six that do

### DIFF
--- a/packages/typescript/types/craft.d.ts
+++ b/packages/typescript/types/craft.d.ts
@@ -1145,13 +1145,33 @@ export interface PickedFile {
   mimeType?: string;
 }
 
+/**
+ * A location fix, exactly as the bridge sends it.
+ *
+ * All eight fields are always present. The native dictionary is built
+ * unconditionally from `CLLocation`'s non-optional properties, so there is no
+ * path that omits one — and this type previously declared six of them, three
+ * of those optional, which left `altitudeAccuracy` and `timestamp` unreachable
+ * from TypeScript even though every fix carries them.
+ *
+ * `heading` and `speed` are `-1` when the device has no fix for them, which is
+ * CoreLocation's own sentinel rather than an absent key. Android has no
+ * geolocation surface, so nothing else fills this in.
+ */
 export interface Position {
   latitude: number;
   longitude: number;
+  /** Horizontal accuracy in metres. */
   accuracy: number;
-  altitude?: number;
-  speed?: number;
-  heading?: number;
+  altitude: number;
+  /** Vertical accuracy in metres. */
+  altitudeAccuracy: number;
+  /** Course over ground in degrees, or `-1` when unavailable. */
+  heading: number;
+  /** Metres per second, or `-1` when unavailable. */
+  speed: number;
+  /** Milliseconds since the Unix epoch. */
+  timestamp: number;
 }
 
 export interface Contact {
@@ -1378,12 +1398,29 @@ export interface CraftARPlaneEvent extends CustomEvent {
   detail: ARPlaneEvent;
 }
 
+/**
+ * A home-screen quick action being tapped.
+ *
+ * **Never dispatched today.** `craft.shortcuts.set()` really does install the
+ * items and they appear in the long-press menu, but no template implements
+ * `application(_:performActionFor:completionHandler:)` or a scene-delegate
+ * equivalent, so a tap launches the app and stops there. A listener registered
+ * for this is never called.
+ */
 export interface CraftShortcutEvent extends CustomEvent {
   detail: {
     type: string;
   };
 }
 
+/**
+ * A donated Siri shortcut being invoked.
+ *
+ * **Never dispatched today.** `craft.siri.register()` donates an
+ * `NSUserActivity`, but the only `onContinueUserActivity` in the template is
+ * bound to `NSUserActivityTypeBrowsingWeb` and routes to the deep-link
+ * handler, so invoking a donated shortcut relaunches the app and is dropped.
+ */
 export interface CraftSiriShortcutEvent extends CustomEvent {
   detail: SiriInvocationEvent;
 }
@@ -1402,11 +1439,36 @@ export interface CraftWatchContextEvent extends CustomEvent {
   detail: Record<string, any>;
 }
 
-export interface CraftVoiceActionEvent extends CustomEvent {
+export interface CraftLocationUpdateEvent extends CustomEvent {
+  detail: Position;
+}
+
+export interface CraftLocationErrorEvent extends CustomEvent {
   detail: {
-    action: string;
-    data?: string;
+    message: string;
   };
+}
+
+export interface CraftNetworkChangeEvent extends CustomEvent {
+  detail: NetworkStatus;
+}
+
+export interface CraftPushTokenEvent extends CustomEvent {
+  detail: {
+    token: string;
+  };
+}
+
+/**
+ * The `userInfo` of the notification the user acted on, forwarded verbatim.
+ * The bridge does not reshape it, so its keys are whatever was scheduled.
+ */
+export interface CraftNotificationResponseEvent extends CustomEvent {
+  detail: Record<string, any>;
+}
+
+export interface CraftWatchUserInfoEvent extends CustomEvent {
+  detail: Record<string, any>;
 }
 
 export interface CraftErrorEvent extends CustomEvent {
@@ -1428,14 +1490,24 @@ declare global {
     craftMotionUpdate: CraftMotionUpdateEvent;
     craftBluetoothDevice: CraftBluetoothDeviceEvent;
     craftARPlane: CraftARPlaneEvent;
-    craftShortcut: CraftShortcutEvent;
-    craftSiriShortcut: CraftSiriShortcutEvent;
+    craftLocationUpdate: CraftLocationUpdateEvent;
+    craftLocationError: CraftLocationErrorEvent;
+    craftNetworkChange: CraftNetworkChangeEvent;
+    craftPushToken: CraftPushTokenEvent;
+    craftNotificationResponse: CraftNotificationResponseEvent;
     craftWatchMessage: CraftWatchMessageEvent;
     craftWatchReachability: CraftWatchReachabilityEvent;
     craftWatchContext: CraftWatchContextEvent;
-    craftVoiceAction: CraftVoiceActionEvent;
+    craftWatchUserInfo: CraftWatchUserInfoEvent;
     craftError: CraftErrorEvent;
     craftDeepLink: CraftDeepLinkEvent;
+    // Kept, and kept last, because nothing dispatches either one: the app
+    // installs the shortcuts and donates the activities, and no template
+    // implements the callback that would deliver a tap. Typed so the listener
+    // an app writes today compiles against the shape it will receive if that
+    // lands; see the note on each interface.
+    craftShortcut: CraftShortcutEvent;
+    craftSiriShortcut: CraftSiriShortcutEvent;
   }
 }
 

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -408,6 +408,9 @@ pub fn build(b: *std.Build) void {
     ios_conformance_tests.root_module.addAnonymousImport("src/ios_events.zig", .{
         .root_source_file = b.path("src/ios_events.zig"),
     });
+    ios_conformance_tests.root_module.addAnonymousImport("craft.d.ts", .{
+        .root_source_file = b.path("../typescript/types/craft.d.ts"),
+    });
     ios_conformance_tests.root_module.addAnonymousImport("src/bridge_mobile_vision.zig", .{
         .root_source_file = b.path("src/bridge_mobile_vision.zig"),
     });

--- a/packages/zig/src/bridge_mobile_bgtasks.zig
+++ b/packages/zig/src/bridge_mobile_bgtasks.zig
@@ -103,10 +103,13 @@
 //! posting); a field that is **present with the wrong type** is refused, never
 //! coerced.
 //!
-//! **The `config.enableBackgroundTasks` gate has no Zig mirror.** It appears
-//! nowhere in `packages/zig/src`, so the three actions here are served
-//! unconditionally — the securestore and notifcancel modules document the same
-//! choice. In an app that left the gate at its default `false` this changes a
+//! **The `config.enableBackgroundTasks` gate is read, not skipped.**
+//! `ios_config.gateFor` maps all three actions to `.background_tasks`, so
+//! `ios_dispatch.offerToModules` answers `CAPABILITY_DISABLED` before this
+//! module is asked. This paragraph used to say the flag "appears nowhere in
+//! `packages/zig/src`" and that the actions were served unconditionally — true
+//! when written, false since `ios_config.zig`, and repeated in eight other
+//! module headers that were equally true and are equally false. In an app that left the gate at its default `false` this changes a
 //! hang into an answer: `schedule` now reaches the scheduler and reports
 //! whatever it says (a rejection, until the plist gains
 //! `BGTaskSchedulerPermittedIdentifiers`), and the cancels report the no-op

--- a/packages/zig/src/bridge_mobile_calendar.zig
+++ b/packages/zig/src/bridge_mobile_calendar.zig
@@ -139,10 +139,17 @@
 //! `deleteCalendarEvent` — which requests nothing (3350) — the key is only
 //! evidence of `config.enableCalendar`, and it is checked for that reason.
 //!
-//! **`config.enableCalendar` has no Zig mirror**, the same gap
-//! `bridge_mobile_contactpicker.zig` records for `enableContacts`. The plist key
-//! `packages/ios/src/index.ts:190` writes iff that flag is the stand-in, and the
-//! mapping is exact — nothing else writes or shares it.
+//! **`config.enableCalendar` is read directly now.** `ios_config.gateFor` maps
+//! all three actions to `.calendar`, so `ios_dispatch.offerToModules` answers
+//! `CAPABILITY_DISABLED` before this module is asked. This used to say the flag
+//! had no Zig mirror, which was true until `ios_config.zig` read
+//! `craft.config.json`.
+//!
+//! The plist key `packages/ios/src/index.ts:190` writes iff that flag was the
+//! stand-in, and on the one path where it is *only* evidence of the flag rather
+//! than a precondition of the API it is now redundant with the real gate.
+//! Tracked in issue #131; the paths where the key is a genuine precondition are
+//! separated below and stay.
 //!
 //! **Behaviour changes on every disabled or malformed path, in Zig's favour.**
 //! Swift's three cases have no `else` (717-731): an app with

--- a/packages/zig/src/bridge_mobile_contactpicker.zig
+++ b/packages/zig/src/bridge_mobile_contactpicker.zig
@@ -83,12 +83,20 @@
 //! Until then, "the native call failed" is what a cancel says, and saying so
 //! here is the point.
 //!
-//! **`config.enableContacts` has no Zig mirror.** `ios.zig`'s `AppConfig` has
-//! no such field — the same gap `bridge_mobile_system.zig` records for
-//! `enableShare`. The Info.plist is read instead, and for this flag the mapping
-//! is exact: `packages/ios/src/index.ts:189` writes `NSContactsUsageDescription`
-//! if and only if `config.enableContacts`, with none of the sharing that made
-//! the location keys ambiguous.
+//! **`config.enableContacts` is read directly now, and the plist proxy below
+//! is what is left over.** `ios_config.gateFor` maps this action to
+//! `.contacts`, so `ios_dispatch.offerToModules` answers `CAPABILITY_DISABLED`
+//! before this module is asked. The paragraph here used to say the flag had no
+//! Zig mirror, which was true until `ios_config.zig` read
+//! `craft.config.json`.
+//!
+//! The `NSContactsUsageDescription` check further down was the stand-in for
+//! that flag — `packages/ios/src/index.ts:189` writes the key if and only if
+//! `config.enableContacts`, with none of the sharing that made the location
+//! keys ambiguous. It is now a second, weaker gate behind the real one, and it
+//! can only differ in the direction that refuses an action the config allows:
+//! an app whose Info.plist was not written by the SDK. Tracked in issue #131
+//! along with three more of the same shape.
 //!
 //! Two things about that gate have to be said plainly. First, the key is **not
 //! a precondition of the API**: `CNContactPickerViewController` runs out of

--- a/packages/zig/src/bridge_mobile_filepicker.zig
+++ b/packages/zig/src/bridge_mobile_filepicker.zig
@@ -74,11 +74,12 @@
 //! Info.plist key to read instead: `renderUsageDescriptions`
 //! (`packages/ios/src/index.ts:183-199`) writes nothing from either flag.
 //!
-//! Both are therefore served unconditionally, and an app that set
-//! `enableFilePicker: false` or `enableFileDownload: false` now gets the
-//! behaviour anyway. Restoring the gate means adding the fields to
-//! `AppConfig`, not adding a guess here — the same trade
-//! `bridge_mobile_system.zig` records word for word for `share`.
+//! Both flags are read directly now: `ios_config.gateFor` maps `pickFile` to
+//! `.file_picker` and `saveFile` to `.file_download`, so
+//! `ios_dispatch.offerToModules` answers `CAPABILITY_DISABLED` before this
+//! module is asked. This used to say both were served unconditionally and that
+//! restoring the gate meant adding fields to `AppConfig` — true when written,
+//! and answered by `ios_config.zig` reading `craft.config.json` instead.
 //!
 //! Falling through to the shim is not the safe option it was for
 //! `takeScreenshot`, because the shim does not answer these correctly today:

--- a/packages/zig/src/bridge_mobile_haptics.zig
+++ b/packages/zig/src/bridge_mobile_haptics.zig
@@ -1,10 +1,34 @@
 //! The haptics half of the `mobile` namespace: `haptic` and `vibrate`.
 //!
 //! Split out of `bridge_mobile.zig` because the two actions have opposite
-//! contracts — `haptic` is fire-and-forget and gated on a config flag, while
-//! `vibrate` replies and is gated on nothing — and because one of them cannot
-//! be served honestly from Zig yet. Keeping that admission next to the working
-//! action, rather than folded into the namespace's main file, is the point.
+//! contracts: `haptic` is fire-and-forget and gated on `config.enableHaptics`,
+//! `vibrate` replies and is gated on nothing.
+//!
+//! ## The refusal that used to live here
+//!
+//! `haptic` was declared `.status = .unavailable` for one reason, quoted from
+//! the manifest it carried: the flag "is not visible to Zig; serving it here
+//! would enable haptics for every app that never opted in". That was exactly
+//! right when it was written. The Taptic Engine has no readback, so a flip
+//! would have been invisible in CI and obvious on a device — and the default
+//! config has `enableHaptics` false, so the blast radius was every app that
+//! had not opted in.
+//!
+//! The condition that reason set for itself has since been met, by work that
+//! was not looking at this file. `ios_config.zig` reads `craft.config.json`
+//! out of the bundle, `gateFor("haptic")` maps the action to `.haptics`, and
+//! `ios_dispatch.zig` refuses any gated action whose flag is off *before* the
+//! module chain runs. The precise hazard the refusal was protecting against —
+//! an app on the default config buzzing on `craft.haptics.impact()` — is now
+//! the one case that cannot happen: the gate rejects it with
+//! `CAPABILITY_DISABLED`, which is what the spec's `else` arm sends too.
+//!
+//! Nothing re-checked that. The reason sat here, correct on the day it was
+//! written and wrong for every day after `ios_config.zig` landed, and the only
+//! way it surfaced was someone reading it again. `ios_conformance_test.zig`
+//! now fails the build for a gated action declared `.unavailable`, because a
+//! module claiming both "Zig can enforce this gate" and "Zig cannot read this
+//! gate" is stating a contradiction that a test can see.
 
 const std = @import("std");
 const builtin = @import("builtin");
@@ -25,53 +49,46 @@ pub const A = struct {
     pub const vibrate = "vibrate";
 };
 
-/// `haptic` is declared `unavailable`, and that is a decision, not an oversight.
+/// The whole of `haptic`'s decision: `body["style"] as? String ?? "medium"`,
+/// then the spec's switch.
 ///
-/// The Swift it replaces does not run `triggerHaptic` unconditionally — it runs
-/// it `if config.enableHaptics` (`CraftApp.swift:537`), and that flag defaults
-/// to **false** in both the template (`CraftApp.swift:190`) and the SDK
-/// (`packages/ios/src/index.ts:118`). It reaches Zig through nothing: no
-/// `craft_ios_*` export carries it, no build option encodes it. So serving
-/// `haptic` from here means serving a *different action* from the one the spec
-/// defines — every app on the default config would start buzzing on
-/// `craft.haptics.impact()`, which is the entire shipped haptics surface, and
-/// no test in this repo could see it because the Taptic Engine has no readback.
-///
-/// The three ways to make that go away are all worse than saying so:
-///   - fire anyway → a behaviour change that is invisible in CI and obvious on
-///     a device;
-///   - hardcode the gate false → a permanent no-op that reports nothing, which
-///     is the shape of the nine Android handlers that were deleted;
-///   - reply `{"success":true}` → fabricated success, the thing this migration
-///     exists to stop.
-///
-/// So the handler refuses and the manifest says why. Unblocking it is small and
-/// deliberate: plumb the flag in (a `craft_ios_set_capabilities` export or a
-/// build option), then swap the refusal in `haptic()` for the mapping and the
-/// trigger below, both of which are written and pinned by the tests at the
-/// bottom of this file. What must not happen is the flip happening silently.
-///
-/// Note the inconsistency this preserves: `case "vibrate"` has no
-/// `enableHaptics` gate in the spec either, so `craft.vibrate([100])` already
-/// fires impacts on an app with haptics "disabled". `vibrate` stays ungated to
-/// match; the asymmetry is the spec's, not ours.
-const haptic_unavailable_reason =
-    "iOS gates haptic on config.enableHaptics, which defaults to false and is " ++
-    "not visible to Zig; serving it here would enable haptics for every app " ++
-    "that never opted in";
+/// Split out from `haptic` so it can be asserted on a host. The trigger cannot
+/// — `UIImpactFeedbackGenerator` is not in a test runner's process — so a test
+/// calling `haptic` end-to-end can only observe `ClassNotFound`, which says
+/// nothing about whether the right style was chosen. This is the half where a
+/// mistake would be silent on a device too: the Taptic Engine has no readback,
+/// so a `heavy` served as `medium` feels like a device being a device.
+fn hapticTypeIn(allocator: std.mem.Allocator, data: []const u8) !HapticType {
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, data, .{}) catch
+        return bridge_error.BridgeError.InvalidJSON;
+    defer parsed.deinit();
 
+    const root = switch (parsed.value) {
+        .object => |obj| obj,
+        else => return bridge_error.BridgeError.InvalidJSON,
+    };
+
+    // Swift's `as? String` fails for every non-string, and `?? "medium"` sends
+    // all of them to the same place: absent, null, number, bool, array, object.
+    const style = switch (root.get("style") orelse std.json.Value{ .null = {} }) {
+        .string => |text| text,
+        else => "medium",
+    };
+    return hapticTypeForStyle(style);
+}
+
+/// `vibrate` stays ungated, and that is the spec's asymmetry rather than ours.
+///
+/// `case "vibrate"` has no `enableHaptics` check in the spec, so
+/// `craft.vibrate([100])` fires impacts on an app with haptics "disabled".
+/// Adding a gate here would be a divergence dressed as a tidy-up.
 pub const capability_actions = [_]capabilities.ActionDecl{
-    // `.none` is the action's contract regardless of status: the page's
-    // `craft.haptic()` returns undefined and the spec's `case "haptic"` never
-    // touches `resolveCallback`. An error still reaches the page — with no
-    // pending entry to settle, `craft-bridge.js` reports it to the console —
-    // so a refusal is logged rather than swallowed.
-    .{
-        .name = A.haptic,
-        .reply = .none,
-        .status = .unavailable,
-        .reason = haptic_unavailable_reason,
-    },
+    // `.none` is the contract: the page's `craft.haptic()` returns undefined
+    // and the spec's `case "haptic"` never touches `resolveCallback`. An error
+    // still reaches the page — with no pending entry to settle,
+    // `craft-bridge.js` reports it to the console — so a refusal is logged
+    // rather than swallowed.
+    .{ .name = A.haptic, .reply = .none },
     // `.result` carrying the JSON literal `true`. Not a shape worth improving:
     // the hand-off path already delivers exactly this today, and `.none` would
     // park any `_req`-based caller for the full 30s timeout.
@@ -104,19 +121,27 @@ pub const HapticsBridge = struct {
         return bridge_error.BridgeError.UnknownAction;
     }
 
-    /// Refuses, for the reason recorded on `haptic_unavailable_reason`.
+    /// `case "haptic"` (`CraftApp.swift:576-582`).
     ///
-    /// The payload is not parsed first. Reporting a malformed `style` would
-    /// imply the style was going to be used, and it is not — a refusal that
-    /// sometimes reports a different cause is harder to act on than one that
-    /// always says the same thing.
+    /// The gate is not checked here. `ios_dispatch.route` refuses every gated
+    /// action whose flag is off before any module is asked, so reaching this
+    /// function already means `enableHaptics` is true — and checking twice
+    /// would put a second copy of the rule where the two could disagree.
     ///
-    /// The error name is what lands in the device log; the page sees
-    /// `NATIVE_CALL_FAILED`, `ios_dispatch.asBridgeError`'s catch-all, because
-    /// the wire protocol has no code for "declared unavailable". The manifest
-    /// is where an app reads the actual reason.
-    fn haptic(_: *Self, _: []const u8) !void {
-        return error.HapticsGateNotVisibleToZig;
+    /// `style` is read the way Swift reads it: `body["style"] as? String ??
+    /// "medium"`. A missing key, a number, an object — every failed cast takes
+    /// the same default, so this reads the string when there is one and hands
+    /// `hapticTypeForStyle` the literal `"medium"` otherwise. That is one
+    /// spelling of the default rather than two: `hapticTypeForStyle` maps an
+    /// unrecognised style to `.impact_medium` as well, matching the spec's
+    /// `default:` arm, and this path exercises the same branch.
+    ///
+    /// No reply on success, matching `.none` and the spec. The error from
+    /// `triggerHapticChecked` is the one thing that can come back, and it means
+    /// UIKit was not there to accept the call — never that the device stayed
+    /// still, which no iOS API reports.
+    fn haptic(self: *Self, data: []const u8) !void {
+        try triggerHapticChecked(try hapticTypeIn(self.allocator, data));
     }
 
     /// `case "vibrate"` (`CraftApp.swift:685-691`).
@@ -472,7 +497,9 @@ test "an unavailable action carries the reason with it" {
         try testing.expect(decl.reason != null);
         try testing.expect(decl.reason.?.len > 0);
     }
-    try testing.expectEqual(capabilities.ActionStatus.unavailable, capability_actions[0].status);
+    // Both live now. `haptic` was `.unavailable` until `ios_config.zig` made
+    // the flag its reason blamed readable; see the module header.
+    try testing.expectEqual(capabilities.ActionStatus.live, capability_actions[0].status);
     try testing.expectEqual(capabilities.ActionStatus.live, capability_actions[1].status);
 }
 
@@ -508,18 +535,36 @@ test "an action the namespace does not serve is reported, not ignored" {
     );
 }
 
-test "haptic refuses rather than firing an ungated haptic" {
-    // The refusal is the migration's honest answer while `config.enableHaptics`
-    // has no Zig representation. If this test starts failing because someone
-    // implemented the action, the flag has to have been plumbed through first —
-    // that is the conversation this assertion exists to force.
-    var bridge = HapticsBridge.init(testing.allocator);
-    defer bridge.deinit();
+test "haptic reads the style the way the spec's cast reads it" {
+    // What replaced the refusal. The old test asserted
+    // `error.HapticsGateNotVisibleToZig` and existed to force a conversation if
+    // anyone implemented the action; the flag is readable now
+    // (`ios_config.gateFor("haptic")`), the conversation happened, and this is
+    // what the action actually decides.
+    const alloc = testing.allocator;
 
-    try testing.expectError(
-        error.HapticsGateNotVisibleToZig,
-        bridge.handleMessage(A.haptic, "{\"style\":\"medium\"}"),
-    );
+    try testing.expectEqual(HapticType.impact_heavy, try hapticTypeIn(alloc, "{\"style\":\"heavy\"}"));
+    try testing.expectEqual(HapticType.selection, try hapticTypeIn(alloc, "{\"style\":\"selection\"}"));
+
+    // `as? String` fails for each of these, and `?? "medium"` catches them all.
+    // A page posting `{style: 2}` gets a medium impact, not an error — matching
+    // the spec, which cannot report one either: `case "haptic"` has no reply.
+    try testing.expectEqual(HapticType.impact_medium, try hapticTypeIn(alloc, "{}"));
+    try testing.expectEqual(HapticType.impact_medium, try hapticTypeIn(alloc, "{\"style\":null}"));
+    try testing.expectEqual(HapticType.impact_medium, try hapticTypeIn(alloc, "{\"style\":2}"));
+    try testing.expectEqual(HapticType.impact_medium, try hapticTypeIn(alloc, "{\"style\":true}"));
+    try testing.expectEqual(HapticType.impact_medium, try hapticTypeIn(alloc, "{\"style\":[\"heavy\"]}"));
+    try testing.expectEqual(HapticType.impact_medium, try hapticTypeIn(alloc, "{\"style\":{\"v\":\"heavy\"}}"));
+
+    // And an unrecognised string takes the spec's `default:` arm rather than
+    // failing — `craft.haptics.selection()` posts 'soft'.
+    try testing.expectEqual(HapticType.impact_medium, try hapticTypeIn(alloc, "{\"style\":\"soft\"}"));
+
+    // Malformed input is the one thing that is not a style: there is no
+    // dictionary for Swift's subscript to read, so this cannot take the
+    // default and call itself faithful.
+    try testing.expectError(bridge_error.BridgeError.InvalidJSON, hapticTypeIn(alloc, "not json"));
+    try testing.expectError(bridge_error.BridgeError.InvalidJSON, hapticTypeIn(alloc, "[1,2]"));
 }
 
 test "every style the shipped surface posts maps the way the spec's switch does" {

--- a/packages/zig/src/bridge_mobile_imagepicker.zig
+++ b/packages/zig/src/bridge_mobile_imagepicker.zig
@@ -78,23 +78,30 @@
 //! **false** (`CraftApp.swift:192`, `packages/ios/src/index.ts:120`). When it
 //! is false the `case` falls off the end and replies *nothing at all*, while
 //! `CraftSwiftShim.handleAction` still returns `true` (`:5247`) so Zig
-//! believes the hand-off succeeded. The injected promise is the hand-built
-//! kind with no timeout. **In a default-config app, `openCamera` and
-//! `pickImage` hang the page forever today.** The "working Swift shim" is
-//! only working for an app that set `enableCamera: true`.
+//! believes the hand-off succeeded, and the injected promise is the hand-built
+//! kind with no timeout — so on the shim a default-config app hangs the page
+//! forever. `ios_config.gateFor` maps both actions to `.camera` now, so
+//! `ios_dispatch.offerToModules` answers `CAPABILITY_DISABLED` first and that
+//! hang is unreachable while Zig is linked. This paragraph asserted the hang
+//! in the present tense until then, and the next one said `enableCamera` had
+//! no Zig-reachable channel at all.
 //!
-//! `enableCamera` has no Zig-reachable channel, so this module gates on the
-//! Info.plist keys `packages/ios/src/index.ts:185-186` writes:
+//! The Info.plist keys `packages/ios/src/index.ts:185-186` writes are still
+//! read, for two different reasons:
 //!
 //!  - **`NSCameraUsageDescription` is an extra gate on `openCamera` only, and
 //!    it is a crash guard rather than a config proxy.** Presenting a `.camera` picker in a
 //!    process without that key is a TCC termination, not an error anything
 //!    could be told about. It is written for
 //!    `enableCamera || enableVideoRecording || enableQRScanner || enableAR`.
-//!  - **`NSPhotoLibraryUsageDescription` stands in for `config.enableCamera`,
+//!  - **`NSPhotoLibraryUsageDescription` stood in for `config.enableCamera`,
 //!    and it is over-broad by `enableVideoRecording`** — it is written for
-//!    `enableCamera || enableVideoRecording`, which is the closest proxy
-//!    available. It is emphatically **not** a photo-library permission gate:
+//!    `enableCamera || enableVideoRecording`, which was the closest proxy
+//!    available while the flag could not be read. It is now a second, weaker
+//!    gate behind the real one, and the only one of these proxies inexact even
+//!    in an SDK-generated app. Tracked in issue #131 with three more.
+//!
+//!    It is emphatically **not** a photo-library permission gate:
 //!    `UIImagePickerController` with `.photoLibrary` has run out-of-process
 //!    since iOS 11 and neither prompts nor requires the key. Refusing on it is
 //!    a statement about how the app was configured, never about what the

--- a/packages/zig/src/bridge_mobile_location.zig
+++ b/packages/zig/src/bridge_mobile_location.zig
@@ -1236,16 +1236,20 @@ const key_always = "NSLocationAlwaysAndWhenInUseUsageDescription";
 /// Decide, from evidence in the running process, whether geolocation was
 /// configured and which prompt to ask for.
 ///
-/// Neither `config.enableGeolocation` nor `config.enableBackgroundLocation` has
-/// a Zig mirror — they appear nowhere in `packages/zig/src` outside a comment —
-/// which is the same gap `bridge_mobile_watch.zig` documents for
-/// `enableWatchApp`. Rather than guess, this reads the Info.plist keys the
-/// generator writes from exactly those flags. Apple requires the usage
-/// description before authorization may be requested at all, so its absence is
-/// both the honest signal that the app was never built for location and the
-/// condition under which requesting would be illegitimate; the refusal happens
+/// Both `config.enableGeolocation` and `config.enableBackgroundLocation` are
+/// read directly now — `ios_config.gateFor` maps `getCurrentPosition`,
+/// `watchPosition` and `startLocationRecording` to `.geolocation`, and
+/// `ios_dispatch.offerToModules` answers `CAPABILITY_DISABLED` before this
+/// module is asked. This used to say neither had a Zig mirror and that they
+/// appeared nowhere in `packages/zig/src`; `ios_config.zig`'s own header names
+/// this file as one of the workarounds it replaced.
+///
+/// The plist read below stays, and not as a config proxy. Apple requires the
+/// usage description before authorization may be requested at all, so its
+/// absence is the condition under which requesting would be illegitimate — a
+/// precondition of the API rather than evidence of a flag. The refusal happens
 /// before any request is made, so what the system would otherwise do never
-/// arises.
+/// arises, and which of the two keys is present still selects the prompt.
 ///
 /// Two divergences, both real and neither hideable:
 ///

--- a/packages/zig/src/bridge_mobile_motion.zig
+++ b/packages/zig/src/bridge_mobile_motion.zig
@@ -79,15 +79,21 @@
 //! `else`**, so on the Swift path with the flag off `startMotionUpdates`
 //! replies nothing at all while `CraftSwiftShim.handleAction` still returns
 //! true: the page's promise never settles. The flag defaults to `false`
-//! (`packages/ios/src/index.ts:139`) and has no mirror anywhere under
-//! `packages/zig/src`.
+//! (`packages/ios/src/index.ts:139`). It is read directly now:
+//! `ios_config.gateFor` maps `startMotionUpdates` to `.motion_sensors`, so
+//! `ios_dispatch.offerToModules` answers `CAPABILITY_DISABLED` before this
+//! module is asked. Until `ios_config.zig` read `craft.config.json` the flag
+//! had no mirror anywhere under `packages/zig/src`, and the paragraph below is
+//! what this module did about that.
 //!
 //! `NSMotionUsageDescription` is an *exact* proxy for it —
 //! `packages/ios/src/index.ts:192` writes that Info.plist key from
 //! `config.enableMotionSensors` and from nothing else, with no `||` (unlike the
 //! location keys, where `bridge_mobile_location.zig` had to document a residual
 //! gap). So `requireMotionConfigured` reads the key and refuses when it is
-//! absent. Two things that buys, and one it costs:
+//! absent — now a second, weaker gate behind the real one, which can only
+//! differ by refusing an action the config allows. Tracked in issue #131 with
+//! three more of the same shape. Two things it bought, and one it cost:
 //!
 //!  - a hang becomes a nameable refusal, which is strictly better than the
 //!    shim's silence;
@@ -249,8 +255,9 @@ pub const default_interval_ms: f64 = 100;
 const reply_true = "true";
 
 /// Emitted into Info.plist by `packages/ios/src/index.ts:192` iff
-/// `config.enableMotionSensors` — the flag with no Zig mirror. See the module
-/// comment for what this proxy claims and what it does not.
+/// `config.enableMotionSensors`, which `ios_config.gateFor` now reads directly.
+/// See the module comment for what this proxy claims, what it does not, and why
+/// it is redundant with the real gate.
 const key_motion_usage = "NSMotionUsageDescription";
 
 /// Which handler an action selects, split out from `handleMessage` so the

--- a/packages/zig/src/bridge_mobile_notifcancel.zig
+++ b/packages/zig/src/bridge_mobile_notifcancel.zig
@@ -43,11 +43,11 @@
 //! with no `else`: a missing `id`, a non-string `id`, or the gate at its
 //! default `false` replies nothing at all, and the untimed promise never
 //! settles. Malformed input errors here instead (`MissingData` /
-//! `InvalidParameter`). The `enableLocalNotifications` gate has no Zig mirror
-//! (it appears nowhere in `packages/zig/src`), so the actions are served
-//! unconditionally — the securestore module documents the same choice, and
-//! cancelling notifications grants a page strictly less than the wipe that
-//! precedent already serves ungated.
+//! `InvalidParameter`), and the gate itself is read rather than skipped:
+//! `ios_config.gateFor` maps all three actions to `.local_notifications`, so
+//! `ios_dispatch.offerToModules` answers `CAPABILITY_DISABLED` before this
+//! module is asked. A settled rejection rather than a hang is the divergence,
+//! and it is the whole of it.
 //!
 //! **An `id` with an embedded NUL.** `\u0000` is a legal JSON escape and a
 //! page can send it; the route to the UN center is `stringWithUTF8String:`,

--- a/packages/zig/src/bridge_mobile_notifications.zig
+++ b/packages/zig/src/bridge_mobile_notifications.zig
@@ -40,11 +40,10 @@
 //! **Swift's silent hang.** The dispatcher arm is
 //! `if config.enableLocalNotifications { … }` with no `else`, and the gate
 //! defaults to `false` — so with notifications disabled the untimed promise
-//! never settles. `enableLocalNotifications` has no mirror anywhere in
-//! `packages/zig/src`, so this action is served unconditionally, the same call
-//! `bridge_mobile_securestore.zig` and `bridge_mobile_notifcancel.zig` made.
-//! Listing an app's *own* pending notifications grants a page strictly less
-//! than the cancel-everything that precedent already serves ungated.
+//! never settles. Here the flag is read: `ios_config.gateFor` maps this action
+//! to `.local_notifications` and `ios_dispatch.offerToModules` answers
+//! `CAPABILITY_DISABLED` before this module is asked. A settled rejection
+//! rather than a hang is the divergence, and it is the whole of it.
 //!
 //! **A truncated string reported as the whole one.** `-[NSString UTF8String]`
 //! is NUL-terminated, so a stored title carrying an embedded U+0000 — which

--- a/packages/zig/src/bridge_mobile_securestore.zig
+++ b/packages/zig/src/bridge_mobile_securestore.zig
@@ -40,18 +40,27 @@
 //! **Swift's silent hang.** The set/get/remove dispatcher arms are `if let`s
 //! with no `else`: a missing `key`, a non-string `value`, or a disabled
 //! `enableSecureStorage` config replies nothing at all, and the legacy promise
-//! never settles. Malformed input errors here instead. The capability gate has
-//! no Zig mirror (`enableSecureStorage` appears nowhere in `packages/zig/src`),
-//! so the actions are served unconditionally. For set/get/remove that grants a
-//! page nothing new: the *ungated* sharedItems actions next door already
-//! read and write the same items (one namespace — see above). The two gated
-//! modules that came before chose differently — clipboard kept its gate
-//! plumbable (`craft_ios_set_clipboard_enabled`, rejecting `PermissionDenied`
-//! when off) and haptics declared its gated action `.unavailable` — and
-//! `secureClear` is where the difference is real: under Swift's default-false
-//! gate a page got CAPABILITY_DISABLED instead of a wipe, and here the wipe is
-//! always live. If that gate is wanted back, clipboard's hook is the pattern;
-//! what must not come back is Swift's silent hang on the other three.
+//! never settles. Malformed input errors here instead, and the gate is read
+//! rather than skipped: `ios_config.gateFor` maps all four actions to
+//! `.secure_storage`, so `ios_dispatch.offerToModules` answers
+//! `CAPABILITY_DISABLED` before this module is asked. A settled rejection
+//! rather than a hang is the divergence, and it is the whole of it.
+//!
+//! This paragraph argued the opposite case at length — that
+//! `enableSecureStorage` "appears nowhere in `packages/zig/src`", that the
+//! actions were therefore served unconditionally, and that `secureClear` was
+//! where it mattered because a page got a wipe where Swift's default-false
+//! gate would have refused. Every sentence of it was true when written and
+//! none of it survived `ios_config.zig`, which read the flags out of
+//! `craft.config.json` and closed the gap for thirty-odd actions at once.
+//! Worth knowing while reading any other module's account of a missing gate:
+//! the same paragraph was written in eight other files.
+//!
+//! What has not changed is that `secureClear` is the one action where the gate
+//! is load-bearing. The *ungated* sharedItems actions next door read and write
+//! the same items (one namespace — see above), so set/get/remove being gated
+//! grants a page nothing it could not reach anyway; a wipe has no such
+//! equivalent.
 //!
 //! **`get`'s collapse of every failure into `null`.** Swift returns `nil` for
 //! *any* non-success status, so a page cannot tell "nothing stored" from "the

--- a/packages/zig/src/bridge_mobile_speech.zig
+++ b/packages/zig/src/bridge_mobile_speech.zig
@@ -56,12 +56,23 @@
 //! **The plist guard replaces the nil-recognizer guard.** Swift builds its
 //! `SFSpeechRecognizer` only when `config.enableSpeechRecognition` is on
 //! (`:439-440`), and `beginRecording`'s `guard let speechRecognizer` then
-//! emits `"Speech recognizer unavailable"` when it is off. Zig cannot see the
-//! ivar, but `packages/ios/src/index.ts:183` writes
+//! emits `"Speech recognizer unavailable"` when it is off. Zig cannot see that
+//! ivar — still true — but `packages/ios/src/index.ts:183` writes
 //! `NSSpeechRecognitionUsageDescription` from that flag **and nothing else,
-//! with no `||`** — the exact-proxy shape `bridge_mobile_motion.zig` already
+//! with no `||`** — the exact-proxy shape `bridge_mobile_motion.zig` also
 //! reads. So a missing key means the flag was off, and the message emitted is
 //! the one Swift would have emitted for the same configuration.
+//!
+//! The flag itself is no longer out of reach: `ios_config.gateFor` maps
+//! `startListening` to `.speech_recognition`, so `ios_dispatch` answers
+//! `CAPABILITY_DISABLED` before this module is asked. That does **not** make
+//! the plist read redundant, and it is worth being precise about why, because
+//! the four other modules reading a key as a flag proxy *are* now redundant
+//! (#131) and this one looks identical at a glance. Here the key is also a
+//! precondition: `requestAuthorization:` without it does not fail, iOS
+//! terminates the process — so the check has to happen whatever the config
+//! says. The gate takes over the reason for refusing a disabled app; the key
+//! still owns not being killed, and the message.
 //!
 //! The check has to run *before* `requestAuthorization:`, where Swift's runs
 //! after, because asking for speech authorization without the key does not

--- a/packages/zig/src/bridge_mobile_system.zig
+++ b/packages/zig/src/bridge_mobile_system.zig
@@ -36,11 +36,13 @@ const is_darwin = builtin.target.os.tag.isDarwin();
 /// custom app schemes are its main use. Filtering here would silently break
 /// them.
 ///
-/// **`share` is served unconditionally.** Swift gates it on
-/// `config.enableShare` and replies `CAPABILITY_DISABLED`; `ios.zig`'s
-/// `AppConfig` has no such field, so Zig cannot reproduce the gate. An app that
-/// set `enableShare: false` will now get a share sheet. Restoring the gate
-/// means adding the field to `AppConfig`, not adding a guess here.
+/// **`share` is gated, and not here.** Swift replies `CAPABILITY_DISABLED`
+/// when `config.enableShare` is off, and `ios_dispatch.offerToModules` sends
+/// the same code before this module is asked — `ios_config.gateFor("share")`
+/// maps it. This paragraph used to say the opposite, that `AppConfig` had no
+/// such field and an app setting `enableShare: false` would get a share sheet
+/// anyway; that was true until `ios_config.zig` read the flags out of
+/// `craft.config.json`, and false from then on with nothing to notice.
 pub const A = struct {
     pub const open_url = "openURL";
     pub const share = "share";

--- a/packages/zig/src/bridge_mobile_watch.zig
+++ b/packages/zig/src/bridge_mobile_watch.zig
@@ -76,10 +76,13 @@
 //! `localizedDescription` are all logged before the enum is chosen.
 //!
 //! **The `enableWatchApp` config gate.** Swift only ever calls
-//! `setupWatchConnectivity` under `if config.enableWatchApp`, and that flag has
-//! no Zig mirror — it appears nowhere in `packages/zig/src`. Both actions are
-//! therefore served unconditionally, exactly as `securestore` and `notifcancel`
-//! document for their own gates. This grants a page nothing it should not have:
+//! `setupWatchConnectivity` under `if config.enableWatchApp` — a setup-time
+//! gate rather than a per-action one, so no `case` arm here carries an
+//! `if config.` and `ios_config.gateFor` correctly maps none of these actions.
+//! Both are therefore served unconditionally, and this is the one module whose
+//! version of that sentence is still true: `securestore` and `notifcancel` said
+//! the same until `ios_config.zig` read the flags their arms *do* carry.
+//! Serving these ungated grants a page nothing it should not have:
 //! with the gate off Swift never activated a session, so `defaultSession`'s
 //! `activationState` is `NotActivated` and both actions answer honestly —
 //! `{"reachable":false}` and a refusal to update.

--- a/packages/zig/src/ios_dispatch.zig
+++ b/packages/zig/src/ios_dispatch.zig
@@ -382,8 +382,10 @@ comptime {
 ///
 /// `.status = .unavailable` in a module's manifest means the handler is
 /// reachable and refuses, deliberately, because Zig cannot do the thing
-/// correctly — `haptic` cannot see `config.enableHaptics`, and the rest say
-/// why in their own `reason`.
+/// correctly; each one says why in its own `reason`. `haptic` was the example
+/// this comment used to give, and is now the example of a reason expiring:
+/// `ios_config.zig` made `config.enableHaptics` readable and the refusal
+/// outlived it.
 ///
 /// In the Zig-hosted app that refusal is the honest end of the line: `route`
 /// tries `handOffToHost` next, and the shim is what actually serves it. The
@@ -391,8 +393,9 @@ comptime {
 /// deliberately does not consult `handOffToHost`, because there the host *is*
 /// the caller. So claiming one of these would not be a refusal instead of an
 /// answer, it would be a refusal instead of the *host's working answer*: an app
-/// that has haptics today would stop buzzing the moment the runtime was linked,
-/// and the page would get a rejection where it used to get silence-and-a-buzz.
+/// that had haptics would have stopped buzzing the moment the runtime was
+/// linked, and the page would have got a rejection where it used to get
+/// silence-and-a-buzz.
 ///
 /// `test/ios_conformance_test.zig` already treats falling through as better
 /// than `.unavailable`. This is that rule, applied to the one path that had no
@@ -904,7 +907,6 @@ test "an action declared unavailable is left to the host, not claimed" {
     // the difference, linking the runtime replaced the working answer with a
     // rejection. `false` here is what sends the call back to Swift's switch.
     const declared_unavailable = [_][]const u8{
-        "haptic",
         "getNetworkStatus",
         "lockOrientation",
         "unlockOrientation",
@@ -929,7 +931,7 @@ test "the fall-through is read from the manifests, not from a list kept beside t
             }
         }
     }
-    try testing.expectEqual(@as(usize, 4), declared);
+    try testing.expectEqual(@as(usize, 3), declared);
 }
 
 test "a live action is still claimed, unavailable is not a blanket hand-back" {
@@ -937,6 +939,10 @@ test "a live action is still claimed, unavailable is not a blanket hand-back" {
     // `.live`, so the seam must keep claiming it. A fall-through that widened
     // to whole modules would silently un-migrate everything beside a refusal.
     try testing.expect(!hostServesItself("vibrate"));
+    // `haptic` was the fourth entry above until `ios_config.zig` made the gate
+    // it could not read readable. It is served here now, so handing it back
+    // would hand back a working action.
+    try testing.expect(!hostServesItself("haptic"));
     try testing.expect(!hostServesItself("setKeepAwake"));
     try testing.expect(!hostServesItself("getDeviceInfo"));
     try testing.expect(!hostServesItself("noSuchAction"));

--- a/packages/zig/test/ios_conformance_test.zig
+++ b/packages/zig/test/ios_conformance_test.zig
@@ -1569,3 +1569,108 @@ test "every recorded reply divergence is real, and still a divergence" {
 
     try testing.expect(deliberate_reply_divergences.len >= 3);
 }
+
+// ---------------------------------------------------------------------------
+// The SDK's event map
+//
+// `craft.d.ts` augments `WindowEventMap`, which is what gives
+// `window.addEventListener('craftLocationUpdate', …)` a typed `detail` instead
+// of a bare `Event`. It is a third statement of the event vocabulary, after
+// the spec's `sendToWeb` calls and `ios_events.Event`, and it was the only one
+// nothing checked — so it had drifted in both directions at once.
+//
+// It declared `craftVoiceAction`, which appears nowhere else in the repository:
+// no dispatch, no subscription, no implementation. A listener written against
+// it type-checks and never fires.
+//
+// It omitted six events that do fire — `craftLocationUpdate`,
+// `craftLocationError`, `craftNetworkChange`, `craftPushToken`,
+// `craftNotificationResponse` and `craftWatchUserInfo` — so the most-used
+// stream in the whole surface reached a page as an untyped `Event` whose
+// `detail` was `any`.
+// ---------------------------------------------------------------------------
+
+const sdk_types = @embedFile("craft.d.ts");
+
+/// The keys of `interface WindowEventMap { … }`.
+fn collectSdkEventMap(allocator: std.mem.Allocator) !std.StringHashMap(void) {
+    var set = std.StringHashMap(void).init(allocator);
+    errdefer set.deinit();
+
+    const start = std.mem.indexOf(u8, sdk_types, "interface WindowEventMap {") orelse
+        return error.EventMapNotFound;
+    const body = sdk_types[start..];
+    const end = std.mem.indexOf(u8, body, "\n  }") orelse return error.EventMapNotFound;
+
+    var it = std.mem.splitScalar(u8, body[0..end], '\n');
+    while (it.next()) |line| {
+        const trimmed = std.mem.trim(u8, line, " \t\r");
+        if (!std.mem.startsWith(u8, trimmed, "craft")) continue;
+        const colon = std.mem.indexOfScalar(u8, trimmed, ':') orelse continue;
+        try set.put(trimmed[0..colon], {});
+    }
+    return set;
+}
+
+test "the SDK's event map declares nothing that never fires" {
+    // `craftVoiceAction` was the case: a name in this map and nowhere else in
+    // the repository. The map is the most authoritative-looking of the three
+    // statements of the vocabulary — it is what an editor autocompletes from —
+    // and it was the one with no check behind it.
+    var map = try collectSdkEventMap(testing.allocator);
+    defer map.deinit();
+
+    // Non-vacuity: a renamed interface would empty this set.
+    try testing.expect(map.count() >= 19);
+
+    var dispatched = try collectSpecDispatchedEvents(testing.allocator);
+    defer dispatched.deinit();
+
+    var it = map.keyIterator();
+    while (it.next()) |name| {
+        if (dispatched.contains(name.*)) continue;
+
+        // The two recorded dead subscriptions are typed on purpose: the page
+        // subscribes to them today, and a listener written now should compile
+        // against the shape it will receive when the missing half lands. Any
+        // other name here is a type with nothing behind it.
+        var recorded = false;
+        for (dead_subscriptions) |d| {
+            if (std.mem.eql(u8, d.event, name.*)) recorded = true;
+        }
+        if (recorded) continue;
+
+        std.debug.print(
+            "craft.d.ts types `{s}` in WindowEventMap, and nothing dispatches it.\n" ++
+                "  A listener written against it type-checks and is never called.\n",
+            .{name.*},
+        );
+        return error.SdkTypesAnEventNothingEmits;
+    }
+}
+
+test "the SDK's event map declares everything that does fire" {
+    // The other direction, and the one that had six holes in it. An event
+    // missing from the map is not a compile error for the page — the
+    // `addEventListener` overload falls back to `Event`, whose `detail` is
+    // `any` — so the cost is silent: no autocomplete, no shape, no check that
+    // the field being read exists.
+    var map = try collectSdkEventMap(testing.allocator);
+    defer map.deinit();
+
+    var dispatched = try collectSpecDispatchedEvents(testing.allocator);
+    defer dispatched.deinit();
+    try testing.expect(dispatched.count() >= 17);
+
+    var it = dispatched.keyIterator();
+    while (it.next()) |name| {
+        if (!map.contains(name.*)) {
+            std.debug.print(
+                "the spec dispatches `{s}` and craft.d.ts does not type it.\n" ++
+                    "  A page listening for it gets a bare Event and a `detail` of any.\n",
+                .{name.*},
+            );
+            return error.SdkDoesNotTypeAnEventThatFires;
+        }
+    }
+}

--- a/packages/zig/test/ios_conformance_test.zig
+++ b/packages/zig/test/ios_conformance_test.zig
@@ -643,6 +643,113 @@ test "the gate table has no entry for an action Zig does not serve" {
     }
 }
 
+/// The `.reason` text of every `.status = .unavailable` entry, by action.
+///
+/// The reason is what a reader trusts, so it is what has to be checked. A
+/// declaration can be resolved two ways here: `.reason = "..."` inline, and
+/// `.reason = some_const` naming a constant elsewhere in the file — both are
+/// in use, and a scan that handled only the first would silently skip the
+/// second rather than fail.
+fn collectUnavailableReasons(allocator: std.mem.Allocator) !std.StringHashMap([]const u8) {
+    var map = std.StringHashMap([]const u8).init(allocator);
+    errdefer map.deinit();
+
+    for (zig_sources) |source| {
+        // Bounded to the manifest array, not the whole file: prose quotes
+        // `.status = .unavailable` — `bridge_mobile_haptics.zig`'s header does,
+        // describing the declaration it removed — and a scan that read comments
+        // would attribute that sentence to whichever entry preceded it.
+        const table_start = std.mem.indexOf(u8, source, "pub const capability_actions = [_]capabilities.ActionDecl{") orelse
+            continue;
+        const table_end = std.mem.indexOfPos(u8, source, table_start, "\n};") orelse continue;
+        const table = source[table_start..table_end];
+
+        var search: usize = 0;
+        while (std.mem.indexOfPos(u8, table, search, ".status = .unavailable")) |at| {
+            search = at + 1;
+
+            // The entry names its action as `A.some_const`; resolve it back
+            // through the `A` block to the string the spec spells.
+            const name_at = std.mem.lastIndexOf(u8, table[0..at], ".name = A.") orelse continue;
+            const const_start = name_at + ".name = A.".len;
+            var const_end = const_start;
+            while (const_end < table.len and (std.ascii.isAlphanumeric(table[const_end]) or
+                table[const_end] == '_')) : (const_end += 1)
+            {}
+
+            var needle_buf: [96]u8 = undefined;
+            const member = table[const_start..const_end];
+            if (member.len + 16 > needle_buf.len) continue;
+            const decl = try std.fmt.bufPrint(&needle_buf, "const {s} = \"", .{member});
+            const decl_at = std.mem.indexOf(u8, source, decl) orelse continue;
+            const value_start = decl_at + decl.len;
+            const value_end = std.mem.indexOfScalarPos(u8, source, value_start, '"') orelse continue;
+            const action = source[value_start..value_end];
+
+            // The reason, inline or by name.
+            const reason_at = std.mem.indexOfPos(u8, table, at, ".reason = ") orelse continue;
+            const reason_start = reason_at + ".reason = ".len;
+            if (table[reason_start] == '"') {
+                const reason_end = std.mem.indexOfScalarPos(u8, table, reason_start + 1, '"') orelse continue;
+                try map.put(action, table[reason_start + 1 .. reason_end]);
+            } else {
+                var ident_end = reason_start;
+                while (ident_end < table.len and (std.ascii.isAlphanumeric(table[ident_end]) or
+                    table[ident_end] == '_')) : (ident_end += 1)
+                {}
+                var const_buf: [96]u8 = undefined;
+                const ident = table[reason_start..ident_end];
+                if (ident.len + 10 > const_buf.len) continue;
+                const const_decl = try std.fmt.bufPrint(&const_buf, "const {s} =", .{ident});
+                const body_at = std.mem.indexOf(u8, source, const_decl) orelse continue;
+                const body_end = std.mem.indexOfScalarPos(u8, source, body_at, ';') orelse continue;
+                // The whole initialiser, `++` concatenation included.
+                try map.put(action, source[body_at..body_end]);
+            }
+        }
+    }
+    return map;
+}
+
+test "no refusal blames a config flag Zig demonstrably reads" {
+    // The rot this exists to catch, in the exact shape it took. `haptic` was
+    // declared `.status = .unavailable` because `config.enableHaptics` "is not
+    // visible to Zig"; `gateFor`'s table said Zig reads that same flag and
+    // refuses the action when it is off. Both were written honestly, months
+    // apart, and nothing put them side by side — so the refusal outlived its
+    // reason and a working implementation sat unused two hundred lines below it.
+    //
+    // Deliberately narrower than "gated and unavailable", which is not a
+    // contradiction: `lockOrientation` is both, and its reason is about a root
+    // view controller rather than about reading a flag. What cannot stand is a
+    // refusal *naming* a flag the gate table proves Zig reads.
+    var gates = try collectZigGates(testing.allocator);
+    defer gates.deinit();
+
+    var reasons = try collectUnavailableReasons(testing.allocator);
+    defer reasons.deinit();
+
+    // Non-vacuity: the scan reads each manifest through two indirections — the
+    // `A.` constant and its declaration — and either could stop matching.
+    try testing.expect(reasons.count() >= 3);
+
+    var it = reasons.iterator();
+    while (it.next()) |entry| {
+        const flag = gates.get(entry.key_ptr.*) orelse continue;
+        if (std.mem.indexOf(u8, entry.value_ptr.*, flag) != null) {
+            std.debug.print(
+                "`{s}` is declared unavailable and its reason names `{s}`, which `gateFor` " ++
+                    "maps it to.\n" ++
+                    "  The manifest says Zig cannot read that flag; the gate table says it does " ++
+                    "and refuses the action when it is off.\n" ++
+                    "  One of them is out of date.\n",
+                .{ entry.key_ptr.*, flag },
+            );
+            return error.RefusalBlamesAFlagZigReads;
+        }
+    }
+}
+
 test "every flag Zig can read is a flag the spec's config actually has" {
     // A misspelled key is not a one-flag bug. A key that is not in the file
     // reads as missing, and one missing key makes the whole decode throw, so


### PR DESCRIPTION
Stacked on #132 — review the top commit.

## A third statement of the event vocabulary, and the one nothing checked

`craft.d.ts` augments `WindowEventMap`. That augmentation is what turns `window.addEventListener('craftLocationUpdate', …)` from a bare `Event` into a typed `detail`, so it is the statement of the event vocabulary a developer actually sees — the one their editor autocompletes from.

There are three such statements now: the spec's `sendToWeb` calls, `ios_events.Event`, and this map. #128 put checks behind the first two. This one had none, and had drifted in both directions at once.

## Typed, and never fires

`craftVoiceAction` was declared here and **nowhere else in the repository** — no dispatch, no subscription, no implementation, on any platform. A listener written against it type-checks and is never called. Removed, along with `CraftVoiceActionEvent`.

## Fires, and had no type

Six events had no entry:

`craftLocationUpdate` · `craftLocationError` · `craftNetworkChange` · `craftPushToken` · `craftNotificationResponse` · `craftWatchUserInfo`

Being missing is not a compile error for the page — the `addEventListener` overload falls back to `Event`, whose `detail` is `any` — so the cost is entirely silent: no autocomplete, no shape, no check that the field being read exists. And it fell on the most-used stream in the surface. Types added from the spec's own payloads, reusing `Position` and `NetworkStatus` where they already existed.

## `Position` described six of eight fields

```ts
// before
export interface Position {
  latitude: number; longitude: number; accuracy: number;
  altitude?: number; speed?: number; heading?: number;
}
```

The native dictionary is built unconditionally from `CLLocation`'s non-optional properties and always carries eight keys. `altitudeAccuracy` and `timestamp` were simply unreachable from TypeScript — the same shape of bug as `getDeviceInfo` answering four of fourteen fields, moved to the type layer.

The three optionals were a misreading of CoreLocation: `heading` and `speed` are `-1` when unavailable, a sentinel, not an absent key. Android has no geolocation surface, so nothing else fills this in. All eight are required now, each documented.

**This is a source break** for anyone writing `const p: Position = { … }`. It is a return type (`getCurrentPosition(): Promise<Position>`), so in practice that is a test mock rather than a caller — flagging it rather than burying it.

## The two that stay, and say why

`craftShortcut` and `craftSiriShortcut` keep their entries and move last in the map. Nothing dispatches either (#127) and each interface now says so in its doc comment — but the injected JS does subscribe to both today, so a listener written now should compile against the shape it will receive if the missing half ever lands.

## The guard

Two conformance tests, anchored on the same `sendToWeb` scan the event-channel checks use:

| mutation | result |
| --- | --- |
| a typed event nothing dispatches (`craftVoiceAction` restored) | `SdkTypesAnEventNothingEmits` |
| a dispatched event dropped from the map | `SdkDoesNotTypeAnEventThatFires` |
| the `interface WindowEventMap {` scan broken | `EventMapNotFound` on both |

`zig build test:ios` 21/21 · `tsc --noEmit` clean · 512 SDK tests pass · pickier clean.
