### PR TITLE
test(android): the deferral table, and the no-op it was needed for

### DIFF
--- a/packages/zig/test/android_conformance_test.zig
+++ b/packages/zig/test/android_conformance_test.zig
@@ -124,6 +124,76 @@ fn collectZigActions(allocator: std.mem.Allocator) !std.StringHashMap(void) {
     return set;
 }
 
+const Deferral = struct {
+    action: []const u8,
+    reason: []const u8,
+};
+
+/// Actions deliberately left on the Kotlin, with the reason each is left.
+///
+/// The iOS table this mirrors exists because three of its reasons had expired
+/// and nothing re-checked them — a migration is where prose goes stale fastest,
+/// since the thing a reason describes is exactly what the next commit changes.
+/// So the table arrives here with the first row that needs it rather than after
+/// the tenth, and the two guards below are the whole point: a row Zig starts
+/// serving fails, and so does a row naming an action the Kotlin no longer has.
+///
+/// Deliberately non-exhaustive. Ninety-one actions are unmigrated and almost
+/// all of them are simply not reached yet, which is an honest state that needs
+/// no row. A reason is owed only where someone would otherwise try and find
+/// out the hard way — and demanding one for the rest would invite an invented
+/// reason, which is worse than silence.
+const deliberate_deferrals = [_]Deferral{
+    // Not a capability gap: the Kotlin builds a `NotificationManagerCompat`,
+    // discards it, never reads `count`, and returns. The real work is left as
+    // two comments. Migrating it would mean porting a no-op — the same reason
+    // the iOS table refuses `startVideoRecording`, whose success path has never
+    // run.
+    //
+    // Android has no first-party badge API and the Kotlin's comment is right
+    // about that; launchers implement it through vendor broadcasts. But the
+    // page cannot tell, because the same call works on iOS. Tracked in #148.
+    .{ .action = "setBadge", .reason = "the Kotlin discards the manager it builds and never reads count; there is no working contract to port" },
+    .{ .action = "clearBadge", .reason = "delegates to setBadge, which does nothing" },
+};
+
+test "every recorded deferral is real, and still a deferral" {
+    // The anti-rot property. A deferral that has been migrated must fail here
+    // rather than sit in a list telling the next reader not to bother.
+    var spec = try collectSpecActions(testing.allocator);
+    defer spec.deinit();
+
+    var zig = try collectZigActions(testing.allocator);
+    defer zig.deinit();
+
+    for (deliberate_deferrals) |d| {
+        if (!spec.contains(d.action)) {
+            std.debug.print(
+                "the deferral table names `{s}`, which CraftBridge.kt does not expose — " ++
+                    "typo, or the method was renamed.\n",
+                .{d.action},
+            );
+            return error.DeferralNamesNoSuchAction;
+        }
+        if (zig.contains(d.action)) {
+            std.debug.print(
+                "the deferral table still lists `{s}`, but Zig serves it now — " ++
+                    "delete the row, its reason is spent.\n",
+                .{d.action},
+            );
+            return error.DeferralAlreadyMigrated;
+        }
+        // A reason is the entire point of the row.
+        try testing.expect(d.reason.len > 0);
+    }
+
+    // Non-vacuity: the loop above is satisfied by an empty table.
+    try testing.expect(deliberate_deferrals.len >= 2);
+
+    // And the table cannot claim more than remain unmigrated.
+    try testing.expect(deliberate_deferrals.len <= max_not_yet_migrated);
+}
+
 test "the spec scan finds the bridge, and finds methods in it" {
     // Non-vacuity, first. Every assertion below is a membership check, and a
     // scan that silently matched nothing would satisfy all of them.


### PR DESCRIPTION
Reports #148.

## `setBadge` does nothing

```kotlin
fun setBadge(count: Int) {
    try {
        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
            val notificationManager = NotificationManagerCompat.from(activity)
            // Badge is typically shown via notification count
            // Full implementation would require creating a notification
        }
    } catch (e: Exception) { log("Badge not supported: ${e.message}") }
}
```

It builds a `NotificationManagerCompat`, discards it, never reads `count`, and returns. The real work is two comments. `clearBadge` delegates to it.

**Every part of the surface reports success anyway:**

- the injected JS exposes it — `setBadge: function(count) { CraftAndroid.setBadge(count) }`
- `craft.d.ts:506` declares `setBadge(count: number): void` for both platforms
- the `catch` only fires on an exception, and nothing here throws — so not even a log line

And the same call **works on iOS**, where `bridge_mobile_display.zig` implements it for real including badge authorization. A page setting an unread count is correct on one platform and quietly wrong on the other, with nothing anywhere to say which.

## Which is why it needs a row, and a row needs a table

Migrating it would mean **porting a no-op** — exactly what the iOS table already refuses for `startVideoRecording` (#115), for the same reason: there's no working contract to carry across.

The iOS deferral table exists because three of its reasons had expired and nothing re-checked them. A migration is where prose goes stale fastest, since what a reason describes is precisely what the next commit changes. So this table arrives with **the first row that needs it** rather than after the tenth.

| mutation | result |
| --- | --- |
| table names a method the Kotlin lacks | `DeferralNamesNoSuchAction` |
| Zig starts serving a deferred action | `DeferralAlreadyMigrated` |
| table emptied below its floor | the non-vacuity check |

## Deliberately non-exhaustive

Ninety-one actions are unmigrated and almost all are simply **not reached yet** — an honest state that needs no row. Demanding a reason for those would invite an invented one, which is worse than silence. A reason is owed only where someone would otherwise try and find out the hard way.

`zig build test:android` → 109 tests, 11/11 steps.
