### PR TITLE
feat(android): getMemoryUsage and log — ratchet 102 -> 100

### DIFF
--- a/packages/android/templates/CraftBridge.kt.template
+++ b/packages/android/templates/CraftBridge.kt.template
@@ -1583,6 +1583,7 @@ class CraftBridge(
 
     @JavascriptInterface
     fun log(message: String) {
+        if (CraftNative.log(message)) return
         android.util.Log.d("CraftBridge", message)
     }
 
@@ -3845,6 +3846,8 @@ class CraftBridge(
 
     @JavascriptInterface
     fun getMemoryUsage(): String {
+        CraftNative.getMemoryUsage()?.let { return it }
+
         val runtime = Runtime.getRuntime()
         val usedMemory = runtime.totalMemory() - runtime.freeMemory()
         val maxMemory = runtime.maxMemory()

--- a/packages/android/templates/CraftNative.kt.template
+++ b/packages/android/templates/CraftNative.kt.template
@@ -57,6 +57,8 @@ object CraftNative {
     }
 
     private external fun nativeGetDeviceInfo(activity: Activity): String?
+    private external fun nativeGetMemoryUsage(): String?
+    private external fun nativeLog(message: String): Boolean
 
     /**
      * `getDeviceInfo`, or null to use the Kotlin implementation.
@@ -74,6 +76,33 @@ object CraftNative {
             nativeGetDeviceInfo(activity)
         } catch (e: UnsatisfiedLinkError) {
             null
+        }
+    }
+
+    /** The JVM heap as JSON, or null to use the Kotlin implementation. */
+    fun getMemoryUsage(): String? {
+        if (!isAvailable) return null
+        return try {
+            nativeGetMemoryUsage()
+        } catch (e: UnsatisfiedLinkError) {
+            null
+        }
+    }
+
+    /**
+     * Write a log line, reporting whether it was written.
+     *
+     * The only native here that answers with a boolean rather than a nullable
+     * result, because there is no value to return and "not mine" still has to
+     * be sayable — a void native would leave the caller unable to tell a
+     * written line from a declined one, and it would log twice or not at all.
+     */
+    fun log(message: String): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeLog(message)
+        } catch (e: UnsatisfiedLinkError) {
+            false
         }
     }
 }

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -434,6 +434,9 @@ pub fn build(b: *std.Build) void {
     android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_device.zig", .{
         .root_source_file = b.path("src/bridge_android_device.zig"),
     });
+    android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_system.zig", .{
+        .root_source_file = b.path("src/bridge_android_system.zig"),
+    });
     const run_android_conformance_tests = b.addRunArtifact(android_conformance_tests);
 
     // The page surface, across both bridges. Not folded into the iOS

--- a/packages/zig/src/android_dispatch.zig
+++ b/packages/zig/src/android_dispatch.zig
@@ -37,6 +37,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const jni = @import("jni_runtime.zig");
 const device = @import("bridge_android_device.zig");
+const system = @import("bridge_android_system.zig");
 
 const Jni = jni.Jni;
 
@@ -122,6 +123,20 @@ const natives = [_]jni.JNINativeMethod{
         .signature = "(Landroid/app/Activity;)Ljava/lang/String;",
         .fnPtr = @ptrCast(&nativeGetDeviceInfo),
     },
+    // No Activity parameter: `Runtime` and `Log` are static, so neither of
+    // these needs anything the app hands over. The signature says so, and a
+    // signature that asked for one would fail registration rather than be
+    // quietly ignored.
+    .{
+        .name = "nativeGetMemoryUsage",
+        .signature = "()Ljava/lang/String;",
+        .fnPtr = @ptrCast(&nativeGetMemoryUsage),
+    },
+    .{
+        .name = "nativeLog",
+        .signature = "(Ljava/lang/String;)Z",
+        .fnPtr = @ptrCast(&nativeLog),
+    },
 };
 
 /// How binding went. A value rather than a log line, so every path is
@@ -182,6 +197,49 @@ fn nativeGetDeviceInfo(env: jni.JNIEnv, _: jni.jobject, activity: jni.jobject) c
     @memcpy(owned, json);
 
     return j.newStringUtf(owned.ptr) catch null;
+}
+
+/// `nativeGetMemoryUsage()` — the JVM heap, as JSON.
+fn nativeGetMemoryUsage(env: jni.JNIEnv, _: jni.jobject) callconv(.c) jni.jstring {
+    const j = Jni.init(env);
+
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const usage = system.readMemory(j) catch |err| {
+        std.log.warn("craft: getMemoryUsage fell through to the shim ({s})", .{@errorName(err)});
+        return null;
+    };
+
+    const json = system.renderMemory(allocator, usage) catch return null;
+    const owned = allocator.allocSentinel(u8, json.len, 0) catch return null;
+    @memcpy(owned, json);
+
+    return j.newStringUtf(owned.ptr) catch null;
+}
+
+/// `nativeLog(message)` — returns whether Zig wrote the line.
+///
+/// A boolean rather than void, because "not mine" has to be expressible.
+/// `void` would leave the Kotlin unable to tell a successful native log from a
+/// runtime that declined, and it would log the message twice or not at all.
+fn nativeLog(env: jni.JNIEnv, _: jni.jobject, message: jni.jstring) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const text = j.stringToUtf8(allocator, message) catch return jni.JNI_FALSE;
+    const owned = allocator.allocSentinel(u8, text.len, 0) catch return jni.JNI_FALSE;
+    @memcpy(owned, text);
+
+    system.writeLog(j, owned.ptr) catch |err| {
+        std.log.warn("craft: log fell through to the shim ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+    return jni.JNI_TRUE;
 }
 
 // =============================================================================
@@ -295,7 +353,7 @@ test "the registered natives name methods the Kotlin actually declares" {
     // A descriptor is checked by the JVM at registration, so a wrong one fails
     // at load rather than at call — but only if the *name* matches something.
     // These two strings are the contract with CraftBridge.kt.
-    try testing.expectEqual(@as(usize, 1), natives.len);
+    try testing.expectEqual(@as(usize, 3), natives.len);
     try testing.expectEqualStrings("nativeGetDeviceInfo", std.mem.span(natives[0].name));
 
     // And the class they bind to is the fixed one, not the templated bridge.

--- a/packages/zig/src/bridge_android_system.zig
+++ b/packages/zig/src/bridge_android_system.zig
@@ -1,0 +1,240 @@
+//! The Android actions that need nothing but the JVM: `getMemoryUsage` and
+//! `log`.
+//!
+//! Tier 0 in the sense the iOS migration used: no permission prompt, no UI, no
+//! callback, and — the part specific to Android — **no `Activity`**. Both reach
+//! a static class and stop, so neither depends on anything the app hands over.
+//!
+//! ## `getMemoryUsage` is not the iOS action wearing a different name
+//!
+//! iOS asks the kernel for this process's resident size through `task_info`.
+//! Android asks the *JVM* about its own heap through `java.lang.Runtime`, and
+//! those are different quantities: `Runtime.totalMemory()` is what the managed
+//! heap has reserved, not what the process holds. Every native allocation this
+//! bridge makes is outside it.
+//!
+//! So the two platforms answer with different keys and that is correct rather
+//! than sloppy — iOS emits `usedMB`/`residentSize`/`virtualSize`, Android emits
+//! `usedMB`/`maxMB`/`totalMB`/`usedBytes`/`maxBytes`. Only `usedMB` is shared,
+//! and even that means something different. Making them agree would mean one
+//! of them lying about which number it measured.
+//!
+//! ## The rounding is arithmetic, not formatting
+//!
+//! `Math.round(usedMemory / 1024.0 / 1024.0 * 100) / 100.0` is hundredths of a
+//! megabyte, rounded half up. Done here in integers for the reason
+//! `bridge_mobile_device.zig` gives for the same figure on iOS: the rounding
+//! becomes a property of a function that can be asserted on a host, rather than
+//! of a float format that has to be observed.
+
+const std = @import("std");
+const jni = @import("jni_runtime.zig");
+
+const Jni = jni.Jni;
+
+/// The action names, spelled exactly as `CraftBridge.kt` spells them. The
+/// conformance ratchet matches the two lists by string.
+pub const A = struct {
+    pub const get_memory_usage = "getMemoryUsage";
+    pub const log = "log";
+};
+
+/// What the JVM reports about its own heap.
+pub const MemoryUsage = struct {
+    used_bytes: i64,
+    max_bytes: i64,
+    total_bytes: i64,
+};
+
+/// Bytes as hundredths of a megabyte, rounded half up.
+///
+/// Integer arithmetic so the rounding is assertable. `Math.round` in Java is
+/// `floor(x + 0.5)`, which for a non-negative byte count is the same as adding
+/// half the divisor before dividing — and a byte count is never negative, so
+/// the difference between round-half-up and round-half-away never arises.
+///
+/// The divisor is 1024*1024/100 scaled: hundredths of a MiB means
+/// `bytes * 100 / (1024*1024)`, and the `+ half` is the round.
+pub fn hundredthsOfMebibyte(bytes: i64) i64 {
+    if (bytes <= 0) return 0;
+    const mib: i64 = 1024 * 1024;
+    return @divTrunc(bytes * 100 + @divTrunc(mib, 2), mib);
+}
+
+/// `usedMB` and friends, rendered the way `JSONObject.put(double)` renders
+/// them: a whole number loses its fraction, everything else keeps exactly the
+/// hundredths it has.
+///
+/// Java prints `117.0` for a whole double and Zig's `{d}` prints `117`. That
+/// difference is invisible to `JSON.parse` — both produce the same number — and
+/// chasing it would mean formatting by hand to match a Java quirk no consumer
+/// can observe.
+fn appendMegabytes(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), bytes: i64) !void {
+    const hundredths = hundredthsOfMebibyte(bytes);
+    const fraction = @mod(hundredths, 100);
+
+    try out.print(allocator, "{d}.", .{@divTrunc(hundredths, 100)});
+    // Padded by hand rather than with a width spec. `{d:0>2}` renders `+74`
+    // on this toolchain — a sign, not a zero — which is not a number JSON
+    // accepts, and the reply stops parsing at the dot.
+    if (fraction < 10) try out.append(allocator, '0');
+    try out.print(allocator, "{d}", .{fraction});
+}
+
+/// The reply bytes for `getMemoryUsage`.
+///
+/// Key order follows the Kotlin's `put` order, for the same reason the device
+/// module follows it: a diff against the Kotlin is how this gets reviewed.
+pub fn renderMemory(allocator: std.mem.Allocator, usage: MemoryUsage) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.appendSlice(allocator, "{\"usedMB\":");
+    try appendMegabytes(allocator, &out, usage.used_bytes);
+    try out.appendSlice(allocator, ",\"maxMB\":");
+    try appendMegabytes(allocator, &out, usage.max_bytes);
+    try out.appendSlice(allocator, ",\"totalMB\":");
+    try appendMegabytes(allocator, &out, usage.total_bytes);
+
+    // The byte counts are exact and stay integers. A `long` past 2^53 would
+    // lose precision in `JSON.parse`, but a JVM heap that large does not exist.
+    try out.appendSlice(allocator, ",\"usedBytes\":");
+    try out.print(allocator, "{d}", .{usage.used_bytes});
+    try out.appendSlice(allocator, ",\"maxBytes\":");
+    try out.print(allocator, "{d}", .{usage.max_bytes});
+    try out.append(allocator, '}');
+
+    return out.toOwnedSlice(allocator);
+}
+
+/// Ask `java.lang.Runtime` about the managed heap.
+///
+/// `used = total - free` is the Kotlin's own arithmetic, and it is the only
+/// one of the three that is derived rather than read.
+pub fn readMemory(j: Jni) !MemoryUsage {
+    try j.pushLocalFrame(8);
+    defer _ = j.popLocalFrame(null);
+
+    const cls = try j.findClass("java/lang/Runtime");
+    const runtime = try j.callStaticObjectMethodA(
+        cls,
+        try j.staticMethodId(cls, "getRuntime", "()Ljava/lang/Runtime;"),
+        &.{},
+    );
+
+    const total = try j.callLongMethod(runtime, try j.methodId(cls, "totalMemory", "()J"));
+    const free = try j.callLongMethod(runtime, try j.methodId(cls, "freeMemory", "()J"));
+    const max = try j.callLongMethod(runtime, try j.methodId(cls, "maxMemory", "()J"));
+
+    return .{ .used_bytes = total - free, .max_bytes = max, .total_bytes = total };
+}
+
+/// `android.util.Log.d("CraftBridge", message)`.
+///
+/// The tag is the Kotlin's, character for character. Anyone filtering logcat on
+/// `CraftBridge` is filtering on a string, and changing it because Zig now
+/// emits the line would break a filter that has nothing to do with this
+/// migration.
+pub fn writeLog(j: Jni, message: [*:0]const u8) !void {
+    try j.pushLocalFrame(8);
+    defer _ = j.popLocalFrame(null);
+
+    const cls = try j.findClass("android/util/Log");
+    const tag = try j.newStringUtf("CraftBridge");
+    const text = try j.newStringUtf(message);
+
+    // `Log.d` returns the number of bytes written, which the Kotlin ignores
+    // and so does this. Discarding it is not the same as calling a void
+    // method: the JVM would push a different frame for `CallStaticVoidMethodA`.
+    _ = try j.callStaticIntMethodA(
+        cls,
+        try j.staticMethodId(cls, "d", "(Ljava/lang/String;Ljava/lang/String;)I"),
+        &.{ .{ .l = tag }, .{ .l = text } },
+    );
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+const testing = std.testing;
+
+test "hundredths of a mebibyte round the way Math.round does" {
+    // Exact boundaries first: one MiB is 100 hundredths by definition.
+    try testing.expectEqual(@as(i64, 100), hundredthsOfMebibyte(1024 * 1024));
+    try testing.expectEqual(@as(i64, 200), hundredthsOfMebibyte(2 * 1024 * 1024));
+    try testing.expectEqual(@as(i64, 0), hundredthsOfMebibyte(0));
+
+    // Half rounds up, which is what `floor(x + 0.5)` does for a positive x.
+    // Half a hundredth of a MiB is 1048576/200 = 5242.88 bytes, so 5243 is the
+    // first byte count at or above the halfway point and 5242 is below it.
+    // (Writing the boundary as `1024*1024/200` truncates to 5242 and asserts
+    // the opposite of what it looks like — which is what the first version of
+    // this test did.)
+    try testing.expectEqual(@as(i64, 1), hundredthsOfMebibyte(5243));
+    try testing.expectEqual(@as(i64, 0), hundredthsOfMebibyte(5242));
+
+    // A negative cannot come from a byte count, and answering 0 is better than
+    // answering a negative megabyte.
+    try testing.expectEqual(@as(i64, 0), hundredthsOfMebibyte(-1));
+}
+
+test "the memory reply carries every key the Kotlin puts, and parses" {
+    const usage = MemoryUsage{
+        .used_bytes = 123_456_789,
+        .max_bytes = 536_870_912,
+        .total_bytes = 268_435_456,
+    };
+    const json = try renderMemory(testing.allocator, usage);
+    defer testing.allocator.free(json);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    const obj = parsed.value.object;
+
+    try testing.expectEqual(@as(usize, 5), obj.count());
+    try testing.expectEqual(@as(i64, 123_456_789), obj.get("usedBytes").?.integer);
+    try testing.expectEqual(@as(i64, 536_870_912), obj.get("maxBytes").?.integer);
+
+    // 123456789 / 1048576 = 117.7375… → 117.74
+    try testing.expectApproxEqAbs(@as(f64, 117.74), obj.get("usedMB").?.float, 0.0001);
+    // 536870912 is exactly 512 MiB, and 268435456 exactly 256.
+    try testing.expectApproxEqAbs(@as(f64, 512), obj.get("maxMB").?.float, 0.0001);
+    try testing.expectApproxEqAbs(@as(f64, 256), obj.get("totalMB").?.float, 0.0001);
+}
+
+test "a whole number of megabytes still renders as a number" {
+    // The `.00` path: `512.00` is valid JSON and parses to 512, but a bug in
+    // the fraction split would produce `512.` or `512.0` — one of which is not
+    // JSON at all.
+    const json = try renderMemory(testing.allocator, .{
+        .used_bytes = 1024 * 1024,
+        .max_bytes = 1024 * 1024,
+        .total_bytes = 1024 * 1024,
+    });
+    defer testing.allocator.free(json);
+
+    try testing.expect(std.mem.indexOf(u8, json, "\"usedMB\":1.00,") != null);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectApproxEqAbs(@as(f64, 1), parsed.value.object.get("usedMB").?.float, 0.0001);
+}
+
+test "a heap under a hundredth of a megabyte does not render as garbage" {
+    // The zero-fraction edge, from the other side: a two-digit pad is what
+    // stops 5 hundredths becoming "0.5".
+    const json = try renderMemory(testing.allocator, .{
+        .used_bytes = 52_429, // ~0.05 MiB
+        .max_bytes = 0,
+        .total_bytes = 0,
+    });
+    defer testing.allocator.free(json);
+    try testing.expect(std.mem.indexOf(u8, json, "\"usedMB\":0.05,") != null);
+    try testing.expect(std.mem.indexOf(u8, json, "\"maxMB\":0.00,") != null);
+}
+
+test "the action names match the Kotlin methods exactly" {
+    try testing.expectEqualStrings("getMemoryUsage", A.get_memory_usage);
+    try testing.expectEqualStrings("log", A.log);
+}

--- a/packages/zig/src/jni_runtime.zig
+++ b/packages/zig/src/jni_runtime.zig
@@ -710,6 +710,45 @@ pub const Jni = struct {
         return result;
     }
 
+    pub fn callLongMethod(self: Self, obj: jobject, id: jmethodID) JniError!jlong {
+        const call: *const fn (JNIEnv, jobject, jmethodID) callconv(.c) jlong =
+            @ptrCast(self.table().CallLongMethod orelse return JniError.NotFound);
+        const result = call(self.env, obj, id);
+        try self.check();
+        return result;
+    }
+
+    // --- Static methods ---------------------------------------------------
+    //
+    // `Runtime.getRuntime()` and `Log.d(tag, msg)` are both static, and a
+    // static call is a different table entry from an instance one taking the
+    // class rather than the receiver. Passing a jclass to CallObjectMethod
+    // compiles and is undefined at runtime.
+
+    pub fn staticMethodId(self: Self, cls: jclass, name: [*:0]const u8, sig: [*:0]const u8) JniError!jmethodID {
+        const get: *const fn (JNIEnv, jclass, [*:0]const u8, [*:0]const u8) callconv(.c) jmethodID =
+            @ptrCast(self.table().GetStaticMethodID orelse return JniError.NotFound);
+        const id = get(self.env, cls, name, sig);
+        try self.check();
+        return id orelse JniError.NotFound;
+    }
+
+    pub fn callStaticObjectMethodA(self: Self, cls: jclass, id: jmethodID, args: []const jvalue) JniError!jobject {
+        const call: *const fn (JNIEnv, jclass, jmethodID, [*]const jvalue) callconv(.c) jobject =
+            @ptrCast(self.table().CallStaticObjectMethodA orelse return JniError.NotFound);
+        const result = call(self.env, cls, id, args.ptr);
+        try self.check();
+        return result;
+    }
+
+    pub fn callStaticIntMethodA(self: Self, cls: jclass, id: jmethodID, args: []const jvalue) JniError!jint {
+        const call: *const fn (JNIEnv, jclass, jmethodID, [*]const jvalue) callconv(.c) jint =
+            @ptrCast(self.table().CallStaticIntMethodA orelse return JniError.NotFound);
+        const result = call(self.env, cls, id, args.ptr);
+        try self.check();
+        return result;
+    }
+
     pub fn objectClass(self: Self, obj: jobject) JniError!jclass {
         const get: *const fn (JNIEnv, jobject) callconv(.c) jclass =
             @ptrCast(self.table().GetObjectClass orelse return JniError.NotFound);

--- a/packages/zig/test/android_conformance_test.zig
+++ b/packages/zig/test/android_conformance_test.zig
@@ -40,6 +40,7 @@ const dispatch_source = @embedFile("src/android_dispatch.zig");
 /// migrated actions the scan cannot see read as "still owed".
 const zig_sources = [_][]const u8{
     @embedFile("src/bridge_android_device.zig"),
+    @embedFile("src/bridge_android_system.zig"),
 };
 
 /// How many spec actions Zig does not serve yet.
@@ -48,8 +49,9 @@ const zig_sources = [_][]const u8{
 /// costs. If it ever needs raising, something has left Zig without leaving the
 /// Kotlin, and that is the conversation this constant exists to force.
 ///
-/// History: 103 at the seam; 102 with getDeviceInfo.
-const max_not_yet_migrated: usize = 102;
+/// History: 103 at the seam; 102 with getDeviceInfo; 100 with getMemoryUsage
+/// and log — the first two that need no Activity at all.
+const max_not_yet_migrated: usize = 100;
 
 /// Every `@JavascriptInterface fun <name>(` in the Kotlin bridge.
 ///


### PR DESCRIPTION
The first two Android actions that need **no `Activity` at all**. Both reach a static class and stop, so neither depends on anything the app hands over — which makes them the honest start of Tier 0, rather than `getDeviceInfo`, whose display metrics and package info do need it.

Ratchet **102 → 100**.

## `getMemoryUsage` is not the iOS action wearing a different name

iOS asks the *kernel* for this process's resident size through `task_info`. Android asks the *JVM* about its own heap through `java.lang.Runtime` — and those are different quantities. `totalMemory()` is what the managed heap has reserved, not what the process holds, and every native allocation this bridge makes is outside it.

So the platforms answer with different keys, and that's correct rather than sloppy:

| iOS | Android |
| --- | --- |
| `usedMB`, `residentSize`, `virtualSize` | `usedMB`, `maxMB`, `totalMB`, `usedBytes`, `maxBytes` |

Only `usedMB` is shared, and even that measures something else. Making them agree would mean one of them lying about which number it took.

Split the same way the device module is: `readMemory` does the JNI work and returns a plain struct, `renderMemory` turns it into bytes and touches no Java. The rounding is integer arithmetic rather than a float format, for the reason `bridge_mobile_device.zig` gives for the same figure on iOS — it becomes a property of a function you can assert, not of a format you have to observe.

## `log` is here for the seam, not the code

One line of Kotlin. What it buys is the **first static method call** and the **first native that answers with a boolean**.

Void wouldn't work: the Kotlin has to be able to tell a written line from a declined one, or it logs twice or not at all. And the `"CraftBridge"` tag is kept character for character — anyone filtering logcat on it is filtering on a string, and changing it because Zig now emits the line would break a filter that has nothing to do with this migration.

## Two bugs, both caught by their own tests

**`{d:0>2}` renders `+74` on this toolchain** — a sign, not a zero. The reply read `117.+74` and stopped parsing at the dot. Padded by hand now, with the reason recorded beside it.

**The rounding test asserted the opposite of what it looked like.** It computed the half-way boundary as `1024*1024/200`, which truncates to 5242 — *below* the true 5242.88 — so "half rounds up" was actually testing that just-under-half rounds down. Both boundaries are written out explicitly now.

## JNI additions

`CallLongMethod`, plus `GetStaticMethodID` / `CallStaticObjectMethodA` / `CallStaticIntMethodA`. A static call is a **different table entry** from an instance one and takes the class rather than the receiver — passing a `jclass` to `CallObjectMethod` compiles and is undefined at runtime.

## Verified

| mutation | result |
| --- | --- |
| ratchet lowered 100 → 99 | `MigrationWentBackwards` — the count really is 100 |
| holder renames `nativeLog` | `RegisteredNativeNotDeclared` **and** `DeclaredNativeNotRegistered` |

`zig build test:android` → 63 tests, 11/11 steps · both `.so` build · the generator's 10 tests still pass.

## Next

`clipboardRead`/`clipboardWrite` — the first that need `getSystemService` and an Activity, and the first with a real null path (`primaryClip` can be absent, and the Kotlin returns `""` for it).
