### PR TITLE
feat(android): deleteCalendarEvent — the first action to answer through the channel

### DIFF
--- a/packages/android/templates/CraftBridge.kt.template
+++ b/packages/android/templates/CraftBridge.kt.template
@@ -2350,6 +2350,10 @@ class CraftBridge(
 
     @JavascriptInterface
     fun deleteCalendarEvent(eventId: String) {
+        // Zig answers through the reply channel, so returning here is what
+        // stops the promise being settled twice.
+        if (CraftNative.deleteCalendarEvent(activity, eventId)) return
+
         try {
             val uri = ContentUris.withAppendedId(CalendarContract.Events.CONTENT_URI, eventId.toLong())
             activity.contentResolver.delete(uri, null, null)

--- a/packages/android/templates/CraftNative.kt.template
+++ b/packages/android/templates/CraftNative.kt.template
@@ -107,6 +107,7 @@ object CraftNative {
     private external fun nativeVibrate(activity: Activity, patternJson: String): Boolean
     private external fun nativeCancelNotification(activity: Activity, id: String): Boolean
     private external fun nativeCancelAllNotifications(activity: Activity): Boolean
+    private external fun nativeDeleteCalendarEvent(activity: Activity, eventId: String): Boolean
 
     /**
      * `getDeviceInfo`, or null to use the Kotlin implementation.
@@ -329,6 +330,22 @@ object CraftNative {
         if (!isAvailable) return false
         return try {
             nativeCancelAllNotifications(activity)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    /**
+     * Returns whether Zig *took* the action, not whether the delete worked.
+     *
+     * The first native here that answers asynchronously: the outcome reaches
+     * the page through the reply channel, so true means "do not also run the
+     * Kotlin" and nothing more. Running both would settle the promise twice.
+     */
+    fun deleteCalendarEvent(activity: Activity, eventId: String): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeDeleteCalendarEvent(activity, eventId)
         } catch (e: UnsatisfiedLinkError) {
             false
         }

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -455,6 +455,9 @@ pub fn build(b: *std.Build) void {
     android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_notifcancel.zig", .{
         .root_source_file = b.path("src/bridge_android_notifcancel.zig"),
     });
+    android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_calendar.zig", .{
+        .root_source_file = b.path("src/bridge_android_calendar.zig"),
+    });
     const run_android_conformance_tests = b.addRunArtifact(android_conformance_tests);
 
     // The page surface, across both bridges. Not folded into the iOS

--- a/packages/zig/src/android_dispatch.zig
+++ b/packages/zig/src/android_dispatch.zig
@@ -45,6 +45,7 @@ const securestore = @import("bridge_android_securestore.zig");
 const haptics = @import("bridge_android_haptics.zig");
 const notifcancel = @import("bridge_android_notifcancel.zig");
 const events = @import("android_events.zig");
+const calendar = @import("bridge_android_calendar.zig");
 
 const Jni = jni.Jni;
 
@@ -216,6 +217,14 @@ const natives = [_]jni.JNINativeMethod{
         .name = "nativeCancelAllNotifications",
         .signature = "(Landroid/app/Activity;)Z",
         .fnPtr = @ptrCast(&nativeCancelAllNotifications),
+    },
+    // The first action that answers through the reply channel rather than by
+    // returning. The boolean still means "Zig served it" — the *result* goes
+    // to the page separately, which is exactly the shape iOS's seam has.
+    .{
+        .name = "nativeDeleteCalendarEvent",
+        .signature = "(Landroid/app/Activity;Ljava/lang/String;)Z",
+        .fnPtr = @ptrCast(&nativeDeleteCalendarEvent),
     },
 };
 
@@ -587,6 +596,52 @@ fn nativeCancelAllNotifications(env: jni.JNIEnv, _: jni.jobject, activity: jni.j
     return jni.JNI_TRUE;
 }
 
+/// `nativeDeleteCalendarEvent(activity, eventId)`.
+///
+/// Returns whether Zig took the action, not whether the delete succeeded. The
+/// outcome reaches the page through the reply channel, so a `true` here means
+/// "do not also run the Kotlin" and nothing more — the same distinction
+/// `ios_dispatch` draws between claiming an action and answering it.
+fn nativeDeleteCalendarEvent(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+    event_id: jni.jstring,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const text = j.stringToUtf8(allocator, event_id) catch return jni.JNI_FALSE;
+
+    const id = calendar.parseEventId(text) orelse {
+        // What the shim's NumberFormatException produces, with the message it
+        // produces — but escaped, so an id containing a quote rejects instead
+        // of hanging the promise. See #154.
+        var message: std.ArrayListUnmanaged(u8) = .empty;
+        defer message.deinit(allocator);
+        message.appendSlice(allocator, "For input string: \"") catch return jni.JNI_FALSE;
+        message.appendSlice(allocator, text) catch return jni.JNI_FALSE;
+        message.append(allocator, '"') catch return jni.JNI_FALSE;
+
+        calendar.rejectWith(allocator, message.items) catch return jni.JNI_FALSE;
+        return jni.JNI_TRUE;
+    };
+
+    calendar.deleteEvent(j, activity, id) catch |err| {
+        // A SecurityException for a missing WRITE_CALENDAR permission lands
+        // here, as it lands in the shim's catch. The error name rather than
+        // the Java message: the throwable was already described to logcat and
+        // cleared by `Jni.check`, so its text is gone by now.
+        calendar.rejectWith(allocator, @errorName(err)) catch {};
+        return jni.JNI_TRUE;
+    };
+
+    events.settle(allocator, calendar.resolve_global, "true") catch return jni.JNI_FALSE;
+    return jni.JNI_TRUE;
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -698,7 +753,7 @@ test "the registered natives name methods the Kotlin actually declares" {
     // A descriptor is checked by the JVM at registration, so a wrong one fails
     // at load rather than at call — but only if the *name* matches something.
     // These two strings are the contract with CraftBridge.kt.
-    try testing.expectEqual(@as(usize, 16), natives.len);
+    try testing.expectEqual(@as(usize, 17), natives.len);
     try testing.expectEqualStrings("nativeGetDeviceInfo", std.mem.span(natives[0].name));
 
     // And the class they bind to is the fixed one, not the templated bridge.

--- a/packages/zig/src/bridge_android_calendar.zig
+++ b/packages/zig/src/bridge_android_calendar.zig
@@ -1,0 +1,196 @@
+//! `deleteCalendarEvent` on Android — the first action here that answers
+//! through the reply channel rather than by returning.
+//!
+//! ## What the shim does, and the one thing this does not reproduce
+//!
+//! The Kotlin builds a content URI from the event id, deletes through the
+//! `ContentResolver`, and resolves `true`; on any exception it rejects with
+//! the message. That is all ported.
+//!
+//! What is not ported is how it *sends* the rejection:
+//!
+//!     "window._craftDeleteEventReject && window._craftDeleteEventReject('${e.message}')"
+//!
+//! The message goes into a single-quoted JavaScript string with no escaping,
+//! and `eventId.toLong()` puts the caller's own text in that message —
+//! `NumberFormatException: For input string: "1'x"`. A `'` in the id therefore
+//! produces a script that does not parse, `evaluateJavascript` runs nothing,
+//! and **neither the resolve nor the reject fires**. The promise never
+//! settles, and the injected JS builds it by hand with no timeout, so the page
+//! waits forever with nothing in the console.
+//!
+//! Here the payload is built as JSON through `bridge_error.appendJsonEscaped`,
+//! so the same id rejects normally. That is a divergence in the page's favour
+//! and it is deliberate; the shim keeps the bug on the twenty other paths
+//! until #154 is fixed.
+//!
+//! ## `toLong()` is reproduced exactly, including what it refuses
+//!
+//! `Long.parseLong` accepts an optional sign and decimal digits, and nothing
+//! else — no whitespace, no underscores, no hex, no `+1_000`. Zig's
+//! `parseInt(i64, s, 10)` is more permissive about underscores, so the digits
+//! are checked before parsing. An id the shim would reject must reject here,
+//! or Zig would delete an event the shim would have refused to look up.
+
+const std = @import("std");
+const jni = @import("jni_runtime.zig");
+const events = @import("android_events.zig");
+const bridge_error = @import("bridge_error.zig");
+
+const Jni = jni.Jni;
+const jobject = jni.jobject;
+
+pub const A = struct {
+    pub const delete_calendar_event = "deleteCalendarEvent";
+};
+
+/// The globals the injected JS assigns for this action.
+pub const resolve_global = "_craftDeleteEventResolve";
+pub const reject_global = "_craftDeleteEventReject";
+
+/// `Long.parseLong(text)`, or null where Java would throw.
+///
+/// Deliberately stricter than `std.fmt.parseInt`, which accepts `1_000`.
+/// Java does not, and an id this accepted but the shim would not is an id Zig
+/// would act on and the shim would refuse.
+pub fn parseEventId(text: []const u8) ?i64 {
+    if (text.len == 0) return null;
+
+    var digits = text;
+    if (digits[0] == '+' or digits[0] == '-') digits = digits[1..];
+    if (digits.len == 0) return null;
+
+    for (digits) |c| {
+        if (!std.ascii.isDigit(c)) return null;
+    }
+    return std.fmt.parseInt(i64, text, 10) catch null;
+}
+
+/// `contentResolver.delete(ContentUris.withAppendedId(Events.CONTENT_URI, id), null, null)`.
+pub fn deleteEvent(j: Jni, activity: jobject, id: i64) !void {
+    try j.pushLocalFrame(16);
+    defer _ = j.popLocalFrame(null);
+
+    // `CalendarContract$Events` — a nested class, so the binary name takes the
+    // dollar. `android/provider/CalendarContract/Events` finds nothing.
+    const events_cls = try j.findClass("android/provider/CalendarContract$Events");
+    const base_uri = try j.staticObjectField(
+        events_cls,
+        try j.staticFieldId(events_cls, "CONTENT_URI", "Landroid/net/Uri;"),
+    );
+
+    const content_uris_cls = try j.findClass("android/content/ContentUris");
+    const uri = try j.callStaticObjectMethodA(
+        content_uris_cls,
+        try j.staticMethodId(
+            content_uris_cls,
+            "withAppendedId",
+            "(Landroid/net/Uri;J)Landroid/net/Uri;",
+        ),
+        &.{ .{ .l = base_uri }, .{ .j = id } },
+    );
+
+    const activity_cls = try j.objectClass(activity);
+    const resolver = try j.callObjectMethod(
+        activity,
+        try j.methodId(activity_cls, "getContentResolver", "()Landroid/content/ContentResolver;"),
+    );
+
+    // The row count is discarded, as the Kotlin discards it. Deleting an event
+    // that is not there returns 0 and is not an error on either side — a page
+    // removing something already gone has done nothing wrong.
+    const resolver_cls = try j.objectClass(resolver);
+    _ = try j.callIntMethodA(
+        resolver,
+        try j.methodId(
+            resolver_cls,
+            "delete",
+            "(Landroid/net/Uri;Ljava/lang/String;[Ljava/lang/String;)I",
+        ),
+        &.{ .{ .l = uri }, .{ .l = null }, .{ .l = null } },
+    );
+}
+
+/// Reject with `message`, escaped.
+///
+/// The escaping is the whole point of this function existing rather than the
+/// call being inline — see the module comment and #154.
+pub fn rejectWith(allocator: std.mem.Allocator, message: []const u8) !void {
+    const payload = try rejectPayload(allocator, message);
+    defer allocator.free(payload);
+    try events.settle(allocator, reject_global, payload);
+}
+
+/// `message` as a JSON string, quotes included.
+///
+/// Split out so the test exercises this rather than a copy of it. An earlier
+/// version inlined the escaping here and asserted on the same three lines
+/// rewritten in the test — which passed happily when the escaping was removed
+/// from the code, because the test was not calling the code.
+pub fn rejectPayload(allocator: std.mem.Allocator, message: []const u8) ![]u8 {
+    var payload: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer payload.deinit(allocator);
+
+    // The quotes are this caller's job: `appendJsonEscaped` escapes the
+    // contents and writes no delimiters.
+    try payload.append(allocator, '"');
+    try bridge_error.appendJsonEscaped(allocator, &payload, message);
+    try payload.append(allocator, '"');
+
+    return payload.toOwnedSlice(allocator);
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+const testing = std.testing;
+
+test "an id parses exactly where Long.parseLong would" {
+    try testing.expectEqual(@as(i64, 42), parseEventId("42").?);
+    try testing.expectEqual(@as(i64, -42), parseEventId("-42").?);
+    try testing.expectEqual(@as(i64, 42), parseEventId("+42").?);
+    try testing.expectEqual(@as(i64, 0), parseEventId("0").?);
+    try testing.expectEqual(@as(i64, 9_223_372_036_854_775_807), parseEventId("9223372036854775807").?);
+}
+
+test "an id Java would refuse is refused here too" {
+    // Each of these throws NumberFormatException on the shim, so each must
+    // reject here. An id Zig accepted and the shim did not is an id Zig would
+    // delete an event for that the shim would never have looked up.
+    for ([_][]const u8{
+        "",      "abc",                 "1'x", " 42", "42 ", "4 2", "0x2a", "1e3", "42L", "+", "-",
+        "٤٢",
+        // Zig's parseInt accepts this and Java does not.
+        "1_000",
+        // Past Long.MAX_VALUE.
+        "9223372036854775808",
+    }) |bad| {
+        try testing.expect(parseEventId(bad) == null);
+    }
+}
+
+test "a rejection message with a quote is escaped rather than emitted raw" {
+    // The bug this action does not reproduce. On the shim, an id of `1'x`
+    // produces `…Reject('For input string: "1'x"')`, which does not parse — so
+    // evaluateJavascript runs nothing and the promise never settles.
+    const payload = try rejectPayload(testing.allocator, "For input string: \"1'x\"");
+    defer testing.allocator.free(payload);
+
+    // Valid JSON, and it round-trips to exactly the original message.
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, payload, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("For input string: \"1'x\"", parsed.value.string);
+
+    // And the apostrophe survives as itself rather than as an escape, which is
+    // what makes the emitted script parse where the shim's does not.
+    try testing.expect(std.mem.indexOf(u8, payload, "'") != null);
+}
+
+test "the action name and its globals match the shim exactly" {
+    // The globals are assigned by the injected JS, and a rename on either side
+    // is a promise that never settles.
+    try testing.expectEqualStrings("deleteCalendarEvent", A.delete_calendar_event);
+    try testing.expectEqualStrings("_craftDeleteEventResolve", resolve_global);
+    try testing.expectEqualStrings("_craftDeleteEventReject", reject_global);
+}

--- a/packages/zig/src/jni_runtime.zig
+++ b/packages/zig/src/jni_runtime.zig
@@ -624,6 +624,14 @@ pub const Jni = struct {
         return result;
     }
 
+    pub fn callIntMethodA(self: Self, obj: jobject, id: jmethodID, args: []const jvalue) JniError!jint {
+        const call: *const fn (JNIEnv, jobject, jmethodID, [*]const jvalue) callconv(.c) jint =
+            @ptrCast(self.table().CallIntMethodA orelse return JniError.NotFound);
+        const result = call(self.env, obj, id, args.ptr);
+        try self.check();
+        return result;
+    }
+
     pub fn callBooleanMethodA(self: Self, obj: jobject, id: jmethodID, args: []const jvalue) JniError!bool {
         const call: *const fn (JNIEnv, jobject, jmethodID, [*]const jvalue) callconv(.c) jboolean =
             @ptrCast(self.table().CallBooleanMethodA orelse return JniError.NotFound);

--- a/packages/zig/test/android_conformance_test.zig
+++ b/packages/zig/test/android_conformance_test.zig
@@ -47,6 +47,7 @@ const zig_sources = [_][]const u8{
     @embedFile("src/bridge_android_securestore.zig"),
     @embedFile("src/bridge_android_haptics.zig"),
     @embedFile("src/bridge_android_notifcancel.zig"),
+    @embedFile("src/bridge_android_calendar.zig"),
 };
 
 /// How many spec actions Zig does not serve yet.
@@ -61,8 +62,9 @@ const zig_sources = [_][]const u8{
 /// getNetworkStatus, which iOS declares unavailable and Android can answer;
 /// 91 with the secure-storage quartet, the first to take a Kotlin-held object
 /// rather than the Activity; 89 with haptic and vibrate; 87 with the
-/// notification cancels.
-const max_not_yet_migrated: usize = 87;
+/// notification cancels; 86 with deleteCalendarEvent, the first to answer
+/// through the reply channel rather than by returning.
+const max_not_yet_migrated: usize = 86;
 
 /// Every `@JavascriptInterface fun <name>(` in the Kotlin bridge.
 ///


### PR DESCRIPTION
Ratchet **87 → 86**, and the reply channel (#152) gets its first user.

## What the boolean means

The native returns whether Zig **took** the action, not whether the delete worked. The outcome reaches the page through the channel, so `true` is what stops the Kotlin also running and settling the promise a second time — the same distinction `ios_dispatch` draws between *claiming* an action and *answering* it.

## The one thing deliberately not ported

```kotlin
"window._craftDeleteEventReject && window._craftDeleteEventReject('${e.message}')"
```

The message goes into a single-quoted JavaScript string **unescaped**, and `eventId.toLong()` puts the caller's own text in that message:

```
craft.calendar.delete("1'x")
  → NumberFormatException: For input string: "1'x"
  → …Reject('For input string: "1'x"')
                                  ^ string ends here → SyntaxError
  → evaluateJavascript runs nothing; neither resolve nor reject fires
```

The injected JS builds this promise by hand with **no timeout**, so the page waits forever with nothing in the console. Twenty other paths do the same — filed as #154.

Here the payload is JSON through `appendJsonEscaped`, so the same id rejects normally. A divergence in the page's favour, and deliberate.

## `toLong()` is reproduced including what it refuses

`Long.parseLong` takes an optional sign and decimal digits and nothing else. Zig's `parseInt` also accepts `1_000`. So the digits are checked before parsing — **an id Zig accepted and the shim didn't is an id Zig would delete an event for that the shim would never have looked up.**

Tested against `""`, `"abc"`, `"1'x"`, `" 42"`, `"0x2a"`, `"1e3"`, `"42L"`, `"١٤٢"`, `"1_000"`, and `Long.MAX_VALUE + 1`.

## A test that passed for the wrong reason

The escaping test built its payload **inline** rather than calling `rejectPayload` — so removing the escaping from the code left it green. It was asserting about three lines rewritten in the test, not about the code.

| mutation | before | after |
| --- | --- | --- |
| digit pre-check dropped | caught | caught |
| escaping dropped from the rejection | **not caught** | caught |

Extracted into `rejectPayload`, which the test now calls. Worth flagging because it's the third time this session a test needed to be checked by mutating rather than trusted by reading.

`zig build test:android` → 112 tests, 11/11 steps · both `.so` build · generator 10/10.
