### PR TITLE
test(android): the ratchet, and the two seams JNI leaves unchecked

### DIFF
--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -411,6 +411,31 @@ pub fn build(b: *std.Build) void {
     // pointers, so the tests build one out of Zig functions and run anywhere —
     // no JVM, no emulator, no NDK. That is the whole reason the layer is shaped
     // the way it is.
+    // The Android action ratchet, and the JNI binding contract. Separate from
+    // the iOS gate for the obvious reason and from the surface gate for a
+    // subtler one: this is about what Zig owes Kotlin, not about what either
+    // owes the page.
+    const android_conformance_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("test/android_conformance_test.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    android_conformance_tests.root_module.addAnonymousImport("CraftBridge.kt", .{
+        .root_source_file = b.path("../android/templates/CraftBridge.kt.template"),
+    });
+    android_conformance_tests.root_module.addAnonymousImport("CraftNative.kt", .{
+        .root_source_file = b.path("../android/templates/CraftNative.kt.template"),
+    });
+    android_conformance_tests.root_module.addAnonymousImport("src/android_dispatch.zig", .{
+        .root_source_file = b.path("src/android_dispatch.zig"),
+    });
+    android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_device.zig", .{
+        .root_source_file = b.path("src/bridge_android_device.zig"),
+    });
+    const run_android_conformance_tests = b.addRunArtifact(android_conformance_tests);
+
     // The page surface, across both bridges. Not folded into the iOS
     // conformance gate: it embeds three files and is about what `window.craft`
     // offers rather than about iOS, and the iOS gate is already the largest
@@ -1597,6 +1622,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_ios_conformance_tests.step);
     test_step.dependOn(&run_jni_tests.step);
     test_step.dependOn(&run_bridge_surface_tests.step);
+    test_step.dependOn(&run_android_conformance_tests.step);
     test_step.dependOn(&run_android_bridge_tests.step);
     test_step.dependOn(&run_menubar_tests.step);
     test_step.dependOn(&run_components_tests.step);
@@ -2325,6 +2351,7 @@ pub fn build(b: *std.Build) void {
     // so a run that skipped it would not be an Android test run.
     test_android_step.dependOn(&run_jni_tests.step);
     test_android_step.dependOn(&run_bridge_surface_tests.step);
+    test_android_step.dependOn(&run_android_conformance_tests.step);
     test_android_step.dependOn(&run_android_bridge_tests.step);
 
     // Add Android tests to the main test step

--- a/packages/zig/test/android_conformance_test.zig
+++ b/packages/zig/test/android_conformance_test.zig
@@ -1,0 +1,333 @@
+//! What Android owes the page, and who currently owes it.
+//!
+//! The counterpart to `ios_conformance_test.zig`, and it starts where that one
+//! started: `CraftBridge.kt` is the specification, its `@JavascriptInterface`
+//! methods are the list of actions a craft Android app answers today, and Zig
+//! has to end up answering all of them. This is what stops one being dropped
+//! on the way across.
+//!
+//! iOS reached this file's job with 105 actions unmigrated and is at 13.
+//! Android is at 102 of 103. The ratchet exists now rather than later for the
+//! reason the iOS one earned: the second migration is where a name quietly
+//! stops matching, and by then nothing remembers what the first one agreed to.
+//!
+//! ## Two seams, not one
+//!
+//! iOS has a single contract to check — an action string that must appear on
+//! both sides. Android has two, because the call arrives through JNI:
+//!
+//!   1. **the action**, `@JavascriptInterface fun getDeviceInfo()` against the
+//!      `A` block of whichever Zig module serves it;
+//!   2. **the binding**, the `name` in `android_dispatch.natives` against the
+//!      `external fun` that `CraftNative.kt` declares.
+//!
+//! The second has no compiler behind it at all. `RegisterNatives` matches by
+//! string at load, so renaming one side and not the other fails at
+//! `System.loadLibrary` — in the app, on a device, with a message that names
+//! the method and nothing about where the other half went.
+
+const std = @import("std");
+const testing = std.testing;
+
+/// Embedded rather than read from disk, so the test is hermetic and reads
+/// exactly the bytes the build saw.
+const android_spec = @embedFile("CraftBridge.kt");
+const native_holder = @embedFile("CraftNative.kt");
+const dispatch_source = @embedFile("src/android_dispatch.zig");
+
+/// Every Zig module serving part of the Android bridge. A module migrating
+/// actions adds itself here — and the ratchet is what forces that, because
+/// migrated actions the scan cannot see read as "still owed".
+const zig_sources = [_][]const u8{
+    @embedFile("src/bridge_android_device.zig"),
+};
+
+/// How many spec actions Zig does not serve yet.
+///
+/// A ratchet: the number may only go down, and lowering it is what a migration
+/// costs. If it ever needs raising, something has left Zig without leaving the
+/// Kotlin, and that is the conversation this constant exists to force.
+///
+/// History: 103 at the seam; 102 with getDeviceInfo.
+const max_not_yet_migrated: usize = 102;
+
+/// Every `@JavascriptInterface fun <name>(` in the Kotlin bridge.
+///
+/// Anchored on the annotation, not on `fun`, because `CraftBridge.kt` has
+/// plenty of private helpers that are not page-callable — `sendEvent`,
+/// `taskReply`, the permission plumbing. Only an annotated method is part of
+/// the contract, which is the same reason the iOS scan is bounded to the
+/// dispatcher rather than the whole file.
+fn collectSpecActions(allocator: std.mem.Allocator) !std.StringHashMap(void) {
+    var set = std.StringHashMap(void).init(allocator);
+    errdefer set.deinit();
+
+    const marker = "@JavascriptInterface";
+    var search: usize = 0;
+    while (std.mem.indexOfPos(u8, android_spec, search, marker)) |at| {
+        search = at + marker.len;
+
+        const fun_at = std.mem.indexOfPos(u8, android_spec, search, "fun ") orelse break;
+        // Only the declaration that immediately follows: an annotation whose
+        // next `fun` is fifty lines away means the scan has lost its place.
+        if (fun_at - search > 200) continue;
+
+        const name_start = fun_at + "fun ".len;
+        var name_end = name_start;
+        while (name_end < android_spec.len and
+            (std.ascii.isAlphanumeric(android_spec[name_end]) or android_spec[name_end] == '_')) : (name_end += 1)
+        {}
+        if (name_end == name_start) continue;
+        try set.put(android_spec[name_start..name_end], {});
+        search = name_end;
+    }
+    return set;
+}
+
+/// Every action name declared in the `A` blocks of the Android modules.
+fn collectZigActions(allocator: std.mem.Allocator) !std.StringHashMap(void) {
+    var set = std.StringHashMap(void).init(allocator);
+    errdefer set.deinit();
+
+    for (zig_sources) |source| {
+        const block_start = std.mem.indexOf(u8, source, "pub const A = struct {") orelse continue;
+        var it = std.mem.splitScalar(u8, source[block_start..], '\n');
+        _ = it.next();
+        while (it.next()) |line| {
+            const trimmed = std.mem.trim(u8, line, " \t\r");
+            if (std.mem.eql(u8, trimmed, "};")) break;
+            const open = std.mem.indexOfScalar(u8, trimmed, '"') orelse continue;
+            const close = std.mem.indexOfScalarPos(u8, trimmed, open + 1, '"') orelse continue;
+
+            const name = trimmed[open + 1 .. close];
+            if (set.contains(name)) {
+                std.debug.print(
+                    "action '{s}' is declared by more than one Android module.\n" ++
+                        "  Dispatch order would silently pick one.\n",
+                    .{name},
+                );
+                return error.ActionDeclaredTwice;
+            }
+            try set.put(name, {});
+        }
+    }
+    return set;
+}
+
+test "the spec scan finds the bridge, and finds methods in it" {
+    // Non-vacuity, first. Every assertion below is a membership check, and a
+    // scan that silently matched nothing would satisfy all of them.
+    var spec = try collectSpecActions(testing.allocator);
+    defer spec.deinit();
+    try testing.expect(spec.count() >= 100);
+
+    // And it found real ones rather than fragments.
+    try testing.expect(spec.contains("getDeviceInfo"));
+    try testing.expect(spec.contains("clipboardRead"));
+    try testing.expect(spec.contains("vibrate"));
+}
+
+test "every action Zig declares is one the Kotlin bridge actually has" {
+    // The typo guard. `getDeviceinfo` for `getDeviceInfo` compiles on both
+    // sides and is simply never called — the page keeps reaching the Kotlin,
+    // and the Zig implementation sits there looking migrated.
+    var spec = try collectSpecActions(testing.allocator);
+    defer spec.deinit();
+
+    var zig = try collectZigActions(testing.allocator);
+    defer zig.deinit();
+    try testing.expect(zig.count() >= 1);
+
+    var it = zig.keyIterator();
+    while (it.next()) |name| {
+        if (!spec.contains(name.*)) {
+            std.debug.print(
+                "an Android module declares '{s}', which CraftBridge.kt does not expose.\n" ++
+                    "  Either it is misspelled, or it is a surface no page can reach.\n",
+                .{name.*},
+            );
+            return error.ZigServesAnActionTheSpecDoesNotHave;
+        }
+    }
+}
+
+test "nothing has been dropped on the way from Kotlin to Zig" {
+    // The migration guard. Without it, moving an action across is
+    // indistinguishable from losing it: both leave a page calling something
+    // nothing answers.
+    var spec = try collectSpecActions(testing.allocator);
+    defer spec.deinit();
+
+    var zig = try collectZigActions(testing.allocator);
+    defer zig.deinit();
+
+    var not_yet: usize = 0;
+    var it = spec.keyIterator();
+    while (it.next()) |name| {
+        if (!zig.contains(name.*)) not_yet += 1;
+    }
+
+    if (not_yet > max_not_yet_migrated) {
+        std.debug.print(
+            "{d} spec actions are not served by Zig, but the ratchet allows {d}.\n" ++
+                "  An action has left Zig without leaving the Kotlin.\n",
+            .{ not_yet, max_not_yet_migrated },
+        );
+        return error.MigrationWentBackwards;
+    }
+
+    if (not_yet < max_not_yet_migrated) {
+        std.debug.print(
+            "note: {d} spec actions remain unmigrated; max_not_yet_migrated is {d} and can be lowered.\n",
+            .{ not_yet, max_not_yet_migrated },
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The binding
+//
+// `RegisterNatives` matches by string at load time. Nothing checks that the
+// name Zig registers is the name Kotlin declared — not the Zig compiler, which
+// sees a string literal, and not the Kotlin compiler, which sees an `external
+// fun` it assumes someone will bind. The two agree until one is renamed, and
+// then `System.loadLibrary` fails on a device with a message that names the
+// method and says nothing about where its other half went.
+//
+// So the two lists are read out of the two files and compared here, on a host,
+// at build time.
+// ---------------------------------------------------------------------------
+
+/// The `name` field of every entry in `android_dispatch.natives`.
+fn collectRegisteredNatives(allocator: std.mem.Allocator) !std.StringHashMap(void) {
+    var set = std.StringHashMap(void).init(allocator);
+    errdefer set.deinit();
+
+    const table_start = std.mem.indexOf(u8, dispatch_source, "const natives = [_]jni.JNINativeMethod{") orelse
+        return error.NativesTableNotFound;
+    const table_end = std.mem.indexOfPos(u8, dispatch_source, table_start, "\n};") orelse
+        return error.NativesTableNotFound;
+    const table = dispatch_source[table_start..table_end];
+
+    const needle = ".name = \"";
+    var search: usize = 0;
+    while (std.mem.indexOfPos(u8, table, search, needle)) |at| {
+        const start = at + needle.len;
+        const end = std.mem.indexOfScalarPos(u8, table, start, '"') orelse break;
+        try set.put(table[start..end], {});
+        search = end;
+    }
+    return set;
+}
+
+/// Every `external fun <name>(` in the Kotlin holder.
+fn collectDeclaredNatives(allocator: std.mem.Allocator) !std.StringHashMap(void) {
+    var set = std.StringHashMap(void).init(allocator);
+    errdefer set.deinit();
+
+    const needle = "external fun ";
+    var search: usize = 0;
+    while (std.mem.indexOfPos(u8, native_holder, search, needle)) |at| {
+        const start = at + needle.len;
+        var end = start;
+        while (end < native_holder.len and
+            (std.ascii.isAlphanumeric(native_holder[end]) or native_holder[end] == '_')) : (end += 1)
+        {}
+        search = end;
+        if (end > start) try set.put(native_holder[start..end], {});
+    }
+    return set;
+}
+
+test "every native Zig registers is one the Kotlin holder declares" {
+    // This direction fails the library load: RegisterNatives is given a name
+    // the class does not have, refuses the whole batch, and JNI_OnLoad logs
+    // that every action stayed on the shim.
+    var registered = try collectRegisteredNatives(testing.allocator);
+    defer registered.deinit();
+    var declared = try collectDeclaredNatives(testing.allocator);
+    defer declared.deinit();
+
+    // Non-vacuity: two scans, either of which could stop matching and leave
+    // this comparing empty sets.
+    try testing.expect(registered.count() >= 1);
+    try testing.expect(declared.count() >= 1);
+
+    var it = registered.keyIterator();
+    while (it.next()) |name| {
+        if (!declared.contains(name.*)) {
+            std.debug.print(
+                "android_dispatch registers '{s}', which CraftNative.kt does not declare.\n" ++
+                    "  RegisterNatives refuses the batch, and every action stays on the shim.\n",
+                .{name.*},
+            );
+            return error.RegisteredNativeNotDeclared;
+        }
+    }
+}
+
+test "every native the Kotlin holder declares is one Zig registers" {
+    // The quieter direction, and the worse one. An `external fun` nobody binds
+    // loads fine and throws UnsatisfiedLinkError at the call — so it survives
+    // the app starting, and surfaces when a page first reaches the feature.
+    var registered = try collectRegisteredNatives(testing.allocator);
+    defer registered.deinit();
+    var declared = try collectDeclaredNatives(testing.allocator);
+    defer declared.deinit();
+
+    var it = declared.keyIterator();
+    while (it.next()) |name| {
+        if (!registered.contains(name.*)) {
+            std.debug.print(
+                "CraftNative.kt declares '{s}', which android_dispatch never registers.\n" ++
+                    "  It loads, and throws UnsatisfiedLinkError the first time a page calls it.\n",
+                .{name.*},
+            );
+            return error.DeclaredNativeNotRegistered;
+        }
+    }
+}
+
+test "the holder's package is the one JNI_OnLoad looks for" {
+    // The third string with no compiler behind it. `FindClass` takes a binary
+    // name with slashes; the Kotlin declares a package with dots. They are
+    // written in two files, in two languages, and a prebuilt library that
+    // cannot find its holder binds nothing at all.
+    const decl = "package ";
+    const at = std.mem.indexOf(u8, native_holder, decl) orelse return error.NoPackageDeclaration;
+    const start = at + decl.len;
+    var end = start;
+    while (end < native_holder.len and native_holder[end] != '\n' and native_holder[end] != '\r') : (end += 1) {}
+    const package = std.mem.trim(u8, native_holder[start..end], " \t\r");
+
+    const holder_at = std.mem.indexOf(u8, dispatch_source, "pub const holder_class = \"") orelse
+        return error.NoHolderClassConstant;
+    const h_start = holder_at + "pub const holder_class = \"".len;
+    const h_end = std.mem.indexOfScalarPos(u8, dispatch_source, h_start, '"') orelse
+        return error.NoHolderClassConstant;
+    const holder = dispatch_source[h_start..h_end];
+
+    // `com.craft.runtime` + `CraftNative` must spell `com/craft/runtime/CraftNative`.
+    var buf: [128]u8 = undefined;
+    var written: usize = 0;
+    for (package) |c| {
+        buf[written] = if (c == '.') '/' else c;
+        written += 1;
+    }
+    const expected = try std.fmt.bufPrint(buf[written..], "/CraftNative", .{});
+    const full = buf[0 .. written + expected.len];
+
+    if (!std.mem.eql(u8, full, holder)) {
+        std.debug.print(
+            "CraftNative.kt is in package '{s}', so JNI_OnLoad must look for '{s}'.\n" ++
+                "  android_dispatch.holder_class says '{s}'.\n",
+            .{ package, full, holder },
+        );
+        return error.HolderClassDoesNotMatchPackage;
+    }
+
+    // And it stays untemplated: a substitution marker here would make the
+    // prebuilt library app-specific, which is the whole reason this class is
+    // separate from CraftBridge.
+    try testing.expect(std.mem.indexOf(u8, package, "{") == null);
+}


### PR DESCRIPTION
`CraftBridge.kt` exposes **103 `@JavascriptInterface` methods** and Zig serves **one**.

iOS reached this file's job with 105 unmigrated and is at 13. The ratchet exists now rather than later for the reason the iOS one earned: the second migration is where a name quietly stops matching, and by then nothing remembers what the first one agreed to.

## Android has two contracts where iOS has one

The call arrives through JNI, so there are two strings that must agree, not one.

**1. The action** — `@JavascriptInterface fun getDeviceInfo()` against the `A` block of whichever module serves it. Same shape as the iOS scan, anchored on the *annotation* rather than on `fun`: `CraftBridge.kt` is full of private helpers (`sendEvent`, permission plumbing) that aren't page-callable, which is the same reason the iOS scan is bounded to the dispatcher rather than the whole file.

**2. The binding** — the `name` in `android_dispatch.natives` against the `external fun` that `CraftNative.kt` declares.

That second one **has no compiler behind it at all**. `RegisterNatives` matches by string at load time: the Zig compiler sees a string literal, the Kotlin compiler sees an `external fun` it assumes someone will bind, and the two agree right up until one is renamed.

Both directions are checked, and they fail differently:

| | what happens |
| --- | --- |
| Zig registers a name the class lacks | `RegisterNatives` refuses the **whole batch** at load — every action drops to the shim |
| Kotlin declares a name nobody binds | Loads fine; throws `UnsatisfiedLinkError` the **first time a page reaches the feature** |

The second is quieter and worse: it survives the app starting.

## A third string, also uncompiled

`FindClass` takes a binary name with slashes (`com/craft/runtime/CraftNative`); `CraftNative.kt` declares a package with dots. Two files, two languages, and a prebuilt library that can't find its holder binds nothing at all. The package is derived from the Kotlin and compared against `holder_class` — and asserted to stay untemplated, since a substitution marker there would make the shipped library app-specific, which is the entire reason the holder is a separate class from `CraftBridge`.

## Verified

| mutation | result |
| --- | --- |
| Zig action typo (`getDeviceinfo`) | `ZigServesAnActionTheSpecDoesNotHave` |
| registered native renamed | `RegisteredNativeNotDeclared` |
| `holder_class` disagrees with the Kotlin package | `HolderClassDoesNotMatchPackage` |
| ratchet lowered 102 → 101 | `MigrationWentBackwards` — the count really is 102 |
| `@JavascriptInterface` scan broken | the non-vacuity floor |

The reverse binding direction is covered too (`DeclaredNativeNotRegistered`), though it can't be mutation-tested from the Zig side alone without editing the Kotlin template.

`zig build test:android` → **80/80**, 11/11 steps.

## Next

Tier 0 — `clipboardRead`/`clipboardWrite`, `log`, `getMemoryUsage`, `vibrate`, `setBadge`, `openURL`. No permissions, no UI, no callbacks; each is a `Build` static or a single instance call, and the ratchet now makes each one lower a number.
