### PR TITLE
test(bridge): the other direction — what window.craft promises

### DIFF
--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -411,6 +411,28 @@ pub fn build(b: *std.Build) void {
     // pointers, so the tests build one out of Zig functions and run anywhere —
     // no JVM, no emulator, no NDK. That is the whole reason the layer is shaped
     // the way it is.
+    // The page surface, across both bridges. Not folded into the iOS
+    // conformance gate: it embeds three files and is about what `window.craft`
+    // offers rather than about iOS, and the iOS gate is already the largest
+    // test in the tree.
+    const bridge_surface_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("test/bridge_surface_test.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    bridge_surface_tests.root_module.addAnonymousImport("CraftApp.swift", .{
+        .root_source_file = b.path("../ios/templates/CraftApp.swift"),
+    });
+    bridge_surface_tests.root_module.addAnonymousImport("CraftBridge.kt", .{
+        .root_source_file = b.path("../android/templates/CraftBridge.kt.template"),
+    });
+    bridge_surface_tests.root_module.addAnonymousImport("craft.d.ts", .{
+        .root_source_file = b.path("../typescript/types/craft.d.ts"),
+    });
+    const run_bridge_surface_tests = b.addRunArtifact(bridge_surface_tests);
+
     const jni_tests = b.addTest(.{
         .root_module = b.createModule(.{
             .root_source_file = b.path("src/jni_runtime.zig"),
@@ -1574,6 +1596,7 @@ pub fn build(b: *std.Build) void {
     }
     test_step.dependOn(&run_ios_conformance_tests.step);
     test_step.dependOn(&run_jni_tests.step);
+    test_step.dependOn(&run_bridge_surface_tests.step);
     test_step.dependOn(&run_android_bridge_tests.step);
     test_step.dependOn(&run_menubar_tests.step);
     test_step.dependOn(&run_components_tests.step);
@@ -1660,6 +1683,7 @@ pub fn build(b: *std.Build) void {
         test_ios_step.dependOn(&run_ios_module_tests.step);
     }
     test_ios_step.dependOn(&run_ios_conformance_tests.step);
+    test_ios_step.dependOn(&run_bridge_surface_tests.step);
 
     const test_menubar_step = b.step("test:menubar", "Run Menubar tests");
     test_menubar_step.dependOn(&run_menubar_tests.step);
@@ -2300,6 +2324,7 @@ pub fn build(b: *std.Build) void {
     // second one: `jni_runtime.zig` is the only way anything here reaches Java,
     // so a run that skipped it would not be an Android test run.
     test_android_step.dependOn(&run_jni_tests.step);
+    test_android_step.dependOn(&run_bridge_surface_tests.step);
     test_android_step.dependOn(&run_android_bridge_tests.step);
 
     // Add Android tests to the main test step

--- a/packages/zig/test/bridge_surface_test.zig
+++ b/packages/zig/test/bridge_surface_test.zig
@@ -1,0 +1,195 @@
+//! What `window.craft` promises, and what each bridge actually puts on it.
+//!
+//! `ios_conformance_test.zig` checks one direction and says so: every action
+//! the injected JavaScript can *post* is one the dispatcher handles. That was
+//! written for the `ota*` bug — five methods whose promises could never settle.
+//!
+//! The reverse has never been checked, and it is where the surface has drifted
+//! furthest. `craft.d.ts` declares `window.craft` as `CraftBridge`, an
+//! interface of 78 direct methods; 33 of them are not on the object iOS
+//! injects and 17 are on neither platform's. They type-check and throw
+//! `TypeError`.
+//!
+//! ## What this is not claiming
+//!
+//! The *actions* work. Both bridges expose a generic escape hatch —
+//! `craft._invoke(action, payload)` on iOS (`CraftApp.swift:2543`) and
+//! `craft.invoke('namespace.action', params)` in `craft-bridge.js` — and the
+//! dispatcher arms behind these names are implemented, several of them in Zig.
+//! So the gap is a missing *named method* and a declaration promising one, not
+//! a missing capability. Worth stating because "unreachable" was the first
+//! reading and it was wrong.
+//!
+//! ## Ratchets rather than a table of reasons
+//!
+//! The unimplemented names get counts, not rows. A row here would have to
+//! carry a reason, and there is no honest reason to write for most of them:
+//! they are a backlog nobody has worked through, not a set of decisions —
+//! and `ios_conformance_test.zig` already records why demanding a reason for
+//! that state "would only invite an invented reason". The failure message
+//! names every offender, so the count losing detail costs nothing.
+
+const std = @import("std");
+const testing = std.testing;
+
+const ios_spec = @embedFile("CraftApp.swift");
+const android_spec = @embedFile("CraftBridge.kt");
+const sdk_types = @embedFile("craft.d.ts");
+
+/// How many `CraftBridge` methods iOS's injected object does not define.
+///
+/// A ratchet in the shape `max_not_yet_migrated` already uses: it may only go
+/// down. Adding a declaration without the method fails here, which is the
+/// conversation this constant exists to force.
+const max_absent_from_ios: usize = 33;
+
+/// The same, for methods on neither bridge. A subset of the above by
+/// construction, and the worse half: nothing an app runs on provides them.
+const max_absent_from_both: usize = 17;
+
+/// The `window.craft = { … }` object literal, brace-balanced.
+///
+/// Both bridges build one, which is what makes a single check meaningful:
+/// Android reaches native through `CraftAndroid.<method>()` and iOS through
+/// `postMessage`, but the object a page writes against is the same idea on
+/// both, and `craft.d.ts` describes exactly one of them.
+fn craftObject(source: []const u8) ?[]const u8 {
+    const marker = "window.craft = {";
+    const at = std.mem.indexOf(u8, source, marker) orelse return null;
+    var depth: usize = 0;
+    var i = at + marker.len - 1;
+    while (i < source.len) : (i += 1) {
+        switch (source[i]) {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if (depth == 0) return source[at .. i + 1];
+            },
+            else => {},
+        }
+    }
+    return null;
+}
+
+/// Is `name` defined as a function on this object, at any nesting depth?
+///
+/// Depth is deliberately ignored. `craft.d.ts` declares these as direct
+/// methods, so a namespaced implementation is still a mismatch with the type —
+/// but it is a *different* mismatch from nothing existing at all, and calling
+/// the second one "missing" while quietly passing the first would hide the
+/// worse case behind the milder one.
+fn definesMethod(object: []const u8, name: []const u8) bool {
+    var search: usize = 0;
+    while (std.mem.indexOfPos(u8, object, search, name)) |at| {
+        search = at + 1;
+
+        // A whole word, not a suffix: `stopScan` must not match `startScan`.
+        if (at > 0) {
+            const before = object[at - 1];
+            if (std.ascii.isAlphanumeric(before) or before == '_') continue;
+        }
+
+        var i = at + name.len;
+        while (i < object.len and (object[i] == ' ' or object[i] == '\n')) : (i += 1) {}
+        if (i >= object.len or object[i] != ':') continue;
+
+        i += 1;
+        while (i < object.len and (object[i] == ' ' or object[i] == '\n')) : (i += 1) {}
+        if (std.mem.startsWith(u8, object[i..], "function")) return true;
+    }
+    return false;
+}
+
+/// The method names declared directly on `interface CraftBridge`.
+///
+/// Two-space indent is the discriminator: it is what separates a method on the
+/// interface itself from one nested inside a namespace object, and only the
+/// former is a promise about `window.craft.<name>`.
+fn collectDeclaredMethods(allocator: std.mem.Allocator) !std.ArrayListUnmanaged([]const u8) {
+    var out: std.ArrayListUnmanaged([]const u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    const start = std.mem.indexOf(u8, sdk_types, "export interface CraftBridge {") orelse
+        return error.CraftBridgeInterfaceNotFound;
+    const rest = sdk_types[start..];
+    const end = std.mem.indexOf(u8, rest, "\n}") orelse return error.CraftBridgeInterfaceNotFound;
+
+    var it = std.mem.splitScalar(u8, rest[0..end], '\n');
+    while (it.next()) |line| {
+        if (!std.mem.startsWith(u8, line, "  ")) continue;
+        if (std.mem.startsWith(u8, line, "   ")) continue;
+
+        const body = line[2..];
+        var i: usize = 0;
+        while (i < body.len and (std.ascii.isAlphanumeric(body[i]) or body[i] == '_')) : (i += 1) {}
+        if (i == 0 or i >= body.len or body[i] != '(') continue;
+        try out.append(allocator, body[0..i]);
+    }
+    return out;
+}
+
+test "the surface scans find both objects and the interface" {
+    // Non-vacuity, and the floors are the point: every assertion below counts
+    // absences, so a scan that found nothing would report a perfect surface.
+    const ios = craftObject(ios_spec) orelse return error.IosCraftObjectNotFound;
+    const android = craftObject(android_spec) orelse return error.AndroidCraftObjectNotFound;
+    try testing.expect(ios.len > 10_000);
+    try testing.expect(android.len > 10_000);
+
+    var declared = try collectDeclaredMethods(testing.allocator);
+    defer declared.deinit(testing.allocator);
+    try testing.expect(declared.items.len >= 70);
+
+    // And the matcher works in both directions on a name each bridge really
+    // does define — otherwise "absent everywhere" would be the vacuous answer.
+    try testing.expect(definesMethod(ios, "getDeviceInfo"));
+    try testing.expect(definesMethod(android, "getDeviceInfo"));
+    try testing.expect(!definesMethod(ios, "noSuchMethodAnywhere"));
+}
+
+test "every method craft.d.ts declares exists on the bridges that ship it" {
+    // Not `.?` — a broken scan should fail this test with a name, not abort the
+    // whole runner on an unwrap and take the other tests' output with it.
+    const ios = craftObject(ios_spec) orelse return error.IosCraftObjectNotFound;
+    const android = craftObject(android_spec) orelse return error.AndroidCraftObjectNotFound;
+
+    var declared = try collectDeclaredMethods(testing.allocator);
+    defer declared.deinit(testing.allocator);
+
+    var absent_ios: usize = 0;
+    var absent_both: usize = 0;
+
+    for (declared.items) |name| {
+        const on_ios = definesMethod(ios, name);
+        const on_android = definesMethod(android, name);
+        if (on_ios and on_android) continue;
+
+        if (!on_ios) absent_ios += 1;
+        if (!on_ios and !on_android) {
+            absent_both += 1;
+            std.debug.print("  craft.{s}() is declared and exists on neither bridge\n", .{name});
+        } else if (!on_ios) {
+            std.debug.print("  craft.{s}() is declared, exists on Android, TypeError on iOS\n", .{name});
+        } else {
+            std.debug.print("  craft.{s}() is declared, exists on iOS, TypeError on Android\n", .{name});
+        }
+    }
+
+    if (absent_ios > max_absent_from_ios or absent_both > max_absent_from_both) {
+        std.debug.print(
+            "\n{d} declared methods are absent from iOS (allowed {d}), {d} from both (allowed {d}).\n" ++
+                "  A method on `CraftBridge` is a promise that `window.craft.<name>` is callable.\n" ++
+                "  Either implement it on the bridge or stop declaring it.\n",
+            .{ absent_ios, max_absent_from_ios, absent_both, max_absent_from_both },
+        );
+        return error.DeclaredMethodMissingFromBridge;
+    }
+
+    // The ratchet is only a ratchet if it is tightened.
+    if (absent_ios < max_absent_from_ios or absent_both < max_absent_from_both) {
+        std.debug.print(
+            "note: {d} absent from iOS and {d} from both; the ratchets are {d}/{d} and can be lowered.\n",
+            .{ absent_ios, absent_both, max_absent_from_ios, max_absent_from_both },
+        );
+    }
+}


### PR DESCRIPTION
Closes the direction `ios_conformance_test.zig` was explicitly never checking. Reports #140.

## The check that existed, and the half it left out

> **every action the page can call is one the spec handles** — The `ota*` check. Five methods in the injected JavaScript posted actions the switch never handled…

That is JS → dispatcher. The reverse — a **declared method with no implementation** — has never been checked, and it is where the surface has drifted furthest.

`craft.d.ts` declares `window.craft` as `CraftBridge`, an interface of **78 direct methods**:

- **33** are not on the object iOS injects
- **17** are on neither platform's

They type-check and throw `TypeError`. And 16 of them work on Android, so the same source compiles and runs on one platform and not the other:

```ts
const tag = await window.craft.scanNFC()   // fine on Android, TypeError on iOS
```

## What this does not claim

The **actions work**. Both bridges expose a generic escape hatch — `craft._invoke(action, payload)` on iOS (`CraftApp.swift:2543`), `craft.invoke('namespace.action', params)` in `craft-bridge.js` — and the dispatcher arms behind these names are implemented, several of them now in Zig.

So the gap is a missing *named method* and a declaration promising one, not a missing capability. Worth stating plainly, because **"33 unreachable actions" was my first reading and it was wrong** — I went looking for the hatch before filing, and it exists.

## Already found once, by hand

`bridge_mobile_motion.zig` documents exactly this for a single action:

> Worth knowing while reading any of that: **`window.craft.startMotionUpdates` does not exist in the injected iOS JavaScript.** … That is a second pre-existing bug

One module noticed, wrote it into its own header, and nothing else could see it. Same shape as `craftShortcut` in #127 and the twelve gate claims in #132. It is thirty-three, not one.

## Ratchets, not a table of reasons

A table row would have to carry a reason, and there is no honest reason to write for most of these — they are a backlog nobody has worked through, not decisions. `ios_conformance_test.zig` already records why demanding one for that state "would only invite an invented reason". The failure message names every offender, so the count loses nothing:

```
craft.scanNFC() is declared, exists on Android, TypeError on iOS
craft.getContacts() is declared and exists on neither bridge
...
33 declared methods are absent from iOS (allowed 33), 17 from both (allowed 17).
  A method on `CraftBridge` is a promise that `window.craft.<name>` is callable.
  Either implement it on the bridge or stop declaring it.
```

## One judgment call

Nesting depth is **ignored** when looking for a method. `craft.d.ts` declares these as direct methods, so a namespaced implementation (`craft.contacts.getAll`) is still a mismatch with the type — but it's a *different* mismatch from nothing existing at all, and treating the second as "missing" while quietly passing the first would hide the worse case behind the milder one.

## Verified

| mutation | result |
| --- | --- |
| SDK declares a method on neither bridge | `DeclaredMethodMissingFromBridge` |
| ratchet lowered 33 → 32 | fails — the count really is 33 |
| the `window.craft = {` scan broken | both non-vacuity floors, and cleanly (`orelse return`, not `.?`, so a broken scan names itself instead of aborting the runner) |

Its own gate rather than folded into the iOS one — it embeds three files and is about `window.craft`, not about iOS. Joins `test`, `test:ios` and `test:android`, since both platforms owe this contract.

`zig build test:ios` 21/21 + surface gate · `test:android` 9/9 steps.
