### PR TITLE
feat(android): getDeviceInfo in Zig, and the JNI calls it needed

### DIFF
--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -413,6 +413,18 @@ pub fn build(b: *std.Build) void {
     });
     const run_jni_tests = b.addRunArtifact(jni_tests);
 
+    // The Android bridge modules. Rooted at the device module because it is
+    // the only one so far; a second joins by being imported from here, the way
+    // `ios.zig` gathers the iOS ones.
+    const android_bridge_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/bridge_android_device.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    const run_android_bridge_tests = b.addRunArtifact(android_bridge_tests);
+
     ios_conformance_tests.root_module.addAnonymousImport("CraftApp.swift", .{
         .root_source_file = b.path("../ios/templates/CraftApp.swift"),
     });
@@ -1526,6 +1538,7 @@ pub fn build(b: *std.Build) void {
     }
     test_step.dependOn(&run_ios_conformance_tests.step);
     test_step.dependOn(&run_jni_tests.step);
+    test_step.dependOn(&run_android_bridge_tests.step);
     test_step.dependOn(&run_menubar_tests.step);
     test_step.dependOn(&run_components_tests.step);
     test_step.dependOn(&run_gpu_tests.step);
@@ -2202,6 +2215,7 @@ pub fn build(b: *std.Build) void {
     // second one: `jni_runtime.zig` is the only way anything here reaches Java,
     // so a run that skipped it would not be an Android test run.
     test_android_step.dependOn(&run_jni_tests.step);
+    test_android_step.dependOn(&run_android_bridge_tests.step);
 
     // Add Android tests to the main test step
     test_step.dependOn(&run_android_tests.step);

--- a/packages/zig/src/bridge_android_device.zig
+++ b/packages/zig/src/bridge_android_device.zig
@@ -1,0 +1,468 @@
+//! `getDeviceInfo` on Android — the first action this bridge serves from Zig.
+//!
+//! The Kotlin it replaces is `CraftBridge.getDeviceInfo()`, a
+//! `@JavascriptInterface` method that builds a `JSONObject` of thirteen keys
+//! and returns it as a string. Thirteen is the number that matters: an action
+//! that answers twelve of them reports success and hands the page `undefined`
+//! for the thirteenth, which is the exact regression `getDeviceInfo answers
+//! every field the spec answers` was written for on the iOS side. So this
+//! answers all thirteen or it is not this action.
+//!
+//! ## The shape, and why it is split in two
+//!
+//! `read` does the JNI work and returns a plain `DeviceInfo`. `render` turns a
+//! `DeviceInfo` into the reply bytes. Nothing about `render` touches Java.
+//!
+//! That split is what makes the reply testable. Escaping, key completeness,
+//! number formatting and the float's precision are all decided in `render`,
+//! and a host test drives it directly with no JVM, no emulator and no fake.
+//! The half that genuinely needs a device is then only the field *wiring* —
+//! which class, which name, which signature.
+//!
+//! ## Where this diverges from the Kotlin, deliberately
+//!
+//! **`appVersion` and `appBuild` have Kotlin `try`/`catch` fallbacks** —
+//! `"unknown"` and `0` — for a `getPackageInfo` that throws
+//! `NameNotFoundException`. Those are reproduced exactly: a Java exception on
+//! that path is caught, cleared, and turned into the same fallback, not
+//! propagated. An app whose own package is unfindable is a broken install, and
+//! the spec's answer to it is a string that says so rather than a failed call.
+//!
+//! **Everything else propagates.** A missing `android/os/Build` is not a
+//! condition to paper over with a default — it means the class loader handed
+//! back something no Android process would, and a fabricated `"unknown"` there
+//! would be an invented device rather than a reported failure.
+
+const std = @import("std");
+const jni = @import("jni_runtime.zig");
+const bridge_error = @import("bridge_error.zig");
+
+const Jni = jni.Jni;
+const jobject = jni.jobject;
+
+/// The action name, spelled exactly as the Kotlin method is named. The
+/// conformance scan matches the two by string.
+pub const A = struct {
+    pub const get_device_info = "getDeviceInfo";
+};
+
+/// Everything the reply carries, read out of Java and owned by the caller.
+///
+/// Strings are allocated; `deinit` frees them. `platform` is not a field: it
+/// is the literal `"android"` in the Kotlin and there is nothing to read.
+pub const DeviceInfo = struct {
+    model: []const u8,
+    manufacturer: []const u8,
+    brand: []const u8,
+    device: []const u8,
+    system_version: []const u8,
+    app_version: []const u8,
+    sdk_version: i32,
+    screen_width: i32,
+    screen_height: i32,
+    density: f32,
+    app_build: i64,
+    is_emulator: bool,
+
+    pub fn deinit(self: DeviceInfo, allocator: std.mem.Allocator) void {
+        allocator.free(self.model);
+        allocator.free(self.manufacturer);
+        allocator.free(self.brand);
+        allocator.free(self.device);
+        allocator.free(self.system_version);
+        allocator.free(self.app_version);
+    }
+};
+
+/// The reply bytes, byte-for-byte what the page's `JSON.parse` receives.
+///
+/// Keys are emitted in the Kotlin's `put` order. That is not required by JSON
+/// and no consumer depends on it, but a diff against the Kotlin is the way
+/// this gets reviewed, and matching the order keeps that diff readable.
+pub fn render(allocator: std.mem.Allocator, info: DeviceInfo) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.append(allocator, '{');
+    try appendString(allocator, &out, "model", info.model);
+    try appendString(allocator, &out, "manufacturer", info.manufacturer);
+    try appendString(allocator, &out, "brand", info.brand);
+    try appendString(allocator, &out, "device", info.device);
+    try appendString(allocator, &out, "systemVersion", info.system_version);
+
+    try out.appendSlice(allocator, ",\"sdkVersion\":");
+    try out.print(allocator, "{d}", .{info.sdk_version});
+    try out.appendSlice(allocator, ",\"screenWidth\":");
+    try out.print(allocator, "{d}", .{info.screen_width});
+    try out.appendSlice(allocator, ",\"screenHeight\":");
+    try out.print(allocator, "{d}", .{info.screen_height});
+
+    // `density` is a Java float and JSONObject renders it with Java's
+    // shortest-round-trip rule, so 2.75 is "2.75" and never "2.7500000".
+    // `{d}` is Zig's equivalent; a fixed-precision format would put trailing
+    // zeroes on a value a page may well be comparing as a string.
+    try out.appendSlice(allocator, ",\"density\":");
+    try out.print(allocator, "{d}", .{info.density});
+
+    try out.appendSlice(allocator, ",\"platform\":\"android\"");
+
+    try appendString(allocator, &out, "appVersion", info.app_version);
+
+    try out.appendSlice(allocator, ",\"appBuild\":");
+    try out.print(allocator, "{d}", .{info.app_build});
+
+    try out.appendSlice(allocator, ",\"isEmulator\":");
+    try out.appendSlice(allocator, if (info.is_emulator) "true" else "false");
+
+    try out.append(allocator, '}');
+    return out.toOwnedSlice(allocator);
+}
+
+/// `,"key":"escaped value"`.
+///
+/// The quotes are written here, not by `appendJsonEscaped`, which escapes the
+/// contents and emits no delimiters. Leaving them to it produces a document
+/// that tears at the first value containing a quote — and a device name is
+/// user-settable on most Android builds, so that value is reachable.
+fn appendString(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    key: []const u8,
+    value: []const u8,
+) !void {
+    // A separator only when something is already in the object. `out` holds
+    // just `{` on the first call, so the check is exact rather than a guess —
+    // and an unconditional comma here produced `{,"model":...`, which is a
+    // document that stops parsing at character two.
+    if (out.items.len > 1) try out.append(allocator, ',');
+    try out.append(allocator, '"');
+    try out.appendSlice(allocator, key);
+    try out.appendSlice(allocator, "\":\"");
+    try bridge_error.appendJsonEscaped(allocator, out, value);
+    try out.append(allocator, '"');
+}
+
+// =============================================================================
+// The JNI half
+// =============================================================================
+
+/// `Build.FINGERPRINT.contains("generic") || contains("emulator")`.
+///
+/// Kotlin's own test, kept as a function so it can be asserted without a
+/// device. Deliberately not widened: the Kotlin does not check `"sdk"`,
+/// `"vbox"` or the other markers a more thorough emulator test would, and this
+/// answers the same question the shim answers.
+pub fn fingerprintLooksEmulated(fingerprint: []const u8) bool {
+    return std.mem.indexOf(u8, fingerprint, "generic") != null or
+        std.mem.indexOf(u8, fingerprint, "emulator") != null;
+}
+
+/// Read a `static final String` off a class, as UTF-8.
+fn staticString(
+    allocator: std.mem.Allocator,
+    j: Jni,
+    cls: jni.jclass,
+    name: [*:0]const u8,
+) ![]u8 {
+    const id = try j.staticFieldId(cls, name, "Ljava/lang/String;");
+    const value = try j.staticObjectField(cls, id);
+    defer j.deleteLocalRef(value);
+    return j.stringToUtf8(allocator, value);
+}
+
+/// Everything the reply needs, read out of the running process.
+///
+/// `activity` is the `android.app.Activity` the Kotlin bridge holds — the same
+/// object its `activity.windowManager` and `activity.packageManager` reach.
+///
+/// The whole body runs inside one local frame. Reading this much walks eleven
+/// Java objects (two classes, four strings, a WindowManager, a Display, a
+/// DisplayMetrics, a PackageManager, a PackageInfo) and the JVM only
+/// guarantees sixteen local slots — so the alternative to a frame is eleven
+/// `defer`s, one of which eventually gets forgotten.
+pub fn read(allocator: std.mem.Allocator, j: Jni, activity: jobject) !DeviceInfo {
+    try j.pushLocalFrame(24);
+    // `null`: nothing read here survives the frame. Every string is already
+    // copied into allocator memory by `stringToUtf8`, and every number is a
+    // value — so there is no reference worth promoting.
+    defer _ = j.popLocalFrame(null);
+
+    const build = try j.findClass("android/os/Build");
+
+    const model = try staticString(allocator, j, build, "MODEL");
+    errdefer allocator.free(model);
+    const manufacturer = try staticString(allocator, j, build, "MANUFACTURER");
+    errdefer allocator.free(manufacturer);
+    const brand = try staticString(allocator, j, build, "BRAND");
+    errdefer allocator.free(brand);
+    const device = try staticString(allocator, j, build, "DEVICE");
+    errdefer allocator.free(device);
+
+    const fingerprint = try staticString(allocator, j, build, "FINGERPRINT");
+    defer allocator.free(fingerprint);
+
+    // `Build$VERSION` — a nested class, and the `$` is not decoration: the JVM
+    // knows this type by that binary name and `android/os/Build/VERSION` finds
+    // nothing.
+    const version_cls = try j.findClass("android/os/Build$VERSION");
+    const system_version = try staticString(allocator, j, version_cls, "RELEASE");
+    errdefer allocator.free(system_version);
+    const sdk_version = try j.staticIntField(
+        version_cls,
+        try j.staticFieldId(version_cls, "SDK_INT", "I"),
+    );
+
+    const metrics = try readDisplayMetrics(j, activity);
+    const package = try readPackageInfo(allocator, j, activity, sdk_version);
+
+    return .{
+        .model = model,
+        .manufacturer = manufacturer,
+        .brand = brand,
+        .device = device,
+        .system_version = system_version,
+        .app_version = package.version_name,
+        .sdk_version = sdk_version,
+        .screen_width = metrics.width,
+        .screen_height = metrics.height,
+        .density = metrics.density,
+        .app_build = package.build,
+        .is_emulator = fingerprintLooksEmulated(fingerprint),
+    };
+}
+
+const Metrics = struct { width: i32, height: i32, density: f32 };
+
+/// `activity.windowManager.defaultDisplay.getMetrics(DisplayMetrics())`.
+///
+/// `getDefaultDisplay` is deprecated from API 30 and the Kotlin suppresses the
+/// warning rather than branching. Reproduced as-is: switching to
+/// `Context.getDisplay()` here would answer a different question on a
+/// multi-display device than the shim answers, and this action's contract is
+/// the shim's until the shim changes.
+fn readDisplayMetrics(j: Jni, activity: jobject) !Metrics {
+    const activity_cls = try j.objectClass(activity);
+    const window_manager = try j.callObjectMethod(
+        activity,
+        try j.methodId(activity_cls, "getWindowManager", "()Landroid/view/WindowManager;"),
+    );
+
+    const wm_cls = try j.objectClass(window_manager);
+    const display = try j.callObjectMethod(
+        window_manager,
+        try j.methodId(wm_cls, "getDefaultDisplay", "()Landroid/view/Display;"),
+    );
+
+    // `DisplayMetrics` is filled in by the callee, so it has to be constructed
+    // here and handed over — the one place this action allocates a Java object.
+    const metrics_cls = try j.findClass("android/util/DisplayMetrics");
+    const metrics = try j.newObjectA(metrics_cls, try j.methodId(metrics_cls, "<init>", "()V"), &.{});
+
+    const display_cls = try j.objectClass(display);
+    try j.callVoidMethodA(
+        display,
+        try j.methodId(display_cls, "getMetrics", "(Landroid/util/DisplayMetrics;)V"),
+        &.{.{ .l = metrics }},
+    );
+
+    // Public fields, not getters — DisplayMetrics has never had accessors.
+    return .{
+        .width = try j.intField(metrics, try j.fieldId(metrics_cls, "widthPixels", "I")),
+        .height = try j.intField(metrics, try j.fieldId(metrics_cls, "heightPixels", "I")),
+        .density = try j.floatField(metrics, try j.fieldId(metrics_cls, "density", "F")),
+    };
+}
+
+const Package = struct { version_name: []const u8, build: i64 };
+
+/// `packageManager.getPackageInfo(packageName, 0)`, with the Kotlin's own
+/// fallbacks for the throw.
+///
+/// The two `try`/`catch` blocks in the shim collapse every failure to
+/// `"unknown"` and `0`, so that is what a Java exception produces here. The
+/// exception is cleared on the way — `Jni.check` does that — because leaving it
+/// pending would poison the next call rather than the current one, and the
+/// next call is in the caller.
+fn readPackageInfo(allocator: std.mem.Allocator, j: Jni, activity: jobject, sdk: i32) !Package {
+    const fallback = Package{ .version_name = try allocator.dupe(u8, "unknown"), .build = 0 };
+    errdefer allocator.free(fallback.version_name);
+
+    const activity_cls = try j.objectClass(activity);
+    const manager = j.callObjectMethod(
+        activity,
+        try j.methodId(activity_cls, "getPackageManager", "()Landroid/content/pm/PackageManager;"),
+    ) catch return fallback;
+
+    const name = j.callObjectMethod(
+        activity,
+        try j.methodId(activity_cls, "getPackageName", "()Ljava/lang/String;"),
+    ) catch return fallback;
+
+    const manager_cls = try j.objectClass(manager);
+    const get_info = try j.methodId(
+        manager_cls,
+        "getPackageInfo",
+        "(Ljava/lang/String;I)Landroid/content/pm/PackageInfo;",
+    );
+    const info = j.callObjectMethodA(manager, get_info, &.{
+        .{ .l = name },
+        .{ .i = 0 },
+    }) catch return fallback;
+
+    const info_cls = try j.objectClass(info);
+
+    const name_field = try j.fieldId(info_cls, "versionName", "Ljava/lang/String;");
+    const version_object = try j.objectField(info, name_field);
+    // `versionName` is genuinely nullable — an app with no `versionName` in its
+    // manifest has it null, and Kotlin's `put` would store JSON null. The shim's
+    // catch does not cover that, so the fallback string is used rather than
+    // emitting a null a page would have to test for.
+    const version_name = if (version_object == null)
+        try allocator.dupe(u8, "unknown")
+    else
+        try j.stringToUtf8(allocator, version_object);
+    errdefer allocator.free(version_name);
+    allocator.free(fallback.version_name);
+
+    // API 28 split the build number in two: `longVersionCode` is the whole
+    // value, `versionCode` its low 32 bits. Reading the wrong one on a modern
+    // app truncates rather than failing.
+    const build: i64 = if (sdk >= 28)
+        try j.longField(info, try j.fieldId(info_cls, "longVersionCode", "J"))
+    else
+        try j.intField(info, try j.fieldId(info_cls, "versionCode", "I"));
+
+    return .{ .version_name = version_name, .build = build };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+const testing = std.testing;
+
+fn sampleInfo() DeviceInfo {
+    return .{
+        .model = "Pixel 8 Pro",
+        .manufacturer = "Google",
+        .brand = "google",
+        .device = "husky",
+        .system_version = "14",
+        .app_version = "1.2.3",
+        .sdk_version = 34,
+        .screen_width = 1008,
+        .screen_height = 2244,
+        .density = 2.625,
+        .app_build = 4_000_000_123,
+        .is_emulator = false,
+    };
+}
+
+test "the reply carries every key the Kotlin puts, and parses" {
+    // The regression this mirrors is iOS's: `getDeviceInfo` was `.live` and
+    // answered four of fourteen fields, so a page read `undefined` from an
+    // action that reported success. Thirteen keys or this is not the action.
+    const json = try render(testing.allocator, sampleInfo());
+    defer testing.allocator.free(json);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    const obj = parsed.value.object;
+
+    try testing.expectEqual(@as(usize, 13), obj.count());
+
+    try testing.expectEqualStrings("Pixel 8 Pro", obj.get("model").?.string);
+    try testing.expectEqualStrings("Google", obj.get("manufacturer").?.string);
+    try testing.expectEqualStrings("google", obj.get("brand").?.string);
+    try testing.expectEqualStrings("husky", obj.get("device").?.string);
+    try testing.expectEqualStrings("14", obj.get("systemVersion").?.string);
+    try testing.expectEqualStrings("android", obj.get("platform").?.string);
+    try testing.expectEqualStrings("1.2.3", obj.get("appVersion").?.string);
+    try testing.expectEqual(@as(i64, 34), obj.get("sdkVersion").?.integer);
+    try testing.expectEqual(@as(i64, 1008), obj.get("screenWidth").?.integer);
+    try testing.expectEqual(@as(i64, 2244), obj.get("screenHeight").?.integer);
+    try testing.expectEqual(@as(i64, 4_000_000_123), obj.get("appBuild").?.integer);
+    try testing.expectEqual(false, obj.get("isEmulator").?.bool);
+    try testing.expectApproxEqAbs(@as(f64, 2.625), obj.get("density").?.float, 0.0001);
+}
+
+test "appBuild survives a value that does not fit in 32 bits" {
+    // The reason `longVersionCode` is read at all. An app past 2^31 builds is
+    // unusual; an app whose `versionCode` encodes a date or an ABI split is
+    // not, and those cross the boundary routinely. Truncating here would
+    // report a different build than the one installed.
+    var info = sampleInfo();
+    info.app_build = 9_007_199_254_740_991;
+    const json = try render(testing.allocator, info);
+    defer testing.allocator.free(json);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqual(
+        @as(i64, 9_007_199_254_740_991),
+        parsed.value.object.get("appBuild").?.integer,
+    );
+}
+
+test "a device name containing a quote does not tear the document" {
+    // `ro.product.model` is settable on a rooted or custom build, and
+    // `appendJsonEscaped` writes no delimiters — so a caller that forgot the
+    // quotes would produce a reply that stops parsing at the first one. The
+    // same trap that broke the iOS location-recording state file.
+    var info = sampleInfo();
+    info.model = "My \"Best\" Phone";
+    info.app_version = "1.0\\beta";
+    const json = try render(testing.allocator, info);
+    defer testing.allocator.free(json);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("My \"Best\" Phone", parsed.value.object.get("model").?.string);
+    try testing.expectEqualStrings("1.0\\beta", parsed.value.object.get("appVersion").?.string);
+    try testing.expectEqual(@as(usize, 13), parsed.value.object.count());
+}
+
+test "a control character in a device name is escaped, not embedded" {
+    var info = sampleInfo();
+    info.model = "Tab\tNewline\n";
+    const json = try render(testing.allocator, info);
+    defer testing.allocator.free(json);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("Tab\tNewline\n", parsed.value.object.get("model").?.string);
+}
+
+test "density renders the way JSONObject renders a float" {
+    // Java prints a float with the shortest representation that round-trips,
+    // so 2.75 is "2.75". A fixed-precision format here would emit "2.7500000"
+    // and change a value some pages compare as a string.
+    var info = sampleInfo();
+    info.density = 2.75;
+    const json = try render(testing.allocator, info);
+    defer testing.allocator.free(json);
+    try testing.expect(std.mem.indexOf(u8, json, "\"density\":2.75,") != null);
+
+    info.density = 3;
+    const whole = try render(testing.allocator, info);
+    defer testing.allocator.free(whole);
+    try testing.expect(std.mem.indexOf(u8, whole, "\"density\":3,") != null);
+}
+
+test "the emulator test asks exactly what the Kotlin asks" {
+    // Real fingerprints, and the two markers the shim looks for.
+    try testing.expect(fingerprintLooksEmulated("generic/sdk_gphone64_arm64/emu64a:14/UE1A.230829.036/11228894:user/release-keys"));
+    try testing.expect(fingerprintLooksEmulated("Android/aosp_cf_x86_64_phone/emulator:13/x/y:userdebug/test-keys"));
+    try testing.expect(!fingerprintLooksEmulated("google/husky/husky:14/AP1A.240405.002/11480754:user/release-keys"));
+    try testing.expect(!fingerprintLooksEmulated("samsung/dm3qxxx/dm3q:14/UP1A.231005.007/S918BXXU4BWL5:user/release-keys"));
+
+    // Not widened past the shim: these are emulator markers this deliberately
+    // does not know about, because the Kotlin does not either.
+    try testing.expect(!fingerprintLooksEmulated("unknown/vbox86p/vbox86p:9/x/y:userdebug/test-keys"));
+}
+
+test "the action name matches the Kotlin method exactly" {
+    // The scan that pairs the two lists matches by string, so a rename on
+    // either side has to be a rename on both.
+    try testing.expectEqualStrings("getDeviceInfo", A.get_device_info);
+}

--- a/packages/zig/src/jni_runtime.zig
+++ b/packages/zig/src/jni_runtime.zig
@@ -80,6 +80,23 @@ pub const jthrowable = jobject;
 pub const jmethodID = ?*anyopaque;
 pub const jfieldID = ?*anyopaque;
 
+/// One Java argument, as the `A`-form calls take them.
+///
+/// A C union of every primitive plus a reference, eight bytes wide. Arguments
+/// are passed as an array of these rather than variadically — see
+/// `Jni.callObjectMethodA` for why that is the only form offered.
+pub const jvalue = extern union {
+    z: jboolean,
+    b: jbyte,
+    c: jchar,
+    s: jshort,
+    i: jint,
+    j: jlong,
+    f: jfloat,
+    d: jdouble,
+    l: jobject,
+};
+
 /// `JNIEnv*` as the JVM passes it to a native method.
 pub const JNIEnv = *const *const JNINativeInterface;
 
@@ -445,6 +462,104 @@ pub const Jni = struct {
         return result;
     }
 
+    // --- The argument-taking forms -------------------------------------
+    //
+    // Every one of these is the `A` variant, taking a `[]const jvalue`. The
+    // bare `CallObjectMethod` is variadic in C, and calling a variadic
+    // function through a `callconv(.c)` pointer means reproducing the
+    // platform's argument-passing rules exactly — which arm64 and x86-64
+    // Android do not share. The `A` form takes an array instead, so there is
+    // no ABI to reproduce and one implementation is right on both.
+    //
+    // `args.ptr` is passed even when the slice is empty; a zero-argument call
+    // never reads it, and a null there would be a second thing to reason about.
+
+    pub fn callObjectMethodA(self: Self, obj: jobject, id: jmethodID, args: []const jvalue) JniError!jobject {
+        const call: *const fn (JNIEnv, jobject, jmethodID, [*]const jvalue) callconv(.c) jobject =
+            @ptrCast(self.table().CallObjectMethodA orelse return JniError.NotFound);
+        const result = call(self.env, obj, id, args.ptr);
+        try self.check();
+        return result;
+    }
+
+    pub fn callVoidMethodA(self: Self, obj: jobject, id: jmethodID, args: []const jvalue) JniError!void {
+        const call: *const fn (JNIEnv, jobject, jmethodID, [*]const jvalue) callconv(.c) void =
+            @ptrCast(self.table().CallVoidMethodA orelse return JniError.NotFound);
+        call(self.env, obj, id, args.ptr);
+        try self.check();
+    }
+
+    /// `new <cls>(args)`. `id` must be the `<init>` method id.
+    pub fn newObjectA(self: Self, cls: jclass, id: jmethodID, args: []const jvalue) JniError!jobject {
+        const new: *const fn (JNIEnv, jclass, jmethodID, [*]const jvalue) callconv(.c) jobject =
+            @ptrCast(self.table().NewObjectA orelse return JniError.NotFound);
+        const obj = new(self.env, cls, id, args.ptr);
+        try self.check();
+        return obj orelse JniError.NotFound;
+    }
+
+    // --- Instance fields -------------------------------------------------
+    //
+    // Needed because Android exposes plain public fields on several of the
+    // classes this bridge reads — `DisplayMetrics.widthPixels`,
+    // `PackageInfo.versionName` — with no getter to call.
+
+    pub fn fieldId(self: Self, cls: jclass, name: [*:0]const u8, sig: [*:0]const u8) JniError!jfieldID {
+        const get: *const fn (JNIEnv, jclass, [*:0]const u8, [*:0]const u8) callconv(.c) jfieldID =
+            @ptrCast(self.table().GetFieldID orelse return JniError.NotFound);
+        const id = get(self.env, cls, name, sig);
+        try self.check();
+        return id orelse JniError.NotFound;
+    }
+
+    pub fn objectField(self: Self, obj: jobject, id: jfieldID) JniError!jobject {
+        const get: *const fn (JNIEnv, jobject, jfieldID) callconv(.c) jobject =
+            @ptrCast(self.table().GetObjectField orelse return JniError.NotFound);
+        const value = get(self.env, obj, id);
+        try self.check();
+        return value;
+    }
+
+    pub fn intField(self: Self, obj: jobject, id: jfieldID) JniError!jint {
+        const get: *const fn (JNIEnv, jobject, jfieldID) callconv(.c) jint =
+            @ptrCast(self.table().GetIntField orelse return JniError.NotFound);
+        const value = get(self.env, obj, id);
+        try self.check();
+        return value;
+    }
+
+    pub fn longField(self: Self, obj: jobject, id: jfieldID) JniError!jlong {
+        const get: *const fn (JNIEnv, jobject, jfieldID) callconv(.c) jlong =
+            @ptrCast(self.table().GetLongField orelse return JniError.NotFound);
+        const value = get(self.env, obj, id);
+        try self.check();
+        return value;
+    }
+
+    pub fn floatField(self: Self, obj: jobject, id: jfieldID) JniError!jfloat {
+        const get: *const fn (JNIEnv, jobject, jfieldID) callconv(.c) jfloat =
+            @ptrCast(self.table().GetFloatField orelse return JniError.NotFound);
+        const value = get(self.env, obj, id);
+        try self.check();
+        return value;
+    }
+
+    /// Make a Java `String` from UTF-8.
+    ///
+    /// The JVM wants *modified* UTF-8 here, the same encoding `stringToUtf8`
+    /// decodes on the way back — so a string carrying a NUL or an astral
+    /// character has to be re-encoded rather than handed over. Callers pass
+    /// NUL-terminated literals and ASCII package names today, which are
+    /// identical in both encodings; `encodeModifiedUtf8` is the function to
+    /// add when that stops being true, and this is where it goes.
+    pub fn newStringUtf(self: Self, text: [*:0]const u8) JniError!jstring {
+        const new: *const fn (JNIEnv, [*:0]const u8) callconv(.c) jstring =
+            @ptrCast(self.table().NewStringUTF orelse return JniError.NotFound);
+        const str = new(self.env, text);
+        try self.check();
+        return str orelse JniError.OutOfMemory;
+    }
+
     pub fn callIntMethod(self: Self, obj: jobject, id: jmethodID) JniError!jint {
         const call: *const fn (JNIEnv, jobject, jmethodID) callconv(.c) jint =
             @ptrCast(self.table().CallIntMethod orelse return JniError.NotFound);
@@ -457,6 +572,31 @@ pub const Jni = struct {
         const get: *const fn (JNIEnv, jobject) callconv(.c) jclass =
             @ptrCast(self.table().GetObjectClass orelse return JniError.NotFound);
         return get(self.env, obj) orelse JniError.NotFound;
+    }
+
+    /// Open a scope that owns every local reference created inside it.
+    ///
+    /// The JVM only guarantees sixteen local reference slots. A function that
+    /// walks a few objects — an Activity to a WindowManager to a Display to a
+    /// DisplayMetrics — spends them without ever looking like it is
+    /// allocating, and overflowing aborts the process rather than failing a
+    /// call. `popLocalFrame` frees the whole scope in one go, which is both
+    /// less code than a `defer` per reference and impossible to get half-right.
+    pub fn pushLocalFrame(self: Self, capacity: jint) JniError!void {
+        const push: *const fn (JNIEnv, jint) callconv(.c) jint =
+            @ptrCast(self.table().PushLocalFrame orelse return JniError.NotFound);
+        if (push(self.env, capacity) != 0) {
+            try self.check();
+            return JniError.OutOfMemory;
+        }
+    }
+
+    /// Close the scope. `keep` is the one reference to survive it, promoted
+    /// into the enclosing frame — null when nothing needs to.
+    pub fn popLocalFrame(self: Self, keep: jobject) jobject {
+        const pop: *const fn (JNIEnv, jobject) callconv(.c) jobject =
+            @ptrCast(self.table().PopLocalFrame orelse return null);
+        return pop(self.env, keep);
     }
 
     pub fn deleteLocalRef(self: Self, obj: jobject) void {
@@ -842,4 +982,123 @@ test "modified UTF-8 decodes to the standard encoding" {
     // Truncated input is refused rather than read past the end.
     try testing.expectError(JniError.MalformedString, decodeModifiedUtf8(alloc, "\xE6\x97"));
     try testing.expectError(JniError.MalformedString, decodeModifiedUtf8(alloc, "\xFF"));
+}
+
+// --- Argument passing ------------------------------------------------------
+
+var fake_seen_args: [4]jvalue = undefined;
+var fake_arg_count: usize = 0;
+var fake_called_obj: jobject = null;
+var fake_called_id: jmethodID = null;
+
+var fake_returned: u8 = 0;
+fn fakeCallObjectMethodA(_: JNIEnv, obj: jobject, id: jmethodID, args: [*]const jvalue) callconv(.c) jobject {
+    fake_called_obj = obj;
+    fake_called_id = id;
+    // The fake knows its own arity; a real one is told by the signature.
+    fake_seen_args[0] = args[0];
+    fake_seen_args[1] = args[1];
+    fake_arg_count = 2;
+    return @ptrCast(&fake_returned);
+}
+
+fn fakeIntField(_: JNIEnv, _: jobject, _: jfieldID) callconv(.c) jint {
+    return 1080;
+}
+fn fakeFloatField(_: JNIEnv, _: jobject, _: jfieldID) callconv(.c) jfloat {
+    return 2.75;
+}
+fn fakeLongField(_: JNIEnv, _: jobject, _: jfieldID) callconv(.c) jlong {
+    return 4_000_000_123;
+}
+fn fakeFieldId(_: JNIEnv, _: jclass, _: [*:0]const u8, _: [*:0]const u8) callconv(.c) jfieldID {
+    return @ptrCast(&fake_field);
+}
+
+test "jvalue is the eight-byte union the A-form calls expect" {
+    // Wrong size here would misalign every argument after the first, and the
+    // call would still run — the classic JNI failure that looks like garbage
+    // data rather than a crash.
+    try testing.expectEqual(@as(usize, 8), @sizeOf(jvalue));
+    try testing.expectEqual(@as(usize, 8), @alignOf(jvalue));
+
+    // Each member reads back what was written, which is what says the union is
+    // laid out rather than merely sized.
+    var v = jvalue{ .i = -7 };
+    try testing.expectEqual(@as(jint, -7), v.i);
+    v = jvalue{ .j = 4_000_000_123 };
+    try testing.expectEqual(@as(jlong, 4_000_000_123), v.j);
+    v = jvalue{ .d = 0.5 };
+    try testing.expectEqual(@as(jdouble, 0.5), v.d);
+}
+
+test "arguments arrive in the array, in order, undamaged" {
+    resetFakes();
+    var table = emptyTable();
+    table.CallObjectMethodA = @ptrCast(&fakeCallObjectMethodA);
+    table.ExceptionOccurred = @ptrCast(&fakeExceptionOccurred);
+
+    const ptr: *const JNINativeInterface = &table;
+    const jni = Jni.init(&ptr);
+
+    var receiver: u8 = 0;
+    var name_string: u8 = 0;
+    var method: u8 = 0;
+
+    // `getPackageInfo(String, int)` — the exact shape getDeviceInfo needs, and
+    // the one a variadic call would be most likely to get wrong: a reference
+    // and an int, which travel in different register files.
+    const args = [_]jvalue{
+        .{ .l = @ptrCast(&name_string) },
+        .{ .i = 0 },
+    };
+    const result = try jni.callObjectMethodA(@ptrCast(&receiver), @ptrCast(&method), &args);
+
+    try testing.expect(result != null);
+    try testing.expectEqual(@as(jobject, @ptrCast(&receiver)), fake_called_obj);
+    try testing.expectEqual(@as(usize, 2), fake_arg_count);
+    try testing.expectEqual(@as(jobject, @ptrCast(&name_string)), fake_seen_args[0].l);
+    try testing.expectEqual(@as(jint, 0), fake_seen_args[1].i);
+}
+
+test "instance fields read through the slots they name" {
+    resetFakes();
+    var table = emptyTable();
+    table.FindClass = @ptrCast(&fakeFindClass);
+    table.GetFieldID = @ptrCast(&fakeFieldId);
+    table.GetIntField = @ptrCast(&fakeIntField);
+    table.GetFloatField = @ptrCast(&fakeFloatField);
+    table.GetLongField = @ptrCast(&fakeLongField);
+    table.ExceptionOccurred = @ptrCast(&fakeExceptionOccurred);
+
+    const ptr: *const JNINativeInterface = &table;
+    const jni = Jni.init(&ptr);
+
+    const cls = try jni.findClass("android/util/DisplayMetrics");
+    var obj: u8 = 0;
+    const metrics: jobject = @ptrCast(&obj);
+
+    // Three different widths off three adjacent table slots — an off-by-one in
+    // the transcription would read the wrong one and still return a number.
+    try testing.expectEqual(@as(jint, 1080), try jni.intField(metrics, try jni.fieldId(cls, "widthPixels", "I")));
+    try testing.expectEqual(@as(jfloat, 2.75), try jni.floatField(metrics, try jni.fieldId(cls, "density", "F")));
+    try testing.expectEqual(@as(jlong, 4_000_000_123), try jni.longField(metrics, try jni.fieldId(cls, "longVersionCode", "J")));
+}
+
+test "a field read that throws reports the exception, not the value" {
+    resetFakes();
+    var table = emptyTable();
+    table.GetIntField = @ptrCast(&fakeIntField);
+    table.ExceptionOccurred = @ptrCast(&fakeExceptionOccurred);
+    table.ExceptionDescribe = @ptrCast(&fakeExceptionDescribe);
+    table.ExceptionClear = @ptrCast(&fakeExceptionClear);
+    table.DeleteLocalRef = @ptrCast(&fakeDeleteLocalRef);
+
+    const ptr: *const JNINativeInterface = &table;
+    const jni = Jni.init(&ptr);
+
+    var throwable: u8 = 0;
+    fake_pending_exception = @ptrCast(&throwable);
+    var obj: u8 = 0;
+    try testing.expectError(JniError.JavaException, jni.intField(@ptrCast(&obj), null));
 }


### PR DESCRIPTION
The first Android action written against the JNI layer (#136), plus the parts of that layer it turned out to need.

## What the layer gained

**Argument-taking calls, all in the `A` form** (`[]const jvalue`). The bare `CallObjectMethod` is variadic in C, and calling a variadic function through a `callconv(.c)` pointer means reproducing the platform's argument-passing rules exactly — which arm64 and x86-64 Android **do not share**. The `A` form takes an array, so there's no ABI to reproduce and one implementation is right on both.

`jvalue`'s size and alignment are asserted. Eight bytes wrong there misaligns every argument after the first and the call still runs — the JNI failure that looks like garbage data rather than a crash. The test passes `(String, int)` specifically, the `getPackageInfo` shape, because a reference and an int travel in different register files and it's the pair a variadic call is most likely to get wrong.

**Instance field reads** — `GetFieldID` and the object/int/long/float getters. Android exposes plain public fields on several of the classes this reads: `DisplayMetrics.widthPixels`, `PackageInfo.versionName`. There are no getters to call.

**Local reference frames.** Reading this one reply walks **eleven** Java objects — two classes, four strings, a WindowManager, a Display, a DisplayMetrics, a PackageManager, a PackageInfo — and the JVM guarantees only sixteen local slots. Overflow *aborts the process* rather than failing a call. The alternative is eleven `defer`s, one of which eventually goes missing.

## The action, split so the reply is testable without a device

`read` does the JNI work and returns a plain `DeviceInfo`. `render` turns that into bytes and touches no Java at all. Escaping, key completeness, number formatting and the float's precision are all decided in `render`, so a host test drives them directly — the half that genuinely needs a device is only the field *wiring*.

**Thirteen keys is the contract.** The iOS equivalent of this action once answered four of fourteen fields and reported success, handing pages `undefined` for `screenWidth`. The test parses the reply and asserts `count() == 13` plus every value.

## Faithful to the Kotlin, and where it isn't

| | |
| --- | --- |
| `appVersion` / `appBuild` | Reproduce the shim's `try`/`catch` fallbacks (`"unknown"`, `0`) for a throwing `getPackageInfo`. A **null `versionName`** — legal, and *not* covered by that catch — takes the same fallback rather than emitting a JSON null a page must test for. |
| `appBuild` | `longVersionCode` above API 28, `versionCode` below. Reading the wrong one truncates a modern app's build number rather than failing. Tested past 2³¹. |
| `Build$VERSION` | With the dollar — that's the binary name; `android/os/Build/VERSION` finds nothing. |
| `getDefaultDisplay` | Stays deprecated-but-used, as in the shim. `Context.getDisplay()` answers a different question on a multi-display device than this action's contract promises. |
| `isEmulator` | Exactly the shim's two markers, deliberately not widened — a test asserts `vbox86p` is **not** detected, because the Kotlin doesn't detect it either. |

## A bug its own test caught

`render` wrote an unconditional leading comma, so the object opened `{,"model"` and stopped parsing at character two. The comment above the line argued confidently for the wrong thing. Also tested: a device name containing `"` — `ro.product.model` is settable on custom builds, and `appendJsonEscaped` writes no delimiters, the same trap that broke the iOS location-recording state file.

`zig build test:android` → **40/40**, peak RSS 294 MB.

## Not yet reachable — stated plainly

There is still **no seam**. No `JNI_OnLoad`, no `RegisterNatives`, no `external fun` on the Kotlin side, so `read` has no caller and no page can reach this. That's the next commit, and it needs the JavaVM's own invoke table, which this doesn't declare.

`RegisterNatives` rather than symbol-name export is the plan: JNI's `Java_com_example_Foo_bar` naming embeds the package, and craft's package name is templated per app — so a name-mangled export would only bind for one package.
