### PR TITLE
feat(android): the notification cancels, and the flashlight pair deferred

### DIFF
--- a/packages/android/templates/CraftBridge.kt.template
+++ b/packages/android/templates/CraftBridge.kt.template
@@ -2414,12 +2414,16 @@ class CraftBridge(
 
     @JavascriptInterface
     fun cancelNotification(id: String) {
+        if (CraftNative.cancelNotification(activity, id)) return
+
         val notificationManager = activity.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.cancel(id.hashCode())
     }
 
     @JavascriptInterface
     fun cancelAllNotifications() {
+        if (CraftNative.cancelAllNotifications(activity)) return
+
         val notificationManager = activity.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.cancelAll()
     }

--- a/packages/android/templates/CraftNative.kt.template
+++ b/packages/android/templates/CraftNative.kt.template
@@ -72,6 +72,8 @@ object CraftNative {
     private external fun nativeSecureClear(prefs: SharedPreferences): Boolean
     private external fun nativeHaptic(activity: Activity, style: String): Boolean
     private external fun nativeVibrate(activity: Activity, patternJson: String): Boolean
+    private external fun nativeCancelNotification(activity: Activity, id: String): Boolean
+    private external fun nativeCancelAllNotifications(activity: Activity): Boolean
 
     /**
      * `getDeviceInfo`, or null to use the Kotlin implementation.
@@ -274,6 +276,26 @@ object CraftNative {
         if (!isAvailable) return false
         return try {
             nativeVibrate(activity, patternJson)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    /** Returns whether Zig cancelled it; false falls through. */
+    fun cancelNotification(activity: Activity, id: String): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeCancelNotification(activity, id)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    /** Returns whether Zig cancelled them all; false falls through. */
+    fun cancelAllNotifications(activity: Activity): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeCancelAllNotifications(activity)
         } catch (e: UnsatisfiedLinkError) {
             false
         }

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -452,6 +452,9 @@ pub fn build(b: *std.Build) void {
     android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_haptics.zig", .{
         .root_source_file = b.path("src/bridge_android_haptics.zig"),
     });
+    android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_notifcancel.zig", .{
+        .root_source_file = b.path("src/bridge_android_notifcancel.zig"),
+    });
     const run_android_conformance_tests = b.addRunArtifact(android_conformance_tests);
 
     // The page surface, across both bridges. Not folded into the iOS

--- a/packages/zig/src/android_dispatch.zig
+++ b/packages/zig/src/android_dispatch.zig
@@ -43,6 +43,7 @@ const intents = @import("bridge_android_intents.zig");
 const network = @import("bridge_android_network.zig");
 const securestore = @import("bridge_android_securestore.zig");
 const haptics = @import("bridge_android_haptics.zig");
+const notifcancel = @import("bridge_android_notifcancel.zig");
 
 const Jni = jni.Jni;
 
@@ -200,6 +201,16 @@ const natives = [_]jni.JNINativeMethod{
         .name = "nativeVibrate",
         .signature = "(Landroid/app/Activity;Ljava/lang/String;)Z",
         .fnPtr = @ptrCast(&nativeVibrate),
+    },
+    .{
+        .name = "nativeCancelNotification",
+        .signature = "(Landroid/app/Activity;Ljava/lang/String;)Z",
+        .fnPtr = @ptrCast(&nativeCancelNotification),
+    },
+    .{
+        .name = "nativeCancelAllNotifications",
+        .signature = "(Landroid/app/Activity;)Z",
+        .fnPtr = @ptrCast(&nativeCancelAllNotifications),
     },
 };
 
@@ -545,6 +556,32 @@ fn nativeVibrate(
     return jni.JNI_TRUE;
 }
 
+/// The jstring goes through untouched — the id is hashed by Java, and
+/// converting to UTF-8 first would throw away the representation the hash is
+/// defined over. See bridge_android_notifcancel.
+fn nativeCancelNotification(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+    id: jni.jstring,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+    notifcancel.cancel(j, activity, id) catch |err| {
+        std.log.warn("craft: cancelNotification fell through to the shim ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+    return jni.JNI_TRUE;
+}
+
+fn nativeCancelAllNotifications(env: jni.JNIEnv, _: jni.jobject, activity: jni.jobject) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+    notifcancel.cancelAll(j, activity) catch |err| {
+        std.log.warn("craft: cancelAllNotifications fell through to the shim ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+    return jni.JNI_TRUE;
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -656,7 +693,7 @@ test "the registered natives name methods the Kotlin actually declares" {
     // A descriptor is checked by the JVM at registration, so a wrong one fails
     // at load rather than at call — but only if the *name* matches something.
     // These two strings are the contract with CraftBridge.kt.
-    try testing.expectEqual(@as(usize, 14), natives.len);
+    try testing.expectEqual(@as(usize, 16), natives.len);
     try testing.expectEqualStrings("nativeGetDeviceInfo", std.mem.span(natives[0].name));
 
     // And the class they bind to is the fixed one, not the templated bridge.

--- a/packages/zig/src/bridge_android_notifcancel.zig
+++ b/packages/zig/src/bridge_android_notifcancel.zig
@@ -1,0 +1,217 @@
+//! `cancelNotification` and `cancelAllNotifications` on Android.
+//!
+//! ## The id is hashed by Java, not by Zig
+//!
+//! `NotificationManager.cancel` takes an `int`, and the page sends a string —
+//! so the Kotlin cancels `id.hashCode()`. Getting that number wrong cancels a
+//! different notification or none at all, silently either way.
+//!
+//! Zig could reimplement it: `h = 31*h + c` over the characters, wrapping at
+//! 32 bits. It does not, and the reason is not effort. Java hashes **UTF-16
+//! code units**, so a notification id carrying an emoji is two surrogate units
+//! there and four bytes in the UTF-8 this bridge otherwise works in — and the
+//! two produce different numbers. Reproducing that means converting back to
+//! UTF-16 first, which is reimplementing the encoding to reimplement the hash.
+//!
+//! Calling `hashCode()` on the `jstring` the JVM already holds cannot diverge.
+//! It costs one JNI call on a path that makes four, and it is the same
+//! judgement `bridge_android_securestore.zig` makes about the store: where the
+//! platform already has the thing, ask it rather than rebuild it.
+//!
+//! The cost is that nothing here is host-testable, and that is the honest
+//! trade — a test of a hash this file does not compute would be testing a
+//! second implementation that does not ship.
+//!
+//! ## Cancelling an unknown id is a no-op that still succeeds
+//!
+//! `cancel` ignores an id it does not have, and so does the Kotlin. That
+//! matches the iOS notification cancels next door, which document the same
+//! idempotence for the same reason: a page clearing a notification it already
+//! dismissed has done nothing wrong.
+
+const std = @import("std");
+const jni = @import("jni_runtime.zig");
+
+const Jni = jni.Jni;
+const jobject = jni.jobject;
+
+pub const A = struct {
+    pub const cancel_notification = "cancelNotification";
+    pub const cancel_all_notifications = "cancelAllNotifications";
+};
+
+/// `activity.getSystemService(Context.NOTIFICATION_SERVICE)`.
+fn notificationManager(j: Jni, activity: jobject) !jobject {
+    const context_cls = try j.findClass("android/content/Context");
+    const name = try j.staticObjectField(
+        context_cls,
+        try j.staticFieldId(context_cls, "NOTIFICATION_SERVICE", "Ljava/lang/String;"),
+    );
+
+    const activity_cls = try j.objectClass(activity);
+    return j.callObjectMethodA(
+        activity,
+        try j.methodId(activity_cls, "getSystemService", "(Ljava/lang/String;)Ljava/lang/Object;"),
+        &.{.{ .l = name }},
+    );
+}
+
+/// `notificationManager.cancel(id.hashCode())`.
+///
+/// Takes the `jstring` rather than a Zig slice on purpose: the hash has to
+/// come from the Java object, and converting to UTF-8 first would throw away
+/// exactly the representation the hash is defined over.
+pub fn cancel(j: Jni, activity: jobject, id: jni.jstring) !void {
+    if (id == null) return jni.JniError.NullReference;
+
+    try j.pushLocalFrame(16);
+    defer _ = j.popLocalFrame(null);
+
+    const id_cls = try j.objectClass(id);
+    const hash = try j.callIntMethod(id, try j.methodId(id_cls, "hashCode", "()I"));
+
+    const manager = try notificationManager(j, activity);
+    const manager_cls = try j.objectClass(manager);
+    try j.callVoidMethodA(
+        manager,
+        try j.methodId(manager_cls, "cancel", "(I)V"),
+        &.{.{ .i = hash }},
+    );
+}
+
+/// `notificationManager.cancelAll()`.
+pub fn cancelAll(j: Jni, activity: jobject) !void {
+    try j.pushLocalFrame(16);
+    defer _ = j.popLocalFrame(null);
+
+    const manager = try notificationManager(j, activity);
+    const manager_cls = try j.objectClass(manager);
+    try j.callVoidMethodA(
+        manager,
+        try j.methodId(manager_cls, "cancelAll", "()V"),
+        &.{},
+    );
+}
+
+// =============================================================================
+// Tests
+//
+// A fake NotificationManager, because the one thing worth pinning here is the
+// *sequence*: the id must be hashed by Java and the result handed to `cancel`,
+// rather than any other integer reaching it.
+// =============================================================================
+
+const testing = std.testing;
+
+var fake_storage: [8]u8 = undefined;
+var fake_cancelled_with: jni.jint = 0;
+var fake_cancel_all_called = false;
+var fake_hash: jni.jint = 0;
+
+fn cobj(tag: usize) jobject {
+    return @ptrCast(&fake_storage[tag]);
+}
+fn cName(id: ?*anyopaque) []const u8 {
+    return std.mem.span(@as([*:0]const u8, @ptrCast(id.?)));
+}
+fn cFindClass(_: jni.JNIEnv, _: [*:0]const u8) callconv(.c) jni.jclass {
+    return cobj(0);
+}
+fn cObjectClass(_: jni.JNIEnv, _: jobject) callconv(.c) jni.jclass {
+    return cobj(0);
+}
+fn cStaticFieldId(_: jni.JNIEnv, _: jni.jclass, _: [*:0]const u8, _: [*:0]const u8) callconv(.c) jni.jfieldID {
+    return cobj(1);
+}
+fn cStaticObjectField(_: jni.JNIEnv, _: jni.jclass, _: jni.jfieldID) callconv(.c) jobject {
+    return cobj(2);
+}
+fn cMethodId(_: jni.JNIEnv, _: jni.jclass, name: [*:0]const u8, _: [*:0]const u8) callconv(.c) jni.jmethodID {
+    return @ptrCast(@constCast(name));
+}
+fn cCallIntMethod(_: jni.JNIEnv, _: jobject, id: jni.jmethodID) callconv(.c) jni.jint {
+    // Only `hashCode` reaches here, and answering something recognisable is
+    // what lets the assertion below be about the wiring rather than the value.
+    if (std.mem.eql(u8, cName(id), "hashCode")) return fake_hash;
+    return 0;
+}
+fn cCallObjectMethodA(_: jni.JNIEnv, _: jobject, _: jni.jmethodID, _: [*]const jni.jvalue) callconv(.c) jobject {
+    return cobj(3);
+}
+fn cCallVoidMethodA(_: jni.JNIEnv, _: jobject, id: jni.jmethodID, args: [*]const jni.jvalue) callconv(.c) void {
+    const name = cName(id);
+    if (std.mem.eql(u8, name, "cancel")) fake_cancelled_with = args[0].i;
+    if (std.mem.eql(u8, name, "cancelAll")) fake_cancel_all_called = true;
+}
+fn cExceptionOccurred(_: jni.JNIEnv) callconv(.c) jobject {
+    return null;
+}
+fn cPush(_: jni.JNIEnv, _: jni.jint) callconv(.c) jni.jint {
+    return 0;
+}
+fn cPop(_: jni.JNIEnv, keep: jobject) callconv(.c) jobject {
+    return keep;
+}
+
+fn fakeEnv(table: *jni.JNINativeInterface) void {
+    table.* = std.mem.zeroes(jni.JNINativeInterface);
+    table.FindClass = @ptrCast(&cFindClass);
+    table.GetObjectClass = @ptrCast(&cObjectClass);
+    table.GetStaticFieldID = @ptrCast(&cStaticFieldId);
+    table.GetStaticObjectField = @ptrCast(&cStaticObjectField);
+    table.GetMethodID = @ptrCast(&cMethodId);
+    table.CallIntMethod = @ptrCast(&cCallIntMethod);
+    table.CallObjectMethodA = @ptrCast(&cCallObjectMethodA);
+    table.CallVoidMethodA = @ptrCast(&cCallVoidMethodA);
+    table.ExceptionOccurred = @ptrCast(&cExceptionOccurred);
+    table.PushLocalFrame = @ptrCast(&cPush);
+    table.PopLocalFrame = @ptrCast(&cPop);
+    fake_cancelled_with = 0;
+    fake_cancel_all_called = false;
+}
+
+test "the id Java hashed is the id that gets cancelled" {
+    // The claim worth pinning: `cancel` receives `hashCode()`'s answer and not
+    // some other integer. A version that passed a length, an index, or a hash
+    // Zig computed itself would cancel a different notification — silently,
+    // because cancelling an id that does not exist succeeds.
+    var table: jni.JNINativeInterface = undefined;
+    fakeEnv(&table);
+    const ptr: *const jni.JNINativeInterface = &table;
+
+    fake_hash = -1_234_567;
+    try cancel(Jni.init(&ptr), cobj(4), cobj(5));
+    try testing.expectEqual(@as(jni.jint, -1_234_567), fake_cancelled_with);
+
+    // Negative hashes are ordinary — Java's is a signed 32-bit wrap — so the
+    // value must survive the trip unchanged rather than being made positive.
+    fake_hash = 0;
+    try cancel(Jni.init(&ptr), cobj(4), cobj(5));
+    try testing.expectEqual(@as(jni.jint, 0), fake_cancelled_with);
+}
+
+test "a null id is refused rather than cancelling notification zero" {
+    // `hashCode()` on null would throw, but the JNI call would have been made
+    // first — and an unchecked null here reaches `cancel(0)`, which quietly
+    // cancels whatever notification hashes to zero.
+    var table: jni.JNINativeInterface = undefined;
+    fakeEnv(&table);
+    const ptr: *const jni.JNINativeInterface = &table;
+
+    try testing.expectError(jni.JniError.NullReference, cancel(Jni.init(&ptr), cobj(4), null));
+    try testing.expectEqual(@as(jni.jint, 0), fake_cancelled_with);
+}
+
+test "cancelAll asks for cancelAll, not a cancel with some id" {
+    var table: jni.JNINativeInterface = undefined;
+    fakeEnv(&table);
+    const ptr: *const jni.JNINativeInterface = &table;
+
+    try cancelAll(Jni.init(&ptr), cobj(4));
+    try testing.expect(fake_cancel_all_called);
+}
+
+test "the action names match the Kotlin methods exactly" {
+    try testing.expectEqualStrings("cancelNotification", A.cancel_notification);
+    try testing.expectEqualStrings("cancelAllNotifications", A.cancel_all_notifications);
+}

--- a/packages/zig/test/android_conformance_test.zig
+++ b/packages/zig/test/android_conformance_test.zig
@@ -46,6 +46,7 @@ const zig_sources = [_][]const u8{
     @embedFile("src/bridge_android_network.zig"),
     @embedFile("src/bridge_android_securestore.zig"),
     @embedFile("src/bridge_android_haptics.zig"),
+    @embedFile("src/bridge_android_notifcancel.zig"),
 };
 
 /// How many spec actions Zig does not serve yet.
@@ -59,8 +60,9 @@ const zig_sources = [_][]const u8{
 /// clipboard pair, the first that do; 96 with openURL and share; 95 with
 /// getNetworkStatus, which iOS declares unavailable and Android can answer;
 /// 91 with the secure-storage quartet, the first to take a Kotlin-held object
-/// rather than the Activity; 89 with haptic and vibrate.
-const max_not_yet_migrated: usize = 89;
+/// rather than the Activity; 89 with haptic and vibrate; 87 with the
+/// notification cancels.
+const max_not_yet_migrated: usize = 87;
 
 /// Every `@JavascriptInterface fun <name>(` in the Kotlin bridge.
 ///
@@ -156,6 +158,20 @@ const deliberate_deferrals = [_]Deferral{
     // page cannot tell, because the same call works on iOS. Tracked in #148.
     .{ .action = "setBadge", .reason = "the Kotlin discards the manager it builds and never reads count; there is no working contract to port" },
     .{ .action = "clearBadge", .reason = "delegates to setBadge, which does nothing" },
+
+    // Kotlin-held state, not a missing API. `setFlashlight` writes
+    // `isFlashlightOn` (`CraftBridge.kt:2011`) and `toggleFlashlight` reads it
+    // to decide what to flip to (`:2026`). Serving `setFlashlight` from Zig
+    // means the Kotlin's body never runs, so the field stops tracking the
+    // torch — and the next `toggleFlashlight` inverts a stale value and turns
+    // the light on when it is already on.
+    //
+    // Zig cannot update the field either: the natives are registered on
+    // `CraftNative`, which has no reference to the `CraftBridge` instance that
+    // owns it. Migrating the pair together would need the state to move too,
+    // and that is a change to the shim rather than a migration away from it.
+    .{ .action = "setFlashlight", .reason = "writes isFlashlightOn, which toggleFlashlight reads; Zig cannot reach the field" },
+    .{ .action = "toggleFlashlight", .reason = "reads isFlashlightOn, which only the Kotlin setFlashlight maintains" },
 };
 
 test "every recorded deferral is real, and still a deferral" {
@@ -189,7 +205,7 @@ test "every recorded deferral is real, and still a deferral" {
     }
 
     // Non-vacuity: the loop above is satisfied by an empty table.
-    try testing.expect(deliberate_deferrals.len >= 2);
+    try testing.expect(deliberate_deferrals.len >= 4);
 
     // And the table cannot claim more than remain unmigrated.
     try testing.expect(deliberate_deferrals.len <= max_not_yet_migrated);


### PR DESCRIPTION
Ratchet **89 → 87**, plus two deferrals with real reasons.

## The id is hashed by Java, not by Zig

`NotificationManager.cancel` takes an `int` and the page sends a string, so the Kotlin cancels `id.hashCode()`. Getting that number wrong cancels a **different notification, or none** — silently either way, since cancelling an id that doesn't exist succeeds.

Zig could reimplement it: `h = 31*h + c`, wrapping at 32 bits. It doesn't, and the reason isn't effort.

**Java hashes UTF-16 code units.** An id carrying an emoji is two surrogate units there and four bytes in the UTF-8 this bridge otherwise works in, and the two produce different numbers. Reproducing that means converting back to UTF-16 first — reimplementing the encoding in order to reimplement the hash.

Calling `hashCode()` on the `jstring` the JVM already holds **cannot diverge**. Same judgement `bridge_android_securestore.zig` makes about the prefs object: where the platform already has the thing, ask it rather than rebuild it.

The cost is that the hash isn't host-testable, and that's the honest trade — a test of a hash this file doesn't compute would be testing a second implementation that doesn't ship.

## What *is* tested

The wiring: that `hashCode()`'s answer is what reaches `cancel`, and that a null id is refused rather than cancelling whatever notification hashes to zero.

| mutation | result |
| --- | --- |
| `.i = hash + 1` | `expected -1234567, found -1234566` |
| `.i = 0` (drop the hash) | **doesn't compile** — `unused local constant hash` |
| null id check removed | the null test fails |

The second is worth noting: the compiler is a stronger guard than a test here, and that's what `unused local constant` buys. I initially misread it as "not caught" because my grep was matching test-failure format and missed a compile error.

## Two deferrals, recorded

`setFlashlight` writes `isFlashlightOn` ([`:2011`](packages/android/templates/CraftBridge.kt.template#L2011)) and `toggleFlashlight` reads it to decide what to flip to ([`:2026`](packages/android/templates/CraftBridge.kt.template#L2026)).

Serving `setFlashlight` from Zig means the Kotlin body never runs, so the field stops tracking the torch — and the next `toggleFlashlight` inverts a stale value, turning the light on when it's already on.

Zig can't update the field either: the natives are registered on `CraftNative`, which has no reference to the `CraftBridge` instance that owns it. Migrating the pair would mean **moving the state**, which is a change to the shim rather than a migration away from it.

`zig build test:android` → 102 tests, 11/11 steps · both `.so` build · generator 10/10.
