### PR TITLE
feat(android): getNetworkStatus — the action iOS cannot serve

### DIFF
--- a/packages/android/templates/CraftBridge.kt.template
+++ b/packages/android/templates/CraftBridge.kt.template
@@ -1878,6 +1878,8 @@ class CraftBridge(
 
     @JavascriptInterface
     fun getNetworkStatus(): String {
+        CraftNative.getNetworkStatus(activity)?.let { return it }
+
         val connectivityManager = activity.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
         val network = connectivityManager.activeNetwork
         val capabilities = connectivityManager.getNetworkCapabilities(network)

--- a/packages/android/templates/CraftNative.kt.template
+++ b/packages/android/templates/CraftNative.kt.template
@@ -63,6 +63,7 @@ object CraftNative {
     private external fun nativeClipboardWrite(activity: Activity, text: String): Boolean
     private external fun nativeOpenUrl(activity: Activity, url: String): Boolean
     private external fun nativeShare(activity: Activity, text: String, title: String): Boolean
+    private external fun nativeGetNetworkStatus(activity: Activity): String?
 
     /**
      * `getDeviceInfo`, or null to use the Kotlin implementation.
@@ -163,6 +164,16 @@ object CraftNative {
             nativeShare(activity, text, title)
         } catch (e: UnsatisfiedLinkError) {
             false
+        }
+    }
+
+    /** The active network as JSON, or null to use the Kotlin implementation. */
+    fun getNetworkStatus(activity: Activity): String? {
+        if (!isAvailable) return null
+        return try {
+            nativeGetNetworkStatus(activity)
+        } catch (e: UnsatisfiedLinkError) {
+            null
         }
     }
 }

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -443,6 +443,9 @@ pub fn build(b: *std.Build) void {
     android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_intents.zig", .{
         .root_source_file = b.path("src/bridge_android_intents.zig"),
     });
+    android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_network.zig", .{
+        .root_source_file = b.path("src/bridge_android_network.zig"),
+    });
     const run_android_conformance_tests = b.addRunArtifact(android_conformance_tests);
 
     // The page surface, across both bridges. Not folded into the iOS

--- a/packages/zig/src/android_dispatch.zig
+++ b/packages/zig/src/android_dispatch.zig
@@ -40,6 +40,7 @@ const device = @import("bridge_android_device.zig");
 const system = @import("bridge_android_system.zig");
 const clipboard = @import("bridge_android_clipboard.zig");
 const intents = @import("bridge_android_intents.zig");
+const network = @import("bridge_android_network.zig");
 
 const Jni = jni.Jni;
 
@@ -158,6 +159,11 @@ const natives = [_]jni.JNINativeMethod{
         .name = "nativeShare",
         .signature = "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)Z",
         .fnPtr = @ptrCast(&nativeShare),
+    },
+    .{
+        .name = "nativeGetNetworkStatus",
+        .signature = "(Landroid/app/Activity;)Ljava/lang/String;",
+        .fnPtr = @ptrCast(&nativeGetNetworkStatus),
     },
 };
 
@@ -365,6 +371,23 @@ fn nativeShare(
     return jni.JNI_TRUE;
 }
 
+fn nativeGetNetworkStatus(env: jni.JNIEnv, _: jni.jobject, activity: jni.jobject) callconv(.c) jni.jstring {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const status = network.read(j, activity) catch |err| {
+        std.log.warn("craft: getNetworkStatus fell through to the shim ({s})", .{@errorName(err)});
+        return null;
+    };
+
+    const json = network.render(allocator, status) catch return null;
+    const owned = allocator.allocSentinel(u8, json.len, 0) catch return null;
+    @memcpy(owned, json);
+    return j.newStringUtf(owned.ptr) catch null;
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -476,7 +499,7 @@ test "the registered natives name methods the Kotlin actually declares" {
     // A descriptor is checked by the JVM at registration, so a wrong one fails
     // at load rather than at call — but only if the *name* matches something.
     // These two strings are the contract with CraftBridge.kt.
-    try testing.expectEqual(@as(usize, 7), natives.len);
+    try testing.expectEqual(@as(usize, 8), natives.len);
     try testing.expectEqualStrings("nativeGetDeviceInfo", std.mem.span(natives[0].name));
 
     // And the class they bind to is the fixed one, not the templated bridge.

--- a/packages/zig/src/bridge_android_network.zig
+++ b/packages/zig/src/bridge_android_network.zig
@@ -1,0 +1,353 @@
+//! `getNetworkStatus` on Android.
+//!
+//! ## The action iOS could not serve, for a reason that is genuinely platform-
+//! specific
+//!
+//! `bridge_mobile_device.zig` declares this `.status = .unavailable` on iOS,
+//! and the reason is not a shortcut: no synchronous iOS API can answer
+//! `isConnected` without fabricating it. `NWPathMonitor` delivers on a
+//! background queue, `SCNetworkReachability` is deprecated, cannot see wired
+//! ethernet, and reports the *host Mac's* reachability on the simulator, and
+//! `getifaddrs` knows which interfaces are up but not whether anything is
+//! reachable. The alternative there is `{"isConnected":true,"type":"unknown"}`,
+//! which a caller cannot tell from a real reading.
+//!
+//! Android has the API iOS lacks. `ConnectivityManager.getNetworkCapabilities`
+//! is synchronous and answers null when nothing is connected, so `isConnected`
+//! is a fact here rather than a guess. Same action name, opposite verdict, and
+//! the difference is the platform rather than the effort.
+//!
+//! ## `isConnected` and `type` are not the same question
+//!
+//! `capabilities != null` means *something* is connected. The transport is a
+//! separate lookup, and the Kotlin's `when` falls through to `"none"` when
+//! none of WIFI, CELLULAR or ETHERNET matches — which happens on Bluetooth
+//! tethering, on a VPN-only interface, and on emulators.
+//!
+//! So `{"isConnected":true,"type":"none"}` is a reachable and correct state,
+//! not a contradiction to smooth over. A reading that forced `type` to
+//! `"unknown"` whenever connected, or forced `isConnected` false whenever the
+//! transport was unrecognised, would each be wrong in a way the page could not
+//! detect.
+
+const std = @import("std");
+const jni = @import("jni_runtime.zig");
+
+const Jni = jni.Jni;
+const jobject = jni.jobject;
+
+pub const A = struct {
+    pub const get_network_status = "getNetworkStatus";
+};
+
+/// The transports the Kotlin's `when` distinguishes, in its order.
+///
+/// Order is contract: `when` takes the first match, so a connection that is
+/// both WIFI and ETHERNET — which a bridged emulator can report — answers
+/// `"wifi"` on both sides only if the checks run in the same sequence.
+pub const Transport = enum {
+    wifi,
+    cellular,
+    ethernet,
+    none,
+
+    pub fn name(self: Transport) []const u8 {
+        return switch (self) {
+            .wifi => "wifi",
+            .cellular => "cellular",
+            .ethernet => "ethernet",
+            .none => "none",
+        };
+    }
+};
+
+pub const NetworkStatus = struct {
+    connected: bool,
+    transport: Transport,
+};
+
+/// The reply bytes, in the Kotlin's `put` order.
+///
+/// `isWifi` and `isCellular` are derived from the transport rather than read
+/// again — that is what the Kotlin does (`connectionType == "wifi"`), and
+/// deriving them separately would let the three disagree.
+pub fn render(allocator: std.mem.Allocator, status: NetworkStatus) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.appendSlice(allocator, "{\"isConnected\":");
+    try out.appendSlice(allocator, if (status.connected) "true" else "false");
+    try out.appendSlice(allocator, ",\"type\":\"");
+    try out.appendSlice(allocator, status.transport.name());
+    try out.appendSlice(allocator, "\",\"isWifi\":");
+    try out.appendSlice(allocator, if (status.transport == .wifi) "true" else "false");
+    try out.appendSlice(allocator, ",\"isCellular\":");
+    try out.appendSlice(allocator, if (status.transport == .cellular) "true" else "false");
+    try out.append(allocator, '}');
+
+    return out.toOwnedSlice(allocator);
+}
+
+/// Ask `ConnectivityManager` what the active network can do.
+pub fn read(j: Jni, activity: jobject) !NetworkStatus {
+    try j.pushLocalFrame(16);
+    defer _ = j.popLocalFrame(null);
+
+    const context_cls = try j.findClass("android/content/Context");
+    const service_name = try j.staticObjectField(
+        context_cls,
+        try j.staticFieldId(context_cls, "CONNECTIVITY_SERVICE", "Ljava/lang/String;"),
+    );
+
+    const activity_cls = try j.objectClass(activity);
+    const manager = try j.callObjectMethodA(
+        activity,
+        try j.methodId(activity_cls, "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;"),
+        &.{.{ .l = service_name }},
+    );
+
+    const manager_cls = try j.objectClass(manager);
+    const network = try j.callObjectMethod(
+        manager,
+        try j.methodId(manager_cls, "getActiveNetwork", "()Landroid/net/Network;"),
+    );
+
+    // `getNetworkCapabilities(null)` is legal and answers null, which is the
+    // same "not connected" the Kotlin reads — so the null network needs no
+    // branch of its own here, only the null capabilities below.
+    const capabilities = try j.callObjectMethodA(
+        manager,
+        try j.methodId(
+            manager_cls,
+            "getNetworkCapabilities",
+            "(Landroid/net/Network;)Landroid/net/NetworkCapabilities;",
+        ),
+        &.{.{ .l = network }},
+    );
+    if (capabilities == null) return .{ .connected = false, .transport = .none };
+
+    const caps_cls = try j.findClass("android/net/NetworkCapabilities");
+    const has_transport = try j.methodId(caps_cls, "hasTransport", "(I)Z");
+
+    // Checked in the Kotlin's order, and stopping at the first match, because
+    // `when` does.
+    const probes = [_]struct { field: [*:0]const u8, transport: Transport }{
+        .{ .field = "TRANSPORT_WIFI", .transport = .wifi },
+        .{ .field = "TRANSPORT_CELLULAR", .transport = .cellular },
+        .{ .field = "TRANSPORT_ETHERNET", .transport = .ethernet },
+    };
+
+    for (probes) |probe| {
+        const value = try j.staticIntField(
+            caps_cls,
+            try j.staticFieldId(caps_cls, probe.field, "I"),
+        );
+        if (try j.callBooleanMethodA(capabilities, has_transport, &.{.{ .i = value }})) {
+            return .{ .connected = true, .transport = probe.transport };
+        }
+    }
+
+    // Connected over something else — Bluetooth tethering, a VPN-only
+    // interface, an emulator. See the module comment: this is a real state.
+    return .{ .connected = true, .transport = .none };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+const testing = std.testing;
+
+fn parsed(status: NetworkStatus) !std.json.Parsed(std.json.Value) {
+    const json = try render(testing.allocator, status);
+    defer testing.allocator.free(json);
+    return std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+}
+
+test "the reply carries every key the Kotlin puts" {
+    var p = try parsed(.{ .connected = true, .transport = .wifi });
+    defer p.deinit();
+    const obj = p.value.object;
+
+    try testing.expectEqual(@as(usize, 4), obj.count());
+    try testing.expectEqual(true, obj.get("isConnected").?.bool);
+    try testing.expectEqualStrings("wifi", obj.get("type").?.string);
+    try testing.expectEqual(true, obj.get("isWifi").?.bool);
+    try testing.expectEqual(false, obj.get("isCellular").?.bool);
+}
+
+test "isWifi and isCellular follow the transport rather than being read twice" {
+    // The Kotlin derives both from `connectionType`, so they cannot disagree
+    // with `type`. Deriving them independently is the bug this pins.
+    {
+        var p = try parsed(.{ .connected = true, .transport = .cellular });
+        defer p.deinit();
+        try testing.expectEqualStrings("cellular", p.value.object.get("type").?.string);
+        try testing.expectEqual(false, p.value.object.get("isWifi").?.bool);
+        try testing.expectEqual(true, p.value.object.get("isCellular").?.bool);
+    }
+    {
+        var p = try parsed(.{ .connected = true, .transport = .ethernet });
+        defer p.deinit();
+        try testing.expectEqualStrings("ethernet", p.value.object.get("type").?.string);
+        try testing.expectEqual(false, p.value.object.get("isWifi").?.bool);
+        try testing.expectEqual(false, p.value.object.get("isCellular").?.bool);
+    }
+}
+
+test "connected over an unrecognised transport is a real state, not a contradiction" {
+    // Bluetooth tethering, a VPN-only interface, most emulators. The Kotlin's
+    // `when` falls through to "none" while `capabilities != null` stays true,
+    // and a reading that "corrected" either half would be wrong in a way the
+    // page could not detect.
+    var p = try parsed(.{ .connected = true, .transport = .none });
+    defer p.deinit();
+    try testing.expectEqual(true, p.value.object.get("isConnected").?.bool);
+    try testing.expectEqualStrings("none", p.value.object.get("type").?.string);
+}
+
+test "no connection reports both halves as absent" {
+    var p = try parsed(.{ .connected = false, .transport = .none });
+    defer p.deinit();
+    try testing.expectEqual(false, p.value.object.get("isConnected").?.bool);
+    try testing.expectEqualStrings("none", p.value.object.get("type").?.string);
+    try testing.expectEqual(false, p.value.object.get("isWifi").?.bool);
+    try testing.expectEqual(false, p.value.object.get("isCellular").?.bool);
+}
+
+test "the transport names are the strings the page compares against" {
+    // `craft.d.ts` types this as a union of these literals, and pages switch
+    // on them. A rename here is a silent behaviour change for every consumer.
+    try testing.expectEqualStrings("wifi", Transport.wifi.name());
+    try testing.expectEqualStrings("cellular", Transport.cellular.name());
+    try testing.expectEqualStrings("ethernet", Transport.ethernet.name());
+    try testing.expectEqualStrings("none", Transport.none.name());
+}
+
+test "the action name matches the Kotlin method exactly" {
+    try testing.expectEqualStrings("getNetworkStatus", A.get_network_status);
+}
+
+// --- A fake ConnectivityManager -------------------------------------------
+//
+// `read` makes the transport claim that the module comment calls contract:
+// the checks run in the Kotlin's order and stop at the first match. Nothing
+// above tests that, because `render` never sees it — so the fake is here to
+// make the claim assertable rather than decorative.
+
+var fake_storage: [8]u8 = undefined;
+var fake_capabilities_null = false;
+/// Which `TRANSPORT_*` values `hasTransport` answers true for. The fake
+/// returns the field name's hash as the constant, so the set is by name.
+var fake_transports: []const []const u8 = &.{};
+var fake_last_field: [*:0]const u8 = "";
+
+fn fobj(tag: usize) jobject {
+    return @ptrCast(&fake_storage[tag]);
+}
+
+fn transportValue(name: []const u8) jni.jint {
+    // Stable small integers standing in for the real constants. Their values
+    // do not matter; that each is distinct does.
+    if (std.mem.eql(u8, name, "TRANSPORT_WIFI")) return 1;
+    if (std.mem.eql(u8, name, "TRANSPORT_CELLULAR")) return 0;
+    if (std.mem.eql(u8, name, "TRANSPORT_ETHERNET")) return 3;
+    return -1;
+}
+
+fn nFindClass(_: jni.JNIEnv, _: [*:0]const u8) callconv(.c) jni.jclass {
+    return fobj(0);
+}
+fn nObjectClass(_: jni.JNIEnv, _: jobject) callconv(.c) jni.jclass {
+    return fobj(0);
+}
+fn nStaticFieldId(_: jni.JNIEnv, _: jni.jclass, name: [*:0]const u8, _: [*:0]const u8) callconv(.c) jni.jfieldID {
+    fake_last_field = name;
+    return @ptrCast(@constCast(name));
+}
+fn nStaticObjectField(_: jni.JNIEnv, _: jni.jclass, _: jni.jfieldID) callconv(.c) jobject {
+    return fobj(1);
+}
+fn nStaticIntField(_: jni.JNIEnv, _: jni.jclass, id: jni.jfieldID) callconv(.c) jni.jint {
+    return transportValue(std.mem.span(@as([*:0]const u8, @ptrCast(id.?))));
+}
+fn nMethodId(_: jni.JNIEnv, _: jni.jclass, name: [*:0]const u8, _: [*:0]const u8) callconv(.c) jni.jmethodID {
+    return @ptrCast(@constCast(name));
+}
+fn nCallObjectMethod(_: jni.JNIEnv, _: jobject, _: jni.jmethodID) callconv(.c) jobject {
+    return fobj(2); // getActiveNetwork
+}
+fn nCallObjectMethodA(_: jni.JNIEnv, _: jobject, id: jni.jmethodID, _: [*]const jni.jvalue) callconv(.c) jobject {
+    const name = std.mem.span(@as([*:0]const u8, @ptrCast(id.?)));
+    if (std.mem.eql(u8, name, "getNetworkCapabilities"))
+        return if (fake_capabilities_null) null else fobj(3);
+    return fobj(4); // getSystemService
+}
+fn nCallBooleanMethodA(_: jni.JNIEnv, _: jobject, _: jni.jmethodID, args: [*]const jni.jvalue) callconv(.c) jni.jboolean {
+    for (fake_transports) |t| {
+        if (transportValue(t) == args[0].i) return jni.JNI_TRUE;
+    }
+    return jni.JNI_FALSE;
+}
+fn nExceptionOccurred(_: jni.JNIEnv) callconv(.c) jobject {
+    return null;
+}
+fn nPush(_: jni.JNIEnv, _: jni.jint) callconv(.c) jni.jint {
+    return 0;
+}
+fn nPop(_: jni.JNIEnv, keep: jobject) callconv(.c) jobject {
+    return keep;
+}
+
+fn readWith(transports: []const []const u8, capabilities_null: bool) !NetworkStatus {
+    fake_transports = transports;
+    fake_capabilities_null = capabilities_null;
+
+    var table = std.mem.zeroes(jni.JNINativeInterface);
+    table.FindClass = @ptrCast(&nFindClass);
+    table.GetObjectClass = @ptrCast(&nObjectClass);
+    table.GetStaticFieldID = @ptrCast(&nStaticFieldId);
+    table.GetStaticObjectField = @ptrCast(&nStaticObjectField);
+    table.GetStaticIntField = @ptrCast(&nStaticIntField);
+    table.GetMethodID = @ptrCast(&nMethodId);
+    table.CallObjectMethod = @ptrCast(&nCallObjectMethod);
+    table.CallObjectMethodA = @ptrCast(&nCallObjectMethodA);
+    table.CallBooleanMethodA = @ptrCast(&nCallBooleanMethodA);
+    table.ExceptionOccurred = @ptrCast(&nExceptionOccurred);
+    table.PushLocalFrame = @ptrCast(&nPush);
+    table.PopLocalFrame = @ptrCast(&nPop);
+
+    const ptr: *const jni.JNINativeInterface = &table;
+    return read(Jni.init(&ptr), fobj(5));
+}
+
+test "each transport is recognised as itself" {
+    try testing.expectEqual(Transport.wifi, (try readWith(&.{"TRANSPORT_WIFI"}, false)).transport);
+    try testing.expectEqual(Transport.cellular, (try readWith(&.{"TRANSPORT_CELLULAR"}, false)).transport);
+    try testing.expectEqual(Transport.ethernet, (try readWith(&.{"TRANSPORT_ETHERNET"}, false)).transport);
+}
+
+test "a connection with two transports answers the first the Kotlin would check" {
+    // The claim the module comment makes. `when` takes its first true branch,
+    // so a bridged emulator reporting both WIFI and ETHERNET must answer
+    // "wifi" — and it only does if the probes run in the Kotlin's order.
+    // Reordering them here changes the answer without changing anything a
+    // reader would look at.
+    const both = try readWith(&.{ "TRANSPORT_ETHERNET", "TRANSPORT_WIFI" }, false);
+    try testing.expectEqual(Transport.wifi, both.transport);
+
+    const cell_and_eth = try readWith(&.{ "TRANSPORT_ETHERNET", "TRANSPORT_CELLULAR" }, false);
+    try testing.expectEqual(Transport.cellular, cell_and_eth.transport);
+}
+
+test "null capabilities is not connected, and an unknown transport still is" {
+    const offline = try readWith(&.{}, true);
+    try testing.expectEqual(false, offline.connected);
+    try testing.expectEqual(Transport.none, offline.transport);
+
+    // Capabilities present, no transport matched — Bluetooth tethering or a
+    // VPN-only interface. Connected, and honestly typed "none".
+    const odd = try readWith(&.{}, false);
+    try testing.expectEqual(true, odd.connected);
+    try testing.expectEqual(Transport.none, odd.transport);
+}

--- a/packages/zig/src/jni_runtime.zig
+++ b/packages/zig/src/jni_runtime.zig
@@ -624,6 +624,16 @@ pub const Jni = struct {
         return result;
     }
 
+    pub fn callBooleanMethodA(self: Self, obj: jobject, id: jmethodID, args: []const jvalue) JniError!bool {
+        const call: *const fn (JNIEnv, jobject, jmethodID, [*]const jvalue) callconv(.c) jboolean =
+            @ptrCast(self.table().CallBooleanMethodA orelse return JniError.NotFound);
+        const result = call(self.env, obj, id, args.ptr);
+        try self.check();
+        // `jboolean` is a `u8` and the JVM only ever sets it to 0 or 1, but a
+        // `!= 0` rather than `== 1` is what the spec licenses.
+        return result != JNI_FALSE;
+    }
+
     pub fn callVoidMethodA(self: Self, obj: jobject, id: jmethodID, args: []const jvalue) JniError!void {
         const call: *const fn (JNIEnv, jobject, jmethodID, [*]const jvalue) callconv(.c) void =
             @ptrCast(self.table().CallVoidMethodA orelse return JniError.NotFound);

--- a/packages/zig/test/android_conformance_test.zig
+++ b/packages/zig/test/android_conformance_test.zig
@@ -43,6 +43,7 @@ const zig_sources = [_][]const u8{
     @embedFile("src/bridge_android_system.zig"),
     @embedFile("src/bridge_android_clipboard.zig"),
     @embedFile("src/bridge_android_intents.zig"),
+    @embedFile("src/bridge_android_network.zig"),
 };
 
 /// How many spec actions Zig does not serve yet.
@@ -53,8 +54,9 @@ const zig_sources = [_][]const u8{
 ///
 /// History: 103 at the seam; 102 with getDeviceInfo; 100 with getMemoryUsage
 /// and log — the first two that need no Activity at all; 98 with the
-/// clipboard pair, the first that do; 96 with openURL and share.
-const max_not_yet_migrated: usize = 96;
+/// clipboard pair, the first that do; 96 with openURL and share; 95 with
+/// getNetworkStatus, which iOS declares unavailable and Android can answer.
+const max_not_yet_migrated: usize = 95;
 
 /// Every `@JavascriptInterface fun <name>(` in the Kotlin bridge.
 ///


### PR DESCRIPTION
Ratchet **96 → 95**, and the most interesting one so far: iOS declares this action `.status = .unavailable`, and that refusal is correct.

## The same action, opposite verdicts, for a real reason

`bridge_mobile_device.zig` refuses `getNetworkStatus` on iOS because **no synchronous iOS API can answer `isConnected` without fabricating it**:

- `NWPathMonitor` delivers on a background queue where `evaluateJavaScript:` is illegal
- `SCNetworkReachability` is deprecated since 17.4, can't see wired ethernet, and reports the *host Mac's* reachability on the simulator
- `getifaddrs` knows which interfaces are up, not whether anything is reachable

The alternative there is `{"isConnected":true,"type":"unknown"}` — which a caller cannot tell from a real reading, making it strictly worse than an error.

**Android has the API iOS lacks.** `getNetworkCapabilities` is synchronous and answers null when nothing is connected, so `isConnected` is a fact here rather than a guess.

Worth stating plainly in the module, because the next person comparing the two platforms' tables will otherwise see one refusing what the other serves and assume someone gave up.

## `isConnected` and `type` are not the same question

`capabilities != null` means *something* is connected. The transport is a separate lookup, and the Kotlin's `when` falls through to `"none"` on Bluetooth tethering, a VPN-only interface, and most emulators.

So **`{"isConnected":true,"type":"none"}` is reachable and correct**, not a contradiction to smooth over. Forcing `type` to `"unknown"` whenever connected, or `isConnected` false whenever the transport is unrecognised, would each be wrong in a way the page could not detect.

## A comment that became a test

The module says the probes run in the Kotlin's order and stop at the first match, because `when` does. That was **just a claim** until a fake `ConnectivityManager` made it assertable:

> a connection reporting both `WIFI` and `ETHERNET` — which a bridged emulator does — must answer `"wifi"`

Reordering the probes changes that answer without changing anything a reader would look at. Now it fails a test.

| mutation | result |
| --- | --- |
| probes reordered (ethernet first) | the two-transport test fails |
| null capabilities reported as connected | the offline test fails |

`isWifi` and `isCellular` are derived from the transport rather than read again — what the Kotlin does, and what stops the three disagreeing.

## Verified

JNI gained `CallBooleanMethodA`. `zig build test:android` → 87 tests, 11/11 steps · both `.so` build · generator 10/10.

## Correction to something I said earlier

I claimed the next Android candidates were structural walls. That was wrong — I'd looked at `setKeepAwake` and `lockOrientation` (which do need `runOnUiThread`, hence a `Runnable`) and generalised from two.

Measuring all 103: **32 need no `evaluateJavascript`, no `runOnUiThread`, no permission check and no listener.** Eight are now migrated, so roughly two dozen remain reachable with the machinery already built — `secureSet/Get/Remove/Clear`, `setBadge`/`clearBadge`, `vibrate`, `haptic`, the notification cancels, and more. The walls are real but they are not next.
