### PR TITLE
feat(android): the seam — Kotlin can now call into Zig

### DIFF
--- a/packages/android/src/index.test.ts
+++ b/packages/android/src/index.test.ts
@@ -32,6 +32,34 @@ describe('Craft Android builder', () => {
     })).toBe('')
   })
 
+  it('emits the native holder to a fixed package, whatever the app is called', async () => {
+    // The prebuilt libcraft.so binds its natives by class name in JNI_OnLoad
+    // and cannot know a package chosen here. So CraftNative lives at a path
+    // that does not depend on the app, and CraftBridge — which does — reaches
+    // it by import. If this file ever moves under packagePath, registration
+    // stops finding the class and every action silently stays on the shim.
+    const output = mkdtempSync(join(tmpdir(), 'craft-android-native-'))
+    await init({ name: 'WildLoop', packageName: 'org.wildloop.app', output })
+
+    const holder = join(output, 'app/src/main/java/com/craft/runtime/CraftNative.kt')
+    expect(existsSync(holder)).toBe(true)
+
+    const source = readFileSync(holder, 'utf-8')
+    expect(source).toContain('package com.craft.runtime')
+    // Nothing here is substituted, and an unreplaced marker would mean it was
+    // routed through the templating that rewrites CraftBridge.
+    expect(source).not.toContain('{{')
+    expect(source).not.toContain('org.wildloop.app')
+
+    // And the generated bridge actually reaches it.
+    const bridge = readFileSync(
+      join(output, 'app/src/main/java/org/wildloop/app/CraftBridge.kt'),
+      'utf-8',
+    )
+    expect(bridge).toContain('import com.craft.runtime.CraftNative')
+    expect(bridge).toContain('CraftNative.getDeviceInfo(activity)?.let { return it }')
+  })
+
   it('copies a complete web distribution while preserving native configuration', async () => {
     const root = mkdtempSync(join(tmpdir(), 'craft-android-assets-'))
     const web = join(root, 'web')

--- a/packages/android/src/index.ts
+++ b/packages/android/src/index.ts
@@ -241,6 +241,15 @@ export async function init(options: InitOptions): Promise<void> {
             )
         }`)
   writeFileSync(join(output, 'app/src/main/java', packagePath, 'CraftBridge.kt'), craftBridge)
+
+  // CraftNative goes to a fixed package, not the app's. The prebuilt
+  // libcraft.so binds its natives by class name in JNI_OnLoad, and it cannot
+  // know a name chosen here — so this one file is deliberately not templated
+  // and deliberately not under packagePath.
+  const craftNative = readFileSync(join(TEMPLATES_DIR, 'CraftNative.kt.template'), 'utf-8')
+  const nativeDir = join(output, 'app/src/main/java/com/craft/runtime')
+  mkdirSync(nativeDir, { recursive: true })
+  writeFileSync(join(nativeDir, 'CraftNative.kt'), craftNative)
   const healthTemplate = readFileSync(join(
     TEMPLATES_DIR,
     config.enableHealthConnect ? 'CraftHealthConnect.kt.template' : 'CraftHealthConnectStub.kt.template',

--- a/packages/android/templates/CraftBridge.kt.template
+++ b/packages/android/templates/CraftBridge.kt.template
@@ -18,6 +18,7 @@ import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.net.Uri
 import android.os.Build
+import com.craft.runtime.CraftNative
 import android.os.Bundle
 import android.os.Looper
 import android.os.VibrationEffect
@@ -1807,6 +1808,11 @@ class CraftBridge(
 
     @JavascriptInterface
     fun getDeviceInfo(): String {
+        // The Zig runtime first, the body below when it declines. Null means
+        // this build does not serve the action natively — a shim-only app, or
+        // one whose libcraft.so failed to bind — and is not an error.
+        CraftNative.getDeviceInfo(activity)?.let { return it }
+
         val metrics = DisplayMetrics()
         @Suppress("DEPRECATION")
         activity.windowManager.defaultDisplay.getMetrics(metrics)

--- a/packages/android/templates/CraftNative.kt.template
+++ b/packages/android/templates/CraftNative.kt.template
@@ -1,0 +1,79 @@
+package com.craft.runtime
+
+import android.app.Activity
+
+/**
+ * The Zig runtime's native methods.
+ *
+ * This class exists for one reason: its package is fixed. `CraftBridge` is
+ * generated with a templated package declaration, so its name differs per app,
+ * and the prebuilt `libcraft.so` cannot know it — neither JNI's
+ * `Java_<package>_...` symbol mangling nor a `FindClass` inside `JNI_OnLoad`
+ * can name a class chosen at generation time. Binding to
+ * `com.craft.runtime.CraftNative` instead lets one library serve every app
+ * unchanged.
+ *
+ * Nothing in this file is substituted. A template marker appearing here would
+ * make the library app-specific and the registration in `android_dispatch.zig`
+ * would stop finding this class.
+ *
+ * ## Every method may answer "not mine"
+ *
+ * A null return means Zig does not serve that action in this build, and the
+ * caller falls through to `CraftBridge`'s own Kotlin. That is the same
+ * hand-back the iOS seam performs, and it is what makes the migration
+ * incremental: an app on a build where Zig serves one action behaves exactly
+ * like one where it serves none.
+ *
+ * ## Why the natives are not `@JvmStatic`
+ *
+ * In a Kotlin `object`, `@JvmStatic` generates a static bridge alongside the
+ * instance method, and which of the two carries the `native` flag is a detail
+ * of the compiler rather than something this can rely on. `RegisterNatives`
+ * binds one specific method, and a static native takes `(JNIEnv*, jclass)`
+ * where an instance native takes `(JNIEnv*, jobject)` — so guessing wrong is
+ * a signature mismatch at load. Declaring them as ordinary instance methods on
+ * the singleton removes the question.
+ */
+object CraftNative {
+
+    /**
+     * True when `libcraft.so` loaded.
+     *
+     * The library is genuinely optional: an app can be built with no Zig
+     * runtime in `jniLibs`, and that is the shim-only configuration rather
+     * than an error. So the failure is caught and remembered — an
+     * `UnsatisfiedLinkError` escaping a static initialiser would take the
+     * whole class down and turn "no native runtime" into a crash on the first
+     * bridge call.
+     */
+    val isAvailable: Boolean = try {
+        System.loadLibrary("craft")
+        true
+    } catch (e: UnsatisfiedLinkError) {
+        false
+    } catch (e: SecurityException) {
+        false
+    }
+
+    private external fun nativeGetDeviceInfo(activity: Activity): String?
+
+    /**
+     * `getDeviceInfo`, or null to use the Kotlin implementation.
+     *
+     * The catch is not belt-and-braces. The library can load while
+     * `JNI_OnLoad` still fails to bind — a missing class, a signature that
+     * does not match — and an unbound `external fun` throws
+     * `UnsatisfiedLinkError` at the call rather than at load. Turning that
+     * into null is what keeps a half-registered runtime behaving like no
+     * runtime at all.
+     */
+    fun getDeviceInfo(activity: Activity): String? {
+        if (!isAvailable) return null
+        return try {
+            nativeGetDeviceInfo(activity)
+        } catch (e: UnsatisfiedLinkError) {
+            null
+        }
+    }
+}

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -420,12 +420,14 @@ pub fn build(b: *std.Build) void {
     });
     const run_jni_tests = b.addRunArtifact(jni_tests);
 
-    // The Android bridge modules. Rooted at the device module because it is
-    // the only one so far; a second joins by being imported from here, the way
-    // `ios.zig` gathers the iOS ones.
+    // The Android bridge modules. Rooted at the dispatch seam, which imports
+    // every module it can route to — so a module joins these tests by being
+    // reachable from the thing that serves it, the way `ios.zig` gathers the
+    // iOS ones. A module nothing dispatches to is untested here, which is the
+    // right signal.
     const android_bridge_tests = b.addTest(.{
         .root_module = b.createModule(.{
-            .root_source_file = b.path("src/bridge_android_device.zig"),
+            .root_source_file = b.path("src/android_dispatch.zig"),
             .target = target,
             .optimize = optimize,
         }),
@@ -2197,12 +2199,60 @@ pub fn build(b: *std.Build) void {
     build_android.dependOn(&android_arm64_install.step);
     build_android_all.dependOn(&android_arm64_install.step);
 
+    // The JNI library, and it has to be shared where the one above is static.
+    // `System.loadLibrary("craft")` resolves `libcraft.so` through the dynamic
+    // loader; a `.a` is not loadable at runtime at all, so a static build of
+    // this would produce an artifact no Kotlin could ever call into.
+    //
+    // Rooted at `android_dispatch.zig` rather than `android.zig`: the seam is
+    // the library's entry point — it owns `JNI_OnLoad` and reaches every
+    // module it can route to — while `android.zig` is the CraftActivity API,
+    // a different thing that happens to target the same OS.
+    //
+    // The name is what Kotlin passes to loadLibrary, so it is `craft` and not
+    // the arch-suffixed name beside it: the loader picks the ABI directory,
+    // and a per-arch name would make the Kotlin need to know its own
+    // architecture.
+    const android_arm64_jni = b.addLibrary(.{
+        .linkage = .dynamic,
+        .name = "craft",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/android_dispatch.zig"),
+            .target = android_arm64_target,
+            .optimize = optimize,
+        }),
+    });
+
+    const android_arm64_jni_install = b.addInstallArtifact(android_arm64_jni, .{
+        .dest_dir = .{ .override = .{ .custom = "android/arm64-v8a" } },
+    });
+    build_android.dependOn(&android_arm64_jni_install.step);
+    build_android_all.dependOn(&android_arm64_jni_install.step);
+
     // Android Emulator (x86_64)
     const android_x86_target = b.resolveTargetQuery(.{
         .cpu_arch = .x86_64,
         .os_tag = .linux,
         .abi = .android,
     });
+
+    const android_x86_jni = b.addLibrary(.{
+        .linkage = .dynamic,
+        .name = "craft",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/android_dispatch.zig"),
+            .target = android_x86_target,
+            .optimize = optimize,
+        }),
+    });
+
+    // `x86_64`, matching the jniLibs directory the loader looks in — not
+    // `x86`, which is the 32-bit ABI and would be silently ignored.
+    const android_x86_jni_install = b.addInstallArtifact(android_x86_jni, .{
+        .dest_dir = .{ .override = .{ .custom = "android/x86_64" } },
+    });
+    build_android_x86.dependOn(&android_x86_jni_install.step);
+    build_android_all.dependOn(&android_x86_jni_install.step);
 
     const android_x86_lib = b.addLibrary(.{
         .linkage = .static,

--- a/packages/zig/src/android_dispatch.zig
+++ b/packages/zig/src/android_dispatch.zig
@@ -90,18 +90,21 @@ pub const holder_class = "com/craft/runtime/CraftNative";
 pub export fn JNI_OnLoad(vm_handle: jni.JavaVM, _: ?*anyopaque) callconv(.c) jni.jint {
     java_vm = vm_handle;
 
-    if (jni.envForThisThread(vm_handle)) |env| {
-        const j = Jni.init(env);
-        if (j.findClass(holder_class)) |cls| {
-            _ = registerFrom(env, cls);
-        } else |err| {
-            std.log.err(
-                "craft: {s} not found ({s}); every action stays on the Kotlin shim",
-                .{ holder_class, @errorName(err) },
-            );
-        }
-    } else {
-        std.log.err("craft: no JNIEnv at load; every action stays on the Kotlin shim", .{});
+    switch (bindNatives(vm_handle)) {
+        .registered => {},
+        .no_env => std.log.err(
+            "craft: no JNIEnv at load; every action stays on the Kotlin shim",
+            .{},
+        ),
+        .class_not_found => std.log.err(
+            "craft: {s} not on the class path; every action stays on the Kotlin shim",
+            .{holder_class},
+        ),
+        .register_failed => std.log.err(
+            "craft: RegisterNatives refused a method on {s}; check the descriptors " ++
+                "against CraftNative.kt. Every action stays on the Kotlin shim",
+            .{holder_class},
+        ),
     }
 
     return jni.JNI_VERSION_1_6;
@@ -121,17 +124,31 @@ const natives = [_]jni.JNINativeMethod{
     },
 };
 
-/// Bind the natives onto `cls`. Called from Kotlin with its own class, because
-/// the class name is templated and `JNI_OnLoad` cannot know it.
+/// How binding went. A value rather than a log line, so every path is
+/// assertable: the test runner treats an error-level log as a failed test, so
+/// a function that reported by logging could only ever be tested on the path
+/// that succeeds — which is the one path that does not need testing.
+pub const LoadOutcome = enum {
+    registered,
+    /// The VM would not give this thread a `JNIEnv`.
+    no_env,
+    /// `CraftNative` was not on the class path.
+    class_not_found,
+    /// The class was found and `RegisterNatives` refused it — almost always a
+    /// method name or descriptor that does not match what Kotlin declares.
+    register_failed,
+};
+
+/// Find the holder and bind the natives to it. No logging; see `LoadOutcome`.
 ///
 /// Idempotent by JNI's own rule: registering a method that is already
 /// registered replaces it, so a second call after a hot reload is not an error.
-pub fn registerFrom(env: jni.JNIEnv, cls: jni.jclass) bool {
-    jni.registerNatives(env, cls, &natives) catch |err| {
-        std.log.err("craft: RegisterNatives failed ({s}); Zig serves no actions this run", .{@errorName(err)});
-        return false;
-    };
-    return true;
+pub fn bindNatives(vm_handle: jni.JavaVM) LoadOutcome {
+    const env = jni.envForThisThread(vm_handle) orelse return .no_env;
+    const j = Jni.init(env);
+    const cls = j.findClass(holder_class) catch return .class_not_found;
+    jni.registerNatives(env, cls, &natives) catch return .register_failed;
+    return .registered;
 }
 
 /// `nativeGetDeviceInfo(activity)` — the first action served from Zig.
@@ -173,15 +190,103 @@ fn nativeGetDeviceInfo(env: jni.JNIEnv, _: jni.jobject, activity: jni.jobject) c
 
 const testing = std.testing;
 
-test "JNI_OnLoad asks for the version Android actually provides" {
+// --- A fake JVM, enough to drive the whole load path ----------------------
+//
+// `JNI_OnLoad` is handed a JavaVM and has to reach a JNIEnv, a class and
+// RegisterNatives before it has bound anything. All three are table entries,
+// so all three can be Zig functions.
+
+var fake_env_table: jni.JNINativeInterface = undefined;
+var fake_env_ptr: *const jni.JNINativeInterface = undefined;
+var fake_class_storage: u8 = 0;
+var fake_registered_count: jni.jint = -1;
+var fake_register_result: jni.jint = jni.JNI_OK;
+var fake_find_class_succeeds = true;
+var fake_get_env_succeeds = true;
+
+fn fakeGetEnv(_: jni.JavaVM, out: *?*anyopaque, _: jni.jint) callconv(.c) jni.jint {
+    if (!fake_get_env_succeeds) return jni.JNI_EDETACHED;
+    out.* = @ptrCast(@constCast(&fake_env_ptr));
+    return jni.JNI_OK;
+}
+
+fn fakeFindClass(_: jni.JNIEnv, _: [*:0]const u8) callconv(.c) jni.jclass {
+    if (!fake_find_class_succeeds) return null;
+    return @ptrCast(&fake_class_storage);
+}
+
+fn fakeExceptionOccurred(_: jni.JNIEnv) callconv(.c) jni.jobject {
+    return null;
+}
+
+fn fakeRegisterNatives(
+    _: jni.JNIEnv,
+    _: jni.jclass,
+    _: [*]const jni.JNINativeMethod,
+    count: jni.jint,
+) callconv(.c) jni.jint {
+    fake_registered_count = count;
+    return fake_register_result;
+}
+
+fn fakeVm() jni.JNIInvokeInterface {
+    var invoke = std.mem.zeroes(jni.JNIInvokeInterface);
+    invoke.GetEnv = @ptrCast(&fakeGetEnv);
+
+    fake_env_table = std.mem.zeroes(jni.JNINativeInterface);
+    fake_env_table.FindClass = @ptrCast(&fakeFindClass);
+    fake_env_table.ExceptionOccurred = @ptrCast(&fakeExceptionOccurred);
+    fake_env_table.RegisterNatives = @ptrCast(&fakeRegisterNatives);
+    fake_env_ptr = &fake_env_table;
+
+    fake_registered_count = -1;
+    fake_register_result = jni.JNI_OK;
+    fake_find_class_succeeds = true;
+    fake_get_env_succeeds = true;
+    return invoke;
+}
+
+test "the load path finds the holder and binds every native to it" {
+    var invoke = fakeVm();
+    const ptr: *const jni.JNIInvokeInterface = &invoke;
+
+    try testing.expectEqual(LoadOutcome.registered, bindNatives(&ptr));
+
+    // Every declared method was handed to RegisterNatives in one call — a
+    // partial registration would leave some actions bound and others throwing
+    // UnsatisfiedLinkError at their first use.
+    try testing.expectEqual(@as(jni.jint, @intCast(natives.len)), fake_registered_count);
+}
+
+test "each way the load can fail is reported as itself" {
+    // These are the three states an app can actually be in, and telling them
+    // apart is the difference between a one-line log and an afternoon: no
+    // runtime linked, a stale Kotlin holder, a descriptor that stopped
+    // matching.
+    var invoke = fakeVm();
+    const ptr: *const jni.JNIInvokeInterface = &invoke;
+
+    fake_get_env_succeeds = false;
+    try testing.expectEqual(LoadOutcome.no_env, bindNatives(&ptr));
+
+    fake_get_env_succeeds = true;
+    fake_find_class_succeeds = false;
+    try testing.expectEqual(LoadOutcome.class_not_found, bindNatives(&ptr));
+
+    fake_find_class_succeeds = true;
+    fake_register_result = -1;
+    try testing.expectEqual(LoadOutcome.register_failed, bindNatives(&ptr));
+}
+
+test "JNI_OnLoad asks for the version Android actually provides, and captures the VM" {
     // Returning a version ART does not offer fails the whole library load, and
-    // the failure surfaces as an UnsatisfiedLinkError with no useful cause.
-    var table = std.mem.zeroes(jni.JNIInvokeInterface);
-    const ptr: *const jni.JNIInvokeInterface = &table;
+    // surfaces as an UnsatisfiedLinkError with no useful cause.
+    var invoke = fakeVm();
+    const ptr: *const jni.JNIInvokeInterface = &invoke;
     try testing.expectEqual(jni.JNI_VERSION_1_6, JNI_OnLoad(&ptr, null));
 
-    // And it captured the VM, which is the handle a later off-thread callback
-    // has to go through.
+    // The VM is the one handle that may be cached across threads, and a later
+    // callback on a framework thread has nothing else to ask for its env.
     try testing.expect(vm() != null);
     java_vm = null;
 }

--- a/packages/zig/src/android_dispatch.zig
+++ b/packages/zig/src/android_dispatch.zig
@@ -1,0 +1,218 @@
+//! Where Kotlin hands an action to Zig.
+//!
+//! The counterpart to `ios_dispatch.zig`, and the two seams differ because the
+//! two bridges do. iOS posts a message and settles a promise later, so its seam
+//! is `craft_ios_handle_action` returning "claimed / not mine" with the reply
+//! arriving separately. Android's `@JavascriptInterface` methods are ordinary
+//! synchronous calls that return a `String`, so the seam is a synchronous
+//! function returning a `jstring`.
+//!
+//! ## `null` means "not mine", exactly as `.not_ours` does on iOS
+//!
+//! Every native method here returns null for an action Zig does not serve, and
+//! the Kotlin falls through to its own implementation. That is the same
+//! hand-back `ios_dispatch.hostServesItself` performs, and it is what makes
+//! this migratable one action at a time: an app running a build where Zig
+//! serves three actions behaves identically to one where it serves none.
+//!
+//! ## The templated package, and why there is a second Kotlin class
+//!
+//! The usual way to bind a `native` method is to export a symbol the JVM finds
+//! by mangling — `Java_com_example_CraftBridge_nativeGetDeviceInfo`. That name
+//! embeds the package, and `CraftBridge.kt.template` opens with
+//! `package {{PACKAGE_NAME}}`, defaulting to `com.craft.<appname>`. A mangled
+//! export would resolve for exactly one app and raise `UnsatisfiedLinkError`
+//! on first call for every other — at runtime, long after a build that looked
+//! fine. `RegisterNatives` binds by name at load time instead and never sees
+//! the package.
+//!
+//! That solves the method name and not the class name: `FindClass` needs one,
+//! and a prebuilt library cannot know a name chosen when the app is generated.
+//! So the natives are not bound to `CraftBridge` at all. They are bound to
+//! `com.craft.runtime.CraftNative`, a small holder whose package is **fixed**
+//! and not templated, and the generated `CraftBridge` delegates to it. One
+//! extra class buys a library that is identical for every app.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const jni = @import("jni_runtime.zig");
+const device = @import("bridge_android_device.zig");
+
+const Jni = jni.Jni;
+
+/// The allocator every reply is built with.
+///
+/// `page_allocator`, and the choice is a build constraint rather than a
+/// preference. `c_allocator` would pull in bionic, and Zig cannot provide
+/// bionic — a static Android library links nothing and builds anyway, but this
+/// one is shared and has to resolve its symbols, so libc here means the whole
+/// library needs the NDK to build at all. Standing free of libc keeps it
+/// buildable with nothing but Zig.
+///
+/// Every native call wraps this in an arena, so the page granularity costs one
+/// page per call rather than one per allocation, and nothing has to be freed
+/// individually on the way out.
+const backing = std.heap.page_allocator;
+
+/// The VM, captured at load so a later callback on a framework thread can ask
+/// it for that thread's `JNIEnv`.
+///
+/// A `JNIEnv` is per-thread and must never be cached across threads; a
+/// `JavaVM` is process-wide and is the one handle that may be. Storing the
+/// wrong one of these is the crash that only shows up once something calls
+/// back from a non-Java thread.
+var java_vm: ?jni.JavaVM = null;
+
+pub fn vm() ?jni.JavaVM {
+    return java_vm;
+}
+
+/// The Java class the natives bind to. Fixed, unlike the bridge's own package.
+pub const holder_class = "com/craft/runtime/CraftNative";
+
+/// The JVM calls this when `System.loadLibrary` resolves the library.
+///
+/// Returning a version the runtime does not offer fails the load, so this
+/// returns 1.6 — what ART provides and what Android documents as the floor.
+///
+/// `FindClass` is legal here and only here for a class of the app's own: this
+/// runs on the thread that called `loadLibrary`, which carries the app's class
+/// loader. The same call from a thread the JVM did not create resolves against
+/// the *system* loader and would not find `CraftNative` at all — one of JNI's
+/// sharper edges, and the reason registration happens at load rather than
+/// lazily on first use.
+///
+/// A failed registration does not fail the load. Returning an error version
+/// here would stop the library loading at all, and the Kotlin holder already
+/// treats a missing native as "ask the shim" — so the honest outcome is a
+/// logged warning and an app that behaves exactly as it did before Zig was
+/// linked.
+pub export fn JNI_OnLoad(vm_handle: jni.JavaVM, _: ?*anyopaque) callconv(.c) jni.jint {
+    java_vm = vm_handle;
+
+    if (jni.envForThisThread(vm_handle)) |env| {
+        const j = Jni.init(env);
+        if (j.findClass(holder_class)) |cls| {
+            _ = registerFrom(env, cls);
+        } else |err| {
+            std.log.err(
+                "craft: {s} not found ({s}); every action stays on the Kotlin shim",
+                .{ holder_class, @errorName(err) },
+            );
+        }
+    } else {
+        std.log.err("craft: no JNIEnv at load; every action stays on the Kotlin shim", .{});
+    }
+
+    return jni.JNI_VERSION_1_6;
+}
+
+/// The native methods this library binds, by Java name and signature.
+///
+/// The signatures are checked by the JVM at registration rather than at call
+/// time, which is the one piece of type safety this seam gets for free: a
+/// wrong descriptor here fails `RegisterNatives` at load with a message naming
+/// the method, rather than corrupting a stack on first use.
+const natives = [_]jni.JNINativeMethod{
+    .{
+        .name = "nativeGetDeviceInfo",
+        .signature = "(Landroid/app/Activity;)Ljava/lang/String;",
+        .fnPtr = @ptrCast(&nativeGetDeviceInfo),
+    },
+};
+
+/// Bind the natives onto `cls`. Called from Kotlin with its own class, because
+/// the class name is templated and `JNI_OnLoad` cannot know it.
+///
+/// Idempotent by JNI's own rule: registering a method that is already
+/// registered replaces it, so a second call after a hot reload is not an error.
+pub fn registerFrom(env: jni.JNIEnv, cls: jni.jclass) bool {
+    jni.registerNatives(env, cls, &natives) catch |err| {
+        std.log.err("craft: RegisterNatives failed ({s}); Zig serves no actions this run", .{@errorName(err)});
+        return false;
+    };
+    return true;
+}
+
+/// `nativeGetDeviceInfo(activity)` — the first action served from Zig.
+///
+/// Returns null on any failure rather than throwing. The Kotlin's own
+/// `getDeviceInfo` is the fallback, so a null here is "ask the shim", which is
+/// strictly better than propagating a Java exception the page would see as an
+/// unexplained rejection from a method whose Kotlin version cannot fail.
+fn nativeGetDeviceInfo(env: jni.JNIEnv, _: jni.jobject, activity: jni.jobject) callconv(.c) jni.jstring {
+    const j = Jni.init(env);
+
+    // One arena for the whole call. The reply is built out of a dozen small
+    // strings that all die together the moment `NewStringUTF` has copied them
+    // into the JVM's heap, which is exactly the lifetime an arena models.
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const info = device.read(allocator, j, activity) catch |err| {
+        std.log.warn("craft: getDeviceInfo fell through to the shim ({s})", .{@errorName(err)});
+        return null;
+    };
+
+    const json = device.render(allocator, info) catch return null;
+
+    // `NewStringUTF` reads to a NUL, and `render` produces a plain slice.
+    // Copied rather than terminated in place because the reply is JSON built
+    // for the page, and giving `render` a sentinel to satisfy would put a
+    // JNI detail into the half of this action that has nothing to do with Java.
+    const owned = allocator.allocSentinel(u8, json.len, 0) catch return null;
+    @memcpy(owned, json);
+
+    return j.newStringUtf(owned.ptr) catch null;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+const testing = std.testing;
+
+test "JNI_OnLoad asks for the version Android actually provides" {
+    // Returning a version ART does not offer fails the whole library load, and
+    // the failure surfaces as an UnsatisfiedLinkError with no useful cause.
+    var table = std.mem.zeroes(jni.JNIInvokeInterface);
+    const ptr: *const jni.JNIInvokeInterface = &table;
+    try testing.expectEqual(jni.JNI_VERSION_1_6, JNI_OnLoad(&ptr, null));
+
+    // And it captured the VM, which is the handle a later off-thread callback
+    // has to go through.
+    try testing.expect(vm() != null);
+    java_vm = null;
+}
+
+test "the registered natives name methods the Kotlin actually declares" {
+    // A descriptor is checked by the JVM at registration, so a wrong one fails
+    // at load rather than at call — but only if the *name* matches something.
+    // These two strings are the contract with CraftBridge.kt.
+    try testing.expectEqual(@as(usize, 1), natives.len);
+    try testing.expectEqualStrings("nativeGetDeviceInfo", std.mem.span(natives[0].name));
+
+    // And the class they bind to is the fixed one, not the templated bridge.
+    // A `{{` here would mean the library had been made app-specific.
+    try testing.expectEqualStrings("com/craft/runtime/CraftNative", holder_class);
+    try testing.expect(std.mem.indexOf(u8, holder_class, "{") == null);
+    try testing.expectEqualStrings(
+        "(Landroid/app/Activity;)Ljava/lang/String;",
+        std.mem.span(natives[0].signature),
+    );
+}
+
+test "the JavaVM table puts GetEnv where the header does" {
+    try testing.expectEqual(@as(usize, 3), @offsetOf(jni.JNIInvokeInterface, "DestroyJavaVM") / @sizeOf(jni.JniFn));
+    try testing.expectEqual(@as(usize, 4), @offsetOf(jni.JNIInvokeInterface, "AttachCurrentThread") / @sizeOf(jni.JniFn));
+    try testing.expectEqual(@as(usize, 6), @offsetOf(jni.JNIInvokeInterface, "GetEnv") / @sizeOf(jni.JniFn));
+    try testing.expectEqual(@as(usize, 8 * @sizeOf(jni.JniFn)), @sizeOf(jni.JNIInvokeInterface));
+}
+
+test "a JNINativeMethod is three pointers, in the header's order" {
+    // RegisterNatives reads this array by offset like everything else in JNI.
+    try testing.expectEqual(@as(usize, 0), @offsetOf(jni.JNINativeMethod, "name"));
+    try testing.expectEqual(@as(usize, @sizeOf(usize)), @offsetOf(jni.JNINativeMethod, "signature"));
+    try testing.expectEqual(@as(usize, 2 * @sizeOf(usize)), @offsetOf(jni.JNINativeMethod, "fnPtr"));
+}

--- a/packages/zig/src/jni_runtime.zig
+++ b/packages/zig/src/jni_runtime.zig
@@ -24,13 +24,18 @@
 //! the transcription by counting rather than by trusting it, and
 //! `jniIndexOf` + the offset test at the bottom assert it.
 //!
-//! ## Why the struct stops at 170
+//! ## Why the struct stops at 215
 //!
-//! It is deliberately truncated after `ReleaseStringUTFChars`. Zig never
-//! *allocates* one of these — the table always belongs to the JVM — so
-//! reading a field at offset ≤ 170 out of the real, longer table is correct,
-//! and every entry not declared is one that cannot be transcribed wrongly.
-//! Adding a call means extending the list in order, from the header.
+//! It is deliberately truncated after `RegisterNatives`. Zig never *allocates*
+//! one of these — the table always belongs to the JVM — so reading a field at
+//! a lower offset out of the real, longer table is correct, and every entry
+//! not declared is one that cannot be transcribed wrongly. Adding a call means
+//! extending the list in order, from the header.
+//!
+//! Forty-four of the declared entries are the array functions at 171-214, and
+//! none of them is called. They are there because `RegisterNatives` sits
+//! behind them: a member's position is its offset, so there is no way to reach
+//! 215 without transcribing every step to it.
 //!
 //! ## Every field is an opaque pointer, on purpose
 //!
@@ -307,7 +312,61 @@ pub const JNINativeInterface = extern struct {
     GetStringUTFLength: JniFn, // 168
     GetStringUTFChars: JniFn, // 169
 
-    ReleaseStringUTFChars: JniFn, // 170 — the table is cut here
+    ReleaseStringUTFChars: JniFn, // 170
+
+    // 171-214 are the array functions. None is called: nothing in this bridge
+    // passes a Java array yet. They are declared anyway because `RegisterNatives`
+    // sits behind them and a member's position is its offset — there is no way
+    // to reach 215 without transcribing every step to it.
+    GetArrayLength: JniFn, // 171
+    NewObjectArray: JniFn,
+    GetObjectArrayElement: JniFn,
+    SetObjectArrayElement: JniFn,
+    NewBooleanArray: JniFn,
+    NewByteArray: JniFn,
+    NewCharArray: JniFn,
+    NewShortArray: JniFn,
+    NewIntArray: JniFn,
+    NewLongArray: JniFn,
+
+    NewFloatArray: JniFn, // 181
+    NewDoubleArray: JniFn,
+    GetBooleanArrayElements: JniFn,
+    GetByteArrayElements: JniFn,
+    GetCharArrayElements: JniFn,
+    GetShortArrayElements: JniFn,
+    GetIntArrayElements: JniFn,
+    GetLongArrayElements: JniFn,
+    GetFloatArrayElements: JniFn,
+    GetDoubleArrayElements: JniFn,
+
+    ReleaseBooleanArrayElements: JniFn, // 191
+    ReleaseByteArrayElements: JniFn,
+    ReleaseCharArrayElements: JniFn,
+    ReleaseShortArrayElements: JniFn,
+    ReleaseIntArrayElements: JniFn,
+    ReleaseLongArrayElements: JniFn,
+    ReleaseFloatArrayElements: JniFn,
+    ReleaseDoubleArrayElements: JniFn,
+    GetBooleanArrayRegion: JniFn,
+    GetByteArrayRegion: JniFn,
+
+    GetCharArrayRegion: JniFn, // 201
+    GetShortArrayRegion: JniFn,
+    GetIntArrayRegion: JniFn,
+    GetLongArrayRegion: JniFn,
+    GetFloatArrayRegion: JniFn,
+    GetDoubleArrayRegion: JniFn,
+    SetBooleanArrayRegion: JniFn,
+    SetByteArrayRegion: JniFn,
+    SetCharArrayRegion: JniFn,
+    SetShortArrayRegion: JniFn,
+
+    SetIntArrayRegion: JniFn, // 211
+    SetLongArrayRegion: JniFn,
+    SetFloatArrayRegion: JniFn,
+    SetDoubleArrayRegion: JniFn,
+    RegisterNatives: JniFn, // 215 — the table is cut here
 };
 
 /// The declared index of a member, for the offset audit below.
@@ -316,6 +375,89 @@ pub const JNINativeInterface = extern struct {
 /// member is one pointer wide — which is the reason they are all opaque.
 pub fn jniIndexOf(comptime name: []const u8) usize {
     return @offsetOf(JNINativeInterface, name) / @sizeOf(JniFn);
+}
+
+// =============================================================================
+// The JavaVM, and binding native methods
+//
+// A second, much smaller table. `JNI_OnLoad` is handed a `JavaVM*` rather than
+// a `JNIEnv*` — the VM is process-wide and thread-independent, the env is
+// per-thread — so reaching Java from `JNI_OnLoad` means asking the VM for this
+// thread's env first.
+// =============================================================================
+
+/// `JavaVM`'s function table. Eight entries, and the layout is from the same
+/// header as the big one.
+pub const JNIInvokeInterface = extern struct {
+    reserved0: JniFn, // 0
+    reserved1: JniFn,
+    reserved2: JniFn,
+    DestroyJavaVM: JniFn, // 3
+    AttachCurrentThread: JniFn, // 4
+    DetachCurrentThread: JniFn, // 5
+    GetEnv: JniFn, // 6
+    AttachCurrentThreadAsDaemon: JniFn, // 7
+};
+
+pub const JavaVM = *const *const JNIInvokeInterface;
+
+/// The JNI version this library asks for and `JNI_OnLoad` returns.
+///
+/// 1.6 is what every Android runtime provides and the floor Android documents;
+/// asking for 1.8 gets `JNI_EVERSION` from ART and the library fails to load.
+pub const JNI_VERSION_1_6: jint = 0x00010006;
+pub const JNI_OK: jint = 0;
+pub const JNI_EDETACHED: jint = -2;
+
+/// One `name`/`signature`/`function` triple for `RegisterNatives`.
+///
+/// `name` and `signature` are `char*` in the header rather than `const char*`;
+/// the JVM does not write through them, and matching the declared type avoids
+/// a cast at every call site.
+pub const JNINativeMethod = extern struct {
+    name: [*:0]const u8,
+    signature: [*:0]const u8,
+    fnPtr: *const anyopaque,
+};
+
+/// This thread's `JNIEnv`, or null when the thread is not attached.
+///
+/// `GetEnv` is the only correct way to get one. A `JNIEnv` belongs to a single
+/// thread and caching one across threads is the classic JNI crash — so a
+/// callback arriving on a framework thread asks here rather than reusing the
+/// env it was registered with. This is the same hazard `ios_events.zig` solves
+/// by hopping to the main queue, in a form where the runtime will not tell you
+/// you got it wrong.
+pub fn envForThisThread(vm: JavaVM) ?JNIEnv {
+    const get: *const fn (JavaVM, *?*anyopaque, jint) callconv(.c) jint =
+        @ptrCast(vm.*.GetEnv orelse return null);
+
+    var env: ?*anyopaque = null;
+    if (get(vm, &env, JNI_VERSION_1_6) != JNI_OK) return null;
+    return @ptrCast(@alignCast(env orelse return null));
+}
+
+/// Bind native implementations to a Java class's `external`/`native` methods.
+///
+/// The alternative is exporting a symbol named
+/// `Java_<package>_<class>_<method>`, which the JVM finds by mangling. That
+/// cannot work here: craft templates the package name per app, so a mangled
+/// export would bind for exactly one package and silently fail to resolve for
+/// every other — an `UnsatisfiedLinkError` at first call, long after build.
+/// Registering by name at load time is independent of the package.
+pub fn registerNatives(
+    env: JNIEnv,
+    cls: jclass,
+    methods: []const JNINativeMethod,
+) JniError!void {
+    const j = Jni.init(env);
+    const register: *const fn (JNIEnv, jclass, [*]const JNINativeMethod, jint) callconv(.c) jint =
+        @ptrCast(env.*.RegisterNatives orelse return JniError.NotFound);
+
+    if (register(env, cls, methods.ptr, @intCast(methods.len)) != JNI_OK) {
+        try j.check();
+        return JniError.NotFound;
+    }
 }
 
 // =============================================================================
@@ -764,12 +906,15 @@ test "the transcribed table puts every member at the index the header gives it" 
     try testing.expectEqual(@as(usize, 167), jniIndexOf("NewStringUTF"));
     try testing.expectEqual(@as(usize, 169), jniIndexOf("GetStringUTFChars"));
     try testing.expectEqual(@as(usize, 170), jniIndexOf("ReleaseStringUTFChars"));
+    try testing.expectEqual(@as(usize, 171), jniIndexOf("GetArrayLength"));
+    try testing.expectEqual(@as(usize, 199), jniIndexOf("GetBooleanArrayRegion"));
+    try testing.expectEqual(@as(usize, 215), jniIndexOf("RegisterNatives"));
 
-    // And the table is exactly as long as it claims — 171 entries, cut after
-    // ReleaseStringUTFChars. A member appended without a reason would make the
+    // And the table is exactly as long as it claims — 216 entries, cut after
+    // RegisterNatives. A member appended without a reason would make the
     // truncation comment a lie.
     try testing.expectEqual(
-        @as(usize, 171 * @sizeOf(JniFn)),
+        @as(usize, 216 * @sizeOf(JniFn)),
         @sizeOf(JNINativeInterface),
     );
 }


### PR DESCRIPTION
`getDeviceInfo` landed in #137 with no caller. This is the wiring — and most of it is about one problem.

## The package is templated, so nothing can name the class

`CraftBridge.kt.template` opens with `package {{PACKAGE_NAME}}`, defaulting to `com.craft.<appname>`. The class a prebuilt library must bind to is therefore named when the *app* is generated, not when the *library* is built. That rules out both usual answers:

- **Exporting `Java_<package>_<class>_<method>`** mangles the package into the symbol. It would resolve for exactly one app and raise `UnsatisfiedLinkError` on first call for every other — at runtime, in the app, long after a build that looked fine.
- **`FindClass` with a hardcoded name in `JNI_OnLoad`** has the same problem one level down.

So the natives bind to **`com.craft.runtime.CraftNative`**, a small holder whose package is fixed and which the generator deliberately writes *outside* `packagePath`. The templated `CraftBridge` reaches it by import. One extra class buys a `libcraft.so` that is byte-identical for every app.

A test asserts the holder lands at that path, contains no substitution marker, doesn't mention the app's package, and that the generated bridge actually imports and calls it.

## Not `@JvmStatic`, deliberately

In a Kotlin `object`, `@JvmStatic` generates a static bridge *alongside* the instance method, and which one carries the `native` flag is a compiler detail. `RegisterNatives` binds one specific method — and a static native takes `(JNIEnv*, jclass)` where an instance native takes `(JNIEnv*, jobject)`. Guessing wrong is a signature mismatch at load. Ordinary instance methods on the singleton remove the question.

## Three things the build needed

| | |
| --- | --- |
| **A shared library** | The existing Android artifacts are `.linkage = .static`, and a `.a` is not loadable at runtime at all — a static build of this would produce something no Kotlin could ever call. |
| **No libc** | A static Android library links nothing and builds anyway; a shared one must resolve its symbols, and **Zig cannot provide bionic**. `link_libc = true` here means the whole library needs the NDK to build. Standing free of it keeps this buildable with nothing but Zig. |
| **An arena per call** | `c_allocator` was the only thing pulling libc in. The reply is a dozen small strings that all die the moment `NewStringUTF` has copied them into the JVM's heap — exactly the lifetime an arena models. |

Verified locally, both ABIs, no NDK:

```
zig-out/android/arm64-v8a/libcraft.so
zig-out/android/x86_64/libcraft.so
000000000017c5ac T JNI_OnLoad
```

## Failure is never fatal, at three levels

An app built without the Zig runtime in `jniLibs` is the **shim-only configuration, not an error**:

1. `System.loadLibrary` throwing is caught in the holder's initialiser. An `UnsatisfiedLinkError` escaping a static initialiser takes the whole class down and turns "no native runtime" into a crash on the first bridge call.
2. A `JNI_OnLoad` that can't find the holder logs and **still returns 1.6** — returning an error version stops the library loading entirely.
3. An unbound `external fun` throws at the *call*, not at load, so the holder catches there too.

Every path lands on the same answer: `null`, and `CraftBridge` runs its own Kotlin. Same hand-back `ios_dispatch.hostServesItself` performs, which is what makes this migratable one action at a time.

## One JNI sharp edge, recorded

`FindClass` is called in `JNI_OnLoad` and only there. It runs on the thread that called `loadLibrary`, which carries the app's class loader — the same call from a thread the JVM did not create resolves against the *system* loader and would not find the holder at all. That's why registration happens at load rather than lazily on first use.

`zig build test:android` 56/56 · `bun test` (android) 10/10 · both `.so`s build · pickier clean.
