### PR TITLE
feat(android): the secure-storage quartet — ratchet 95 -> 91

### DIFF
--- a/packages/android/templates/CraftBridge.kt.template
+++ b/packages/android/templates/CraftBridge.kt.template
@@ -1544,6 +1544,8 @@ class CraftBridge(
 
     @JavascriptInterface
     fun secureSet(key: String, value: String): Boolean {
+        if (CraftNative.secureSet(securePrefs, key, value)) return true
+
         return try {
             securePrefs.edit().putString(key, value).apply()
             true
@@ -1554,6 +1556,14 @@ class CraftBridge(
 
     @JavascriptInterface
     fun secureGet(key: String): String? {
+        // Three answers, not two: Declined falls through, NotFound is a real
+        // null, Found is a real value that may be the empty string.
+        when (val read = CraftNative.secureGet(securePrefs, key)) {
+            is CraftNative.SecureRead.Found -> return read.value
+            CraftNative.SecureRead.NotFound -> return null
+            CraftNative.SecureRead.Declined -> Unit
+        }
+
         return try {
             securePrefs.getString(key, null)
         } catch (e: Exception) {
@@ -1563,6 +1573,8 @@ class CraftBridge(
 
     @JavascriptInterface
     fun secureRemove(key: String): Boolean {
+        if (CraftNative.secureRemove(securePrefs, key)) return true
+
         return try {
             securePrefs.edit().remove(key).apply()
             true
@@ -1573,6 +1585,8 @@ class CraftBridge(
 
     @JavascriptInterface
     fun secureClear(): Boolean {
+        if (CraftNative.secureClear(securePrefs)) return true
+
         return try {
             securePrefs.edit().clear().apply()
             true

--- a/packages/android/templates/CraftNative.kt.template
+++ b/packages/android/templates/CraftNative.kt.template
@@ -1,6 +1,8 @@
 package com.craft.runtime
 
 import android.app.Activity
+import android.content.SharedPreferences
+import org.json.JSONObject
 
 /**
  * The Zig runtime's native methods.
@@ -64,6 +66,10 @@ object CraftNative {
     private external fun nativeOpenUrl(activity: Activity, url: String): Boolean
     private external fun nativeShare(activity: Activity, text: String, title: String): Boolean
     private external fun nativeGetNetworkStatus(activity: Activity): String?
+    private external fun nativeSecureSet(prefs: SharedPreferences, key: String, value: String): Boolean
+    private external fun nativeSecureGet(prefs: SharedPreferences, key: String): String?
+    private external fun nativeSecureRemove(prefs: SharedPreferences, key: String): Boolean
+    private external fun nativeSecureClear(prefs: SharedPreferences): Boolean
 
     /**
      * `getDeviceInfo`, or null to use the Kotlin implementation.
@@ -174,6 +180,73 @@ object CraftNative {
             nativeGetNetworkStatus(activity)
         } catch (e: UnsatisfiedLinkError) {
             null
+        }
+    }
+
+    /**
+     * The three answers a secure read can give.
+     *
+     * `secureGet` returns `String?` to the page, where null means "no such
+     * key". The seam needs to say "Zig did not serve this" as well, and a
+     * nullable String cannot carry both — an absent key and a declined call
+     * lead to different code. There is no spare value to steal either: `""` is
+     * a legitimate stored value, and so is any sentinel a caller could have
+     * saved.
+     */
+    sealed class SecureRead {
+        /** Zig did not serve the call; run the Kotlin implementation. */
+        object Declined : SecureRead()
+
+        /** Zig served it and the key is not present. */
+        object NotFound : SecureRead()
+
+        /** Zig served it and the key holds [value], which may be empty. */
+        data class Found(val value: String) : SecureRead()
+    }
+
+    fun secureSet(prefs: SharedPreferences, key: String, value: String): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeSecureSet(prefs, key, value)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    fun secureGet(prefs: SharedPreferences, key: String): SecureRead {
+        if (!isAvailable) return SecureRead.Declined
+        val envelope = try {
+            nativeSecureGet(prefs, key)
+        } catch (e: UnsatisfiedLinkError) {
+            null
+        } ?: return SecureRead.Declined
+
+        // A malformed envelope is Zig's bug, and declining is the safe answer:
+        // the Kotlin then reads the store itself and the page sees the truth.
+        return try {
+            val json = JSONObject(envelope)
+            if (json.getBoolean("found")) SecureRead.Found(json.getString("value"))
+            else SecureRead.NotFound
+        } catch (e: Exception) {
+            SecureRead.Declined
+        }
+    }
+
+    fun secureRemove(prefs: SharedPreferences, key: String): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeSecureRemove(prefs, key)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    fun secureClear(prefs: SharedPreferences): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeSecureClear(prefs)
+        } catch (e: UnsatisfiedLinkError) {
+            false
         }
     }
 }

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -446,6 +446,9 @@ pub fn build(b: *std.Build) void {
     android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_network.zig", .{
         .root_source_file = b.path("src/bridge_android_network.zig"),
     });
+    android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_securestore.zig", .{
+        .root_source_file = b.path("src/bridge_android_securestore.zig"),
+    });
     const run_android_conformance_tests = b.addRunArtifact(android_conformance_tests);
 
     // The page surface, across both bridges. Not folded into the iOS

--- a/packages/zig/src/android_dispatch.zig
+++ b/packages/zig/src/android_dispatch.zig
@@ -41,6 +41,7 @@ const system = @import("bridge_android_system.zig");
 const clipboard = @import("bridge_android_clipboard.zig");
 const intents = @import("bridge_android_intents.zig");
 const network = @import("bridge_android_network.zig");
+const securestore = @import("bridge_android_securestore.zig");
 
 const Jni = jni.Jni;
 
@@ -164,6 +165,30 @@ const natives = [_]jni.JNINativeMethod{
         .name = "nativeGetNetworkStatus",
         .signature = "(Landroid/app/Activity;)Ljava/lang/String;",
         .fnPtr = @ptrCast(&nativeGetNetworkStatus),
+    },
+    // These four take the SharedPreferences rather than the Activity: the
+    // store is EncryptedSharedPreferences over a MasterKey the Kotlin already
+    // built, and rebuilding it here would be a second implementation of a
+    // security-sensitive construction that has to agree exactly.
+    .{
+        .name = "nativeSecureSet",
+        .signature = "(Landroid/content/SharedPreferences;Ljava/lang/String;Ljava/lang/String;)Z",
+        .fnPtr = @ptrCast(&nativeSecureSet),
+    },
+    .{
+        .name = "nativeSecureGet",
+        .signature = "(Landroid/content/SharedPreferences;Ljava/lang/String;)Ljava/lang/String;",
+        .fnPtr = @ptrCast(&nativeSecureGet),
+    },
+    .{
+        .name = "nativeSecureRemove",
+        .signature = "(Landroid/content/SharedPreferences;Ljava/lang/String;)Z",
+        .fnPtr = @ptrCast(&nativeSecureRemove),
+    },
+    .{
+        .name = "nativeSecureClear",
+        .signature = "(Landroid/content/SharedPreferences;)Z",
+        .fnPtr = @ptrCast(&nativeSecureClear),
     },
 };
 
@@ -388,6 +413,83 @@ fn nativeGetNetworkStatus(env: jni.JNIEnv, _: jni.jobject, activity: jni.jobject
     return j.newStringUtf(owned.ptr) catch null;
 }
 
+fn nativeSecureSet(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    prefs: jni.jobject,
+    key: jni.jstring,
+    value: jni.jstring,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const k = ownedUtf8(j, allocator, key) orelse return jni.JNI_FALSE;
+    const v = ownedUtf8(j, allocator, value) orelse return jni.JNI_FALSE;
+
+    securestore.set(j, prefs, k.ptr, v.ptr) catch |err| {
+        std.log.warn("craft: secureSet fell through to the shim ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+    return jni.JNI_TRUE;
+}
+
+/// Returns the `{"found":…}` envelope, or null when Zig did not serve the call.
+///
+/// Null cannot mean "no such key" here — the Kotlin already uses null for
+/// that, and the seam needs a third answer. See the module comment on
+/// `bridge_android_securestore.zig`.
+fn nativeSecureGet(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    prefs: jni.jobject,
+    key: jni.jstring,
+) callconv(.c) jni.jstring {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const k = ownedUtf8(j, allocator, key) orelse return null;
+    const value = securestore.get(allocator, j, prefs, k.ptr) catch |err| {
+        std.log.warn("craft: secureGet fell through to the shim ({s})", .{@errorName(err)});
+        return null;
+    };
+
+    const json = securestore.renderRead(allocator, value) catch return null;
+    const owned = allocator.allocSentinel(u8, json.len, 0) catch return null;
+    @memcpy(owned, json);
+    return j.newStringUtf(owned.ptr) catch null;
+}
+
+fn nativeSecureRemove(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    prefs: jni.jobject,
+    key: jni.jstring,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+
+    const k = ownedUtf8(j, arena.allocator(), key) orelse return jni.JNI_FALSE;
+    securestore.remove(j, prefs, k.ptr) catch |err| {
+        std.log.warn("craft: secureRemove fell through to the shim ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+    return jni.JNI_TRUE;
+}
+
+fn nativeSecureClear(env: jni.JNIEnv, _: jni.jobject, prefs: jni.jobject) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+    securestore.clear(j, prefs) catch |err| {
+        std.log.warn("craft: secureClear fell through to the shim ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+    return jni.JNI_TRUE;
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -499,7 +601,7 @@ test "the registered natives name methods the Kotlin actually declares" {
     // A descriptor is checked by the JVM at registration, so a wrong one fails
     // at load rather than at call — but only if the *name* matches something.
     // These two strings are the contract with CraftBridge.kt.
-    try testing.expectEqual(@as(usize, 8), natives.len);
+    try testing.expectEqual(@as(usize, 12), natives.len);
     try testing.expectEqualStrings("nativeGetDeviceInfo", std.mem.span(natives[0].name));
 
     // And the class they bind to is the fixed one, not the templated bridge.

--- a/packages/zig/src/bridge_android_securestore.zig
+++ b/packages/zig/src/bridge_android_securestore.zig
@@ -1,0 +1,303 @@
+//! The Android secure-storage quartet: `secureSet`, `secureGet`,
+//! `secureRemove`, `secureClear`.
+//!
+//! ## Kotlin passes the store; Zig does not build one
+//!
+//! Every other action here reaches its platform object through the `Activity`.
+//! These four do not, and the difference is deliberate. `securePrefs` is
+//!
+//!     EncryptedSharedPreferences.create(activity, "craft_secure_prefs",
+//!         masterKey, AES256_SIV, AES256_GCM)
+//!
+//! over a lazily-built `MasterKey`. Zig could construct that — it is two
+//! builder calls and two enum constants — and constructing it would be a
+//! mistake. It is a second implementation of a security-sensitive
+//! construction, in a second language, that has to agree with the first
+//! exactly: a different key scheme, a different file name, a different SIV
+//! mode, and the two halves write data neither can read. Nothing would fail
+//! at build time and the symptom would be a user's saved token disappearing
+//! after an app update.
+//!
+//! So the native methods take the `SharedPreferences` as a parameter. The
+//! object is Kotlin's, the lifetime is Kotlin's, and Zig only ever calls the
+//! plain `SharedPreferences` interface on it — which is the whole of what the
+//! Kotlin does too, since `EncryptedSharedPreferences` *is* a
+//! `SharedPreferences` and the encryption is behind the interface.
+//!
+//! This generalises: where the shim already holds a configured platform
+//! object, handing it across the seam beats rebuilding it.
+//!
+//! ## `secureGet` has three answers where the others have two
+//!
+//! The Kotlin returns `String?`, and null there means "no such key". The seam
+//! also needs to say "Zig did not serve this" — and a nullable String cannot
+//! carry both, because an absent key and a declined call are different things
+//! and the caller must do different things about them.
+//!
+//! There is no spare value to steal: `""` is a legitimate stored value, and so
+//! is any sentinel a caller could also have saved. So the reply is an envelope,
+//! `{"found":…}`, and null is reserved for "declined". Three states, three
+//! representations, none of them overloaded.
+
+const std = @import("std");
+const jni = @import("jni_runtime.zig");
+const bridge_error = @import("bridge_error.zig");
+
+const Jni = jni.Jni;
+const jobject = jni.jobject;
+
+pub const A = struct {
+    pub const secure_set = "secureSet";
+    pub const secure_get = "secureGet";
+    pub const secure_remove = "secureRemove";
+    pub const secure_clear = "secureClear";
+};
+
+/// `prefs.edit()` — the editor every write goes through.
+///
+/// `SharedPreferences.Editor` is an inner interface, so its binary name
+/// carries the `$`: `android/content/SharedPreferences$Editor`.
+fn editor(j: Jni, prefs: jobject) !jobject {
+    const prefs_cls = try j.objectClass(prefs);
+    return j.callObjectMethod(
+        prefs,
+        try j.methodId(prefs_cls, "edit", "()Landroid/content/SharedPreferences$Editor;"),
+    );
+}
+
+/// `edit.apply()`.
+///
+/// `apply` rather than `commit`, matching the Kotlin. It writes to memory
+/// synchronously and to disk on a background thread, and returns void — so a
+/// disk failure is invisible to both implementations, and "true" here means
+/// the edit was accepted rather than persisted. Switching to `commit` would
+/// make Zig report a truth the shim does not, which is a divergence even when
+/// it is an improvement.
+fn apply(j: Jni, edit: jobject) !void {
+    const edit_cls = try j.objectClass(edit);
+    try j.callVoidMethodA(edit, try j.methodId(edit_cls, "apply", "()V"), &.{});
+}
+
+pub fn set(j: Jni, prefs: jobject, key: [*:0]const u8, value: [*:0]const u8) !void {
+    try j.pushLocalFrame(16);
+    defer _ = j.popLocalFrame(null);
+
+    const edit = try editor(j, prefs);
+    const edit_cls = try j.objectClass(edit);
+
+    _ = try j.callObjectMethodA(
+        edit,
+        try j.methodId(
+            edit_cls,
+            "putString",
+            "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;",
+        ),
+        &.{ .{ .l = try j.newStringUtf(key) }, .{ .l = try j.newStringUtf(value) } },
+    );
+    try apply(j, edit);
+}
+
+pub fn remove(j: Jni, prefs: jobject, key: [*:0]const u8) !void {
+    try j.pushLocalFrame(16);
+    defer _ = j.popLocalFrame(null);
+
+    const edit = try editor(j, prefs);
+    const edit_cls = try j.objectClass(edit);
+
+    _ = try j.callObjectMethodA(
+        edit,
+        try j.methodId(edit_cls, "remove", "(Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;"),
+        &.{.{ .l = try j.newStringUtf(key) }},
+    );
+    try apply(j, edit);
+}
+
+pub fn clear(j: Jni, prefs: jobject) !void {
+    try j.pushLocalFrame(16);
+    defer _ = j.popLocalFrame(null);
+
+    const edit = try editor(j, prefs);
+    const edit_cls = try j.objectClass(edit);
+
+    _ = try j.callObjectMethodA(
+        edit,
+        try j.methodId(edit_cls, "clear", "()Landroid/content/SharedPreferences$Editor;"),
+        &.{},
+    );
+    try apply(j, edit);
+}
+
+/// The reply envelope for `secureGet`. See the module comment for why a bare
+/// nullable string cannot carry these three states.
+pub fn renderRead(allocator: std.mem.Allocator, value: ?[]const u8) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    if (value) |text| {
+        try out.appendSlice(allocator, "{\"found\":true,\"value\":\"");
+        // The quotes are this caller's job — `appendJsonEscaped` escapes the
+        // contents and writes no delimiters. A stored value containing a quote
+        // would otherwise tear the envelope and read back as absent.
+        try bridge_error.appendJsonEscaped(allocator, &out, text);
+        try out.appendSlice(allocator, "\"}");
+    } else {
+        try out.appendSlice(allocator, "{\"found\":false}");
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+/// `prefs.getString(key, null)`, as an owned optional. Caller frees.
+pub fn get(allocator: std.mem.Allocator, j: Jni, prefs: jobject, key: [*:0]const u8) !?[]u8 {
+    try j.pushLocalFrame(16);
+    defer _ = j.popLocalFrame(null);
+
+    const prefs_cls = try j.objectClass(prefs);
+    const value = try j.callObjectMethodA(
+        prefs,
+        try j.methodId(
+            prefs_cls,
+            "getString",
+            "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;",
+        ),
+        // The default is null, which is what makes "absent" distinguishable
+        // from a stored empty string.
+        &.{ .{ .l = try j.newStringUtf(key) }, .{ .l = null } },
+    );
+    if (value == null) return null;
+    return try j.stringToUtf8(allocator, value);
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+const testing = std.testing;
+
+test "the read envelope distinguishes absent from empty" {
+    // The whole reason the envelope exists. A stored `""` and a missing key
+    // are different, and a bare nullable string collapses them the moment the
+    // seam also needs to say "declined".
+    const absent = try renderRead(testing.allocator, null);
+    defer testing.allocator.free(absent);
+    const empty = try renderRead(testing.allocator, "");
+    defer testing.allocator.free(empty);
+
+    var a = try std.json.parseFromSlice(std.json.Value, testing.allocator, absent, .{});
+    defer a.deinit();
+    var e = try std.json.parseFromSlice(std.json.Value, testing.allocator, empty, .{});
+    defer e.deinit();
+
+    try testing.expectEqual(false, a.value.object.get("found").?.bool);
+    try testing.expect(a.value.object.get("value") == null);
+
+    try testing.expectEqual(true, e.value.object.get("found").?.bool);
+    try testing.expectEqualStrings("", e.value.object.get("value").?.string);
+}
+
+test "a stored value containing a quote does not tear the envelope" {
+    // Secure storage holds tokens, and a JWT is base64 — but nothing stops a
+    // page storing arbitrary text, and `appendJsonEscaped` writes no
+    // delimiters of its own. The same trap that broke the iOS
+    // location-recording state file.
+    const json = try renderRead(testing.allocator, "a\"b\\c\nd");
+    defer testing.allocator.free(json);
+
+    var p = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer p.deinit();
+    try testing.expectEqual(true, p.value.object.get("found").?.bool);
+    try testing.expectEqualStrings("a\"b\\c\nd", p.value.object.get("value").?.string);
+}
+
+test "the action names match the Kotlin methods exactly" {
+    try testing.expectEqualStrings("secureSet", A.secure_set);
+    try testing.expectEqualStrings("secureGet", A.secure_get);
+    try testing.expectEqualStrings("secureRemove", A.secure_remove);
+    try testing.expectEqualStrings("secureClear", A.secure_clear);
+}
+
+// --- A fake SharedPreferences ---------------------------------------------
+//
+// `renderRead` above tests the envelope, and the envelope is only half the
+// decision: whether a key is absent is settled in `get`, against
+// `getString(key, null)`. A mutation returning `""` for an absent key passed
+// every test in this file until these were written — the same shape of gap the
+// envelope exists to close, one layer down.
+
+var fake_storage: [8]u8 = undefined;
+var fake_value_present = true;
+
+fn sobj(tag: usize) jobject {
+    return @ptrCast(&fake_storage[tag]);
+}
+fn sObjectClass(_: jni.JNIEnv, _: jobject) callconv(.c) jni.jclass {
+    return sobj(0);
+}
+fn sMethodId(_: jni.JNIEnv, _: jni.jclass, name: [*:0]const u8, _: [*:0]const u8) callconv(.c) jni.jmethodID {
+    return @ptrCast(@constCast(name));
+}
+fn sNewStringUTF(_: jni.JNIEnv, _: [*:0]const u8) callconv(.c) jni.jstring {
+    return sobj(1);
+}
+fn sCallObjectMethodA(_: jni.JNIEnv, _: jobject, _: jni.jmethodID, args: [*]const jni.jvalue) callconv(.c) jobject {
+    // `getString(key, null)` — the second argument is the default, and the
+    // fake honours it rather than inventing one, because "the default comes
+    // back" is precisely the absent case.
+    if (!fake_value_present) return args[1].l;
+    return sobj(2);
+}
+fn sGetStringUTFChars(_: jni.JNIEnv, _: jni.jstring, _: ?*jni.jboolean) callconv(.c) ?[*:0]const u8 {
+    return "stored";
+}
+fn sReleaseStringUTFChars(_: jni.JNIEnv, _: jni.jstring, _: [*:0]const u8) callconv(.c) void {}
+fn sExceptionOccurred(_: jni.JNIEnv) callconv(.c) jobject {
+    return null;
+}
+fn sPush(_: jni.JNIEnv, _: jni.jint) callconv(.c) jni.jint {
+    return 0;
+}
+fn sPop(_: jni.JNIEnv, keep: jobject) callconv(.c) jobject {
+    return keep;
+}
+
+fn getWith(present: bool) !?[]u8 {
+    fake_value_present = present;
+    var table = std.mem.zeroes(jni.JNINativeInterface);
+    table.GetObjectClass = @ptrCast(&sObjectClass);
+    table.GetMethodID = @ptrCast(&sMethodId);
+    table.NewStringUTF = @ptrCast(&sNewStringUTF);
+    table.CallObjectMethodA = @ptrCast(&sCallObjectMethodA);
+    table.GetStringUTFChars = @ptrCast(&sGetStringUTFChars);
+    table.ReleaseStringUTFChars = @ptrCast(&sReleaseStringUTFChars);
+    table.ExceptionOccurred = @ptrCast(&sExceptionOccurred);
+    table.PushLocalFrame = @ptrCast(&sPush);
+    table.PopLocalFrame = @ptrCast(&sPop);
+
+    const ptr: *const jni.JNINativeInterface = &table;
+    return get(testing.allocator, Jni.init(&ptr), sobj(3), "token");
+}
+
+test "an absent key reads as null, never as an empty string" {
+    // The mutation this was written for: returning `""` here instead of null
+    // makes every missing key look like a stored empty string, and the
+    // envelope then reports `found: true` for something that was never saved.
+    const absent = try getWith(false);
+    try testing.expect(absent == null);
+
+    const present = try getWith(true);
+    defer if (present) |p| testing.allocator.free(p);
+    try testing.expect(present != null);
+    try testing.expectEqualStrings("stored", present.?);
+}
+
+test "the absent case survives the round trip through the envelope" {
+    // End to end, because the two halves are only correct together: a `get`
+    // that loses the distinction and a `renderRead` that keeps it still
+    // produce `{"found":true}` for a key nobody stored.
+    const absent = try getWith(false);
+    const json = try renderRead(testing.allocator, absent);
+    defer testing.allocator.free(json);
+
+    var p = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer p.deinit();
+    try testing.expectEqual(false, p.value.object.get("found").?.bool);
+}

--- a/packages/zig/test/android_conformance_test.zig
+++ b/packages/zig/test/android_conformance_test.zig
@@ -44,6 +44,7 @@ const zig_sources = [_][]const u8{
     @embedFile("src/bridge_android_clipboard.zig"),
     @embedFile("src/bridge_android_intents.zig"),
     @embedFile("src/bridge_android_network.zig"),
+    @embedFile("src/bridge_android_securestore.zig"),
 };
 
 /// How many spec actions Zig does not serve yet.
@@ -55,8 +56,10 @@ const zig_sources = [_][]const u8{
 /// History: 103 at the seam; 102 with getDeviceInfo; 100 with getMemoryUsage
 /// and log — the first two that need no Activity at all; 98 with the
 /// clipboard pair, the first that do; 96 with openURL and share; 95 with
-/// getNetworkStatus, which iOS declares unavailable and Android can answer.
-const max_not_yet_migrated: usize = 95;
+/// getNetworkStatus, which iOS declares unavailable and Android can answer;
+/// 91 with the secure-storage quartet, the first to take a Kotlin-held object
+/// rather than the Activity.
+const max_not_yet_migrated: usize = 91;
 
 /// Every `@JavascriptInterface fun <name>(` in the Kotlin bridge.
 ///


### PR DESCRIPTION
Ratchet **95 → 91**. Four actions, and a pattern that generalises.

## Kotlin passes the store; Zig does not build one

Every other Android action here reaches its platform object through the `Activity`. These four don't, deliberately.

`securePrefs` is `EncryptedSharedPreferences.create(activity, "craft_secure_prefs", masterKey, AES256_SIV, AES256_GCM)` over a lazily-built `MasterKey`. Zig **could** construct that — two builder calls and two enum constants — and constructing it would be a mistake.

It's a second implementation of a security-sensitive construction, in a second language, that has to agree with the first *exactly*. A different key scheme, file name, or SIV mode and the two halves write data neither can read. **Nothing fails at build time.** The symptom is a user's saved token disappearing after an app update.

So the natives take the `SharedPreferences` as a parameter. The object is Kotlin's, the lifetime is Kotlin's, and Zig calls only the plain `SharedPreferences` interface — which is all the Kotlin does too, since `EncryptedSharedPreferences` *is* one and the encryption sits behind the interface.

**This generalises:** where the shim already holds a configured platform object, handing it across the seam beats rebuilding it.

## `secureGet` has three answers where the others have two

The Kotlin returns `String?`, and null there means *"no such key"*. The seam also needs *"Zig did not serve this"* — and a nullable String can't carry both, because the caller does different things about them.

There's no spare value to steal: `""` is a legitimate stored value, and so is any sentinel a caller could have saved. So the reply is a `{"found":…}` envelope, null is reserved for declined, and the holder decodes it into a sealed `SecureRead`:

```kotlin
when (val read = CraftNative.secureGet(securePrefs, key)) {
    is CraftNative.SecureRead.Found -> return read.value   // may be ""
    CraftNative.SecureRead.NotFound -> return null
    CraftNative.SecureRead.Declined -> Unit                // fall through
}
```

## A mutation that wasn't caught

Returning `""` for an absent key **passed every test in the file.** I'd tested `renderRead` and not `get` — and the absent-versus-empty distinction is settled in `get`, against `getString(key, null)`.

A fake `SharedPreferences` covers it now, including end to end, because the two halves are only correct together: a `get` that loses the distinction and a `renderRead` that keeps it still produce `{"found":true}` for a key nobody stored.

| mutation | before | after |
| --- | --- | --- |
| quotes dropped from the envelope | caught | caught |
| absent key returned as `""` | **not caught** | caught, by two tests |

## `apply`, not `commit`

Matching the Kotlin. `apply` returns void, so a disk failure is invisible to both implementations and `true` means *the edit was accepted*, not *persisted*. Switching to `commit` would make Zig report a truth the shim doesn't — a divergence even when it's an improvement.

## The conformance check earned its keep

I registered the four natives before writing the Kotlin half, and got `RegisteredNativeNotDeclared` at build time — rather than `RegisterNatives` refusing the whole batch at load, on a device, with every action silently dropping to the shim.

`zig build test:android` → 92 tests, 11/11 steps · both `.so` build · generator 10/10.
