### PR TITLE
fix(android): an apostrophe in a reply hangs the page forever

### DIFF
--- a/packages/android/templates/CraftBridge.kt.template
+++ b/packages/android/templates/CraftBridge.kt.template
@@ -166,6 +166,20 @@ class CraftBridge(
         )
     }
 
+    /**
+     * Quote a value for interpolation into JavaScript.
+     *
+     * The result carries its own quotes, so write `f($payload)` — leaving the
+     * surrounding `'...'` in place would quote it twice. A Kotlin null renders as
+     * the string "null", which is what plain interpolation produced before; whether
+     * that should instead be a JS null is a separate question from escaping.
+     *
+     * Without this, a value containing an apostrophe ends the JS string early, the
+     * script fails to parse, and `evaluateJavascript` runs nothing at all — so a
+     * hand-built promise with no timeout never settles.
+     */
+    private fun jsQuote(value: String?): String = JSONObject.quote(value ?: "null")
+
     fun injectBridge() {
         // Before the script, so a native callback arriving while the page is
         // still loading has somewhere to go rather than being counted as
@@ -1474,7 +1488,7 @@ class CraftBridge(
 
         val event = if (requestCode == REQUEST_CAMERA) "_craftCameraResolve" else "_craftGalleryResolve"
         activity.runOnUiThread {
-            webView.evaluateJavascript("window.$event && window.$event('$imageUri')", null)
+            webView.evaluateJavascript("window.$event && window.$event(${jsQuote(imageUri)})", null)
         }
     }
 
@@ -1525,7 +1539,7 @@ class CraftBridge(
 
                     override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
                         webView.evaluateJavascript(
-                            "window._craftBiometricReject && window._craftBiometricReject('$errString')",
+                            "window._craftBiometricReject && window._craftBiometricReject(${jsQuote(errString)})",
                             null
                         )
                     }
@@ -1655,7 +1669,7 @@ class CraftBridge(
         }?.addOnFailureListener { e ->
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftLocationReject && window._craftLocationReject({code: 2, message: '${e.message}'})",
+                    "window._craftLocationReject && window._craftLocationReject({code: 2, message: ${jsQuote(e.message)}})",
                     null
                 )
             }
@@ -2110,7 +2124,7 @@ class CraftBridge(
             currentAppState = newState
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftAppStateCallback && window._craftAppStateCallback('$currentAppState')",
+                    "window._craftAppStateCallback && window._craftAppStateCallback(${jsQuote(currentAppState)})",
                     null
                 )
             }
@@ -2247,11 +2261,11 @@ class CraftBridge(
             val contactId = ContentUris.parseId(results[0].uri!!)
 
             activity.runOnUiThread {
-                webView.evaluateJavascript("window._craftAddContactResolve && window._craftAddContactResolve('$contactId')", null)
+                webView.evaluateJavascript("window._craftAddContactResolve && window._craftAddContactResolve(${jsQuote(contactId)})", null)
             }
         } catch (e: Exception) {
             activity.runOnUiThread {
-                webView.evaluateJavascript("window._craftAddContactReject && window._craftAddContactReject('${e.message}')", null)
+                webView.evaluateJavascript("window._craftAddContactReject && window._craftAddContactReject(${jsQuote(e.message)})", null)
             }
         }
     }
@@ -2339,11 +2353,11 @@ class CraftBridge(
             val eventId = uri?.lastPathSegment ?: ""
 
             activity.runOnUiThread {
-                webView.evaluateJavascript("window._craftCreateEventResolve && window._craftCreateEventResolve('$eventId')", null)
+                webView.evaluateJavascript("window._craftCreateEventResolve && window._craftCreateEventResolve(${jsQuote(eventId)})", null)
             }
         } catch (e: Exception) {
             activity.runOnUiThread {
-                webView.evaluateJavascript("window._craftCreateEventReject && window._craftCreateEventReject('${e.message}')", null)
+                webView.evaluateJavascript("window._craftCreateEventReject && window._craftCreateEventReject(${jsQuote(e.message)})", null)
             }
         }
     }
@@ -2362,7 +2376,7 @@ class CraftBridge(
             }
         } catch (e: Exception) {
             activity.runOnUiThread {
-                webView.evaluateJavascript("window._craftDeleteEventReject && window._craftDeleteEventReject('${e.message}')", null)
+                webView.evaluateJavascript("window._craftDeleteEventReject && window._craftDeleteEventReject(${jsQuote(e.message)})", null)
             }
         }
     }
@@ -2399,11 +2413,11 @@ class CraftBridge(
             }
 
             activity.runOnUiThread {
-                webView.evaluateJavascript("window._craftNotifResolve && window._craftNotifResolve('$id')", null)
+                webView.evaluateJavascript("window._craftNotifResolve && window._craftNotifResolve(${jsQuote(id)})", null)
             }
         } catch (e: Exception) {
             activity.runOnUiThread {
-                webView.evaluateJavascript("window._craftNotifReject && window._craftNotifReject('${e.message}')", null)
+                webView.evaluateJavascript("window._craftNotifReject && window._craftNotifReject(${jsQuote(e.message)})", null)
             }
         }
     }
@@ -2496,7 +2510,7 @@ class CraftBridge(
             })
         } catch (e: Exception) {
             activity.runOnUiThread {
-                webView.evaluateJavascript("window._craftProductsReject && window._craftProductsReject('${e.message}')", null)
+                webView.evaluateJavascript("window._craftProductsReject && window._craftProductsReject(${jsQuote(e.message)})", null)
             }
         }
     }
@@ -2625,14 +2639,14 @@ class CraftBridge(
 
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftDownloadResolve && window._craftDownloadResolve('$downloadId')",
+                    "window._craftDownloadResolve && window._craftDownloadResolve(${jsQuote(downloadId)})",
                     null
                 )
             }
         } catch (e: Exception) {
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftDownloadReject && window._craftDownloadReject('${e.message}')",
+                    "window._craftDownloadReject && window._craftDownloadReject(${jsQuote(e.message)})",
                     null
                 )
             }
@@ -2658,14 +2672,14 @@ class CraftBridge(
 
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftSaveResolve && window._craftSaveResolve('${file.absolutePath}')",
+                    "window._craftSaveResolve && window._craftSaveResolve(${jsQuote(file.absolutePath)})",
                     null
                 )
             }
         } catch (e: Exception) {
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftSaveReject && window._craftSaveReject('${e.message}')",
+                    "window._craftSaveReject && window._craftSaveReject(${jsQuote(e.message)})",
                     null
                 )
             }
@@ -2723,7 +2737,7 @@ class CraftBridge(
             }
         } catch (e: Exception) {
             activity.runOnUiThread {
-                webView.evaluateJavascript("window._craftAudioReject && window._craftAudioReject('${e.message}')", null)
+                webView.evaluateJavascript("window._craftAudioReject && window._craftAudioReject(${jsQuote(e.message)})", null)
             }
         }
     }
@@ -2739,7 +2753,7 @@ class CraftBridge(
                 val bytes = file.readBytes()
                 val base64 = "data:audio/m4a;base64," + Base64.encodeToString(bytes, Base64.NO_WRAP)
                 activity.runOnUiThread {
-                    webView.evaluateJavascript("window._craftAudioStopResolve && window._craftAudioStopResolve('$base64')", null)
+                    webView.evaluateJavascript("window._craftAudioStopResolve && window._craftAudioStopResolve(${jsQuote(base64)})", null)
                 }
             } ?: run {
                 activity.runOnUiThread {
@@ -2748,7 +2762,7 @@ class CraftBridge(
             }
         } catch (e: Exception) {
             activity.runOnUiThread {
-                webView.evaluateJavascript("window._craftAudioStopReject && window._craftAudioStopReject('${e.message}')", null)
+                webView.evaluateJavascript("window._craftAudioStopReject && window._craftAudioStopReject(${jsQuote(e.message)})", null)
             }
         }
     }
@@ -2835,7 +2849,7 @@ class CraftBridge(
         } catch (e: Exception) {
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftDbExecReject && window._craftDbExecReject('${e.message}')",
+                    "window._craftDbExecReject && window._craftDbExecReject(${jsQuote(e.message)})",
                     null
                 )
             }
@@ -2875,7 +2889,7 @@ class CraftBridge(
         } catch (e: Exception) {
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftDbQueryReject && window._craftDbQueryReject('${e.message}')",
+                    "window._craftDbQueryReject && window._craftDbQueryReject(${jsQuote(e.message)})",
                     null
                 )
             }
@@ -2980,9 +2994,9 @@ class CraftBridge(
                 bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
                 val base64 = "data:image/png;base64," + Base64.encodeToString(outputStream.toByteArray(), Base64.NO_WRAP)
 
-                webView.evaluateJavascript("window._craftScreenshotResolve && window._craftScreenshotResolve('$base64')", null)
+                webView.evaluateJavascript("window._craftScreenshotResolve && window._craftScreenshotResolve(${jsQuote(base64)})", null)
             } catch (e: Exception) {
-                webView.evaluateJavascript("window._craftScreenshotReject && window._craftScreenshotReject('${e.message}')", null)
+                webView.evaluateJavascript("window._craftScreenshotReject && window._craftScreenshotReject(${jsQuote(e.message)})", null)
             }
         }
     }
@@ -2995,14 +3009,14 @@ class CraftBridge(
             // WorkManager tasks don't require explicit registration, just track them
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftBgTaskResolve && window._craftBgTaskResolve({taskId: '$taskId', registered: true})",
+                    "window._craftBgTaskResolve && window._craftBgTaskResolve({taskId: ${jsQuote(taskId)}, registered: true})",
                     null
                 )
             }
         } catch (e: Exception) {
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftBgTaskReject && window._craftBgTaskReject('${e.message}')",
+                    "window._craftBgTaskReject && window._craftBgTaskReject(${jsQuote(e.message)})",
                     null
                 )
             }
@@ -3017,14 +3031,14 @@ class CraftBridge(
             // This is a placeholder that shows the API structure
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftBgTaskResolve && window._craftBgTaskResolve({taskId: '$taskId', scheduled: true, delay: $delay})",
+                    "window._craftBgTaskResolve && window._craftBgTaskResolve({taskId: ${jsQuote(taskId)}, scheduled: true, delay: $delay})",
                     null
                 )
             }
         } catch (e: Exception) {
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftBgTaskReject && window._craftBgTaskReject('${e.message}')",
+                    "window._craftBgTaskReject && window._craftBgTaskReject(${jsQuote(e.message)})",
                     null
                 )
             }
@@ -3036,14 +3050,14 @@ class CraftBridge(
         try {
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftBgTaskResolve && window._craftBgTaskResolve({taskId: '$taskId', cancelled: true})",
+                    "window._craftBgTaskResolve && window._craftBgTaskResolve({taskId: ${jsQuote(taskId)}, cancelled: true})",
                     null
                 )
             }
         } catch (e: Exception) {
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftBgTaskReject && window._craftBgTaskReject('${e.message}')",
+                    "window._craftBgTaskReject && window._craftBgTaskReject(${jsQuote(e.message)})",
                     null
                 )
             }
@@ -3062,7 +3076,7 @@ class CraftBridge(
         } catch (e: Exception) {
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftBgTaskReject && window._craftBgTaskReject('${e.message}')",
+                    "window._craftBgTaskReject && window._craftBgTaskReject(${jsQuote(e.message)})",
                     null
                 )
             }
@@ -3099,7 +3113,7 @@ class CraftBridge(
                 )
             } catch (e: Exception) {
                 webView.evaluateJavascript(
-                    "window._craftPDFReject && window._craftPDFReject('${e.message}')",
+                    "window._craftPDFReject && window._craftPDFReject(${jsQuote(e.message)})",
                     null
                 )
             }
@@ -3204,7 +3218,7 @@ class CraftBridge(
         } catch (e: Exception) {
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftPickContactReject && window._craftPickContactReject('${e.message}')",
+                    "window._craftPickContactReject && window._craftPickContactReject(${jsQuote(e.message)})",
                     null
                 )
             }
@@ -3261,7 +3275,7 @@ class CraftBridge(
         } catch (e: Exception) {
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftShortcutsReject && window._craftShortcutsReject('${e.message}')",
+                    "window._craftShortcutsReject && window._craftShortcutsReject(${jsQuote(e.message)})",
                     null
                 )
             }
@@ -3284,7 +3298,7 @@ class CraftBridge(
             } catch (e: Exception) {
                 activity.runOnUiThread {
                     webView.evaluateJavascript(
-                        "window._craftShortcutsReject && window._craftShortcutsReject('${e.message}')",
+                        "window._craftShortcutsReject && window._craftShortcutsReject(${jsQuote(e.message)})",
                         null
                     )
                 }
@@ -3310,14 +3324,14 @@ class CraftBridge(
 
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftSharedKeychainResolve && window._craftSharedKeychainResolve({success: true, key: '$key'})",
+                    "window._craftSharedKeychainResolve && window._craftSharedKeychainResolve({success: true, key: ${jsQuote(key)}})",
                     null
                 )
             }
         } catch (e: Exception) {
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftSharedKeychainReject && window._craftSharedKeychainReject('${e.message}')",
+                    "window._craftSharedKeychainReject && window._craftSharedKeychainReject(${jsQuote(e.message)})",
                     null
                 )
             }
@@ -3334,12 +3348,12 @@ class CraftBridge(
             activity.runOnUiThread {
                 if (value != null) {
                     webView.evaluateJavascript(
-                        "window._craftSharedKeychainResolve && window._craftSharedKeychainResolve({value: '$value', key: '$key'})",
+                        "window._craftSharedKeychainResolve && window._craftSharedKeychainResolve({value: ${jsQuote(value)}, key: ${jsQuote(key)}})",
                         null
                     )
                 } else {
                     webView.evaluateJavascript(
-                        "window._craftSharedKeychainResolve && window._craftSharedKeychainResolve({value: null, key: '$key'})",
+                        "window._craftSharedKeychainResolve && window._craftSharedKeychainResolve({value: null, key: ${jsQuote(key)}})",
                         null
                     )
                 }
@@ -3347,7 +3361,7 @@ class CraftBridge(
         } catch (e: Exception) {
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftSharedKeychainReject && window._craftSharedKeychainReject('${e.message}')",
+                    "window._craftSharedKeychainReject && window._craftSharedKeychainReject(${jsQuote(e.message)})",
                     null
                 )
             }
@@ -3363,14 +3377,14 @@ class CraftBridge(
 
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftSharedKeychainResolve && window._craftSharedKeychainResolve({success: true, key: '$key'})",
+                    "window._craftSharedKeychainResolve && window._craftSharedKeychainResolve({success: true, key: ${jsQuote(key)}})",
                     null
                 )
             }
         } catch (e: Exception) {
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftSharedKeychainReject && window._craftSharedKeychainReject('${e.message}')",
+                    "window._craftSharedKeychainReject && window._craftSharedKeychainReject(${jsQuote(e.message)})",
                     null
                 )
             }
@@ -3404,7 +3418,7 @@ class CraftBridge(
         } catch (e: Exception) {
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftAuthPersistReject && window._craftAuthPersistReject('${e.message}')",
+                    "window._craftAuthPersistReject && window._craftAuthPersistReject(${jsQuote(e.message)})",
                     null
                 )
             }
@@ -3428,7 +3442,7 @@ class CraftBridge(
         } catch (e: Exception) {
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftAuthPersistReject && window._craftAuthPersistReject('${e.message}')",
+                    "window._craftAuthPersistReject && window._craftAuthPersistReject(${jsQuote(e.message)})",
                     null
                 )
             }
@@ -3448,7 +3462,7 @@ class CraftBridge(
         } catch (e: Exception) {
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftAuthPersistReject && window._craftAuthPersistReject('${e.message}')",
+                    "window._craftAuthPersistReject && window._craftAuthPersistReject(${jsQuote(e.message)})",
                     null
                 )
             }
@@ -3540,7 +3554,7 @@ class CraftBridge(
                 .addOnFailureListener { e ->
                     activity.runOnUiThread {
                         webView.evaluateJavascript(
-                            "window._craftMLReject && window._craftMLReject('${e.message}')",
+                            "window._craftMLReject && window._craftMLReject(${jsQuote(e.message)})",
                             null
                         )
                     }
@@ -3548,7 +3562,7 @@ class CraftBridge(
         } catch (e: Exception) {
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftMLReject && window._craftMLReject('${e.message}')",
+                    "window._craftMLReject && window._craftMLReject(${jsQuote(e.message)})",
                     null
                 )
             }
@@ -3607,7 +3621,7 @@ class CraftBridge(
                 .addOnFailureListener { e ->
                     activity.runOnUiThread {
                         webView.evaluateJavascript(
-                            "window._craftMLReject && window._craftMLReject('${e.message}')",
+                            "window._craftMLReject && window._craftMLReject(${jsQuote(e.message)})",
                             null
                         )
                     }
@@ -3615,7 +3629,7 @@ class CraftBridge(
         } catch (e: Exception) {
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftMLReject && window._craftMLReject('${e.message}')",
+                    "window._craftMLReject && window._craftMLReject(${jsQuote(e.message)})",
                     null
                 )
             }
@@ -3662,7 +3676,7 @@ class CraftBridge(
                 .addOnFailureListener { e ->
                     activity.runOnUiThread {
                         webView.evaluateJavascript(
-                            "window._craftMLReject && window._craftMLReject('${e.message}')",
+                            "window._craftMLReject && window._craftMLReject(${jsQuote(e.message)})",
                             null
                         )
                     }
@@ -3670,7 +3684,7 @@ class CraftBridge(
         } catch (e: Exception) {
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftMLReject && window._craftMLReject('${e.message}')",
+                    "window._craftMLReject && window._craftMLReject(${jsQuote(e.message)})",
                     null
                 )
             }
@@ -3718,7 +3732,7 @@ class CraftBridge(
         } catch (e: Exception) {
             activity.runOnUiThread {
                 webView.evaluateJavascript(
-                    "window._craftWidgetReject && window._craftWidgetReject('${e.message}')",
+                    "window._craftWidgetReject && window._craftWidgetReject(${jsQuote(e.message)})",
                     null
                 )
             }
@@ -3750,7 +3764,7 @@ class CraftBridge(
 
         activity.runOnUiThread {
             webView.evaluateJavascript(
-                "window._craftVoiceResolve && window._craftVoiceResolve({registered: true, action: '$action', phrase: '$phrase'})",
+                "window._craftVoiceResolve && window._craftVoiceResolve({registered: true, action: ${jsQuote(action)}, phrase: ${jsQuote(phrase)}})",
                 null
             )
         }
@@ -3763,7 +3777,7 @@ class CraftBridge(
 
         activity.runOnUiThread {
             webView.evaluateJavascript(
-                "window._craftVoiceResolve && window._craftVoiceResolve({removed: true, action: '$action'})",
+                "window._craftVoiceResolve && window._craftVoiceResolve({removed: true, action: ${jsQuote(action)}})",
                 null
             )
         }
@@ -3778,7 +3792,7 @@ class CraftBridge(
             if (action != null) {
                 activity.runOnUiThread {
                     webView.evaluateJavascript(
-                        "window.dispatchEvent(new CustomEvent('craftVoiceAction', {detail: {action: '$action', data: '$data'}}));",
+                        "window.dispatchEvent(new CustomEvent('craftVoiceAction', {detail: {action: ${jsQuote(action)}, data: ${jsQuote(data)}}}));",
                         null
                     )
                 }
@@ -3927,7 +3941,7 @@ class CraftBridge(
         val json = JSONObject(data).toString()
         activity.runOnUiThread {
             webView.evaluateJavascript(
-                "window.dispatchEvent(new CustomEvent('$event', {detail: $json}));",
+                "window.dispatchEvent(new CustomEvent(${jsQuote(event)}, {detail: $json}));",
                 null
             )
         }

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -505,6 +505,49 @@ pub fn build(b: *std.Build) void {
     });
     const run_android_bridge_tests = b.addRunArtifact(android_bridge_tests);
 
+    // The reply channel's escaping, across every Kotlin template.
+    //
+    // Every template is imported, not just the four that talk to the WebView
+    // today, so a file starting to emit JavaScript is already covered.
+    //
+    // The list is hand-written. Generating it by reading the directory here was
+    // tried and removed: `zig build` caches this script's evaluation against its
+    // own contents, so the generated list did not change when a template was
+    // added — the completeness check passed by reading a stale list, which is
+    // the exact failure it existed to prevent.
+    const android_escaping_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("test/android_reply_escaping_test.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    android_escaping_tests.root_module.addAnonymousImport("CraftBridge.kt.template", .{
+        .root_source_file = b.path("../android/templates/CraftBridge.kt.template"),
+    });
+    android_escaping_tests.root_module.addAnonymousImport("CraftBridgeExtensions.kt.template", .{
+        .root_source_file = b.path("../android/templates/CraftBridgeExtensions.kt.template"),
+    });
+    android_escaping_tests.root_module.addAnonymousImport("CraftHealthConnect.kt.template", .{
+        .root_source_file = b.path("../android/templates/CraftHealthConnect.kt.template"),
+    });
+    android_escaping_tests.root_module.addAnonymousImport("CraftHealthConnectStub.kt.template", .{
+        .root_source_file = b.path("../android/templates/CraftHealthConnectStub.kt.template"),
+    });
+    android_escaping_tests.root_module.addAnonymousImport("CraftNative.kt.template", .{
+        .root_source_file = b.path("../android/templates/CraftNative.kt.template"),
+    });
+    android_escaping_tests.root_module.addAnonymousImport("CraftWidgetProvider.kt.template", .{
+        .root_source_file = b.path("../android/templates/CraftWidgetProvider.kt.template"),
+    });
+    android_escaping_tests.root_module.addAnonymousImport("LocationRecordingService.kt.template", .{
+        .root_source_file = b.path("../android/templates/LocationRecordingService.kt.template"),
+    });
+    android_escaping_tests.root_module.addAnonymousImport("MainActivity.kt.template", .{
+        .root_source_file = b.path("../android/templates/MainActivity.kt.template"),
+    });
+    const run_android_escaping_tests = b.addRunArtifact(android_escaping_tests);
+
     ios_conformance_tests.root_module.addAnonymousImport("CraftApp.swift", .{
         .root_source_file = b.path("../ios/templates/CraftApp.swift"),
     });
@@ -1648,6 +1691,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_bridge_surface_tests.step);
     test_step.dependOn(&run_android_conformance_tests.step);
     test_step.dependOn(&run_android_bridge_tests.step);
+    test_step.dependOn(&run_android_escaping_tests.step);
     test_step.dependOn(&run_menubar_tests.step);
     test_step.dependOn(&run_components_tests.step);
     test_step.dependOn(&run_gpu_tests.step);
@@ -2377,6 +2421,7 @@ pub fn build(b: *std.Build) void {
     test_android_step.dependOn(&run_bridge_surface_tests.step);
     test_android_step.dependOn(&run_android_conformance_tests.step);
     test_android_step.dependOn(&run_android_bridge_tests.step);
+    test_android_step.dependOn(&run_android_escaping_tests.step);
 
     // Add Android tests to the main test step
     test_step.dependOn(&run_android_tests.step);

--- a/packages/zig/src/bridge_android_calendar.zig
+++ b/packages/zig/src/bridge_android_calendar.zig
@@ -1,28 +1,26 @@
 //! `deleteCalendarEvent` on Android — the first action here that answers
 //! through the reply channel rather than by returning.
 //!
-//! ## What the shim does, and the one thing this does not reproduce
+//! ## What the shim does
 //!
 //! The Kotlin builds a content URI from the event id, deletes through the
 //! `ContentResolver`, and resolves `true`; on any exception it rejects with
 //! the message. That is all ported.
 //!
-//! What is not ported is how it *sends* the rejection:
+//! The rejection is built as JSON through `bridge_error.appendJsonEscaped`
+//! rather than pasted into a quoted string. When this module was written the
+//! shim did the latter —
 //!
 //!     "window._craftDeleteEventReject && window._craftDeleteEventReject('${e.message}')"
 //!
-//! The message goes into a single-quoted JavaScript string with no escaping,
-//! and `eventId.toLong()` puts the caller's own text in that message —
-//! `NumberFormatException: For input string: "1'x"`. A `'` in the id therefore
-//! produces a script that does not parse, `evaluateJavascript` runs nothing,
-//! and **neither the resolve nor the reject fires**. The promise never
-//! settles, and the injected JS builds it by hand with no timeout, so the page
-//! waits forever with nothing in the console.
-//!
-//! Here the payload is built as JSON through `bridge_error.appendJsonEscaped`,
-//! so the same id rejects normally. That is a divergence in the page's favour
-//! and it is deliberate; the shim keeps the bug on the twenty other paths
-//! until #154 is fixed.
+//! — and `eventId.toLong()` puts the caller's own text in that message, so
+//! `craft.calendar.delete("1'x")` produced a script that did not parse:
+//! `evaluateJavascript` ran nothing, neither the resolve nor the reject fired,
+//! and the hand-built promise had no timeout to notice. #154 fixed all
+//! fifty-eight such emissions, and `android_reply_escaping_test` now keeps
+//! them fixed, so this is no longer a divergence — but the escaping stays
+//! here, because `events.settle` takes a payload that is already JSON and this
+//! module is what has to produce it.
 //!
 //! ## `toLong()` is reproduced exactly, including what it refuses
 //!
@@ -114,7 +112,8 @@ pub fn deleteEvent(j: Jni, activity: jobject, id: i64) !void {
 /// Reject with `message`, escaped.
 ///
 /// The escaping is the whole point of this function existing rather than the
-/// call being inline — see the module comment and #154.
+/// call being inline — `events.settle` sends the payload as written, so a raw
+/// message would emit a script that does not parse. See the module comment.
 pub fn rejectWith(allocator: std.mem.Allocator, message: []const u8) !void {
     const payload = try rejectPayload(allocator, message);
     defer allocator.free(payload);
@@ -171,9 +170,9 @@ test "an id Java would refuse is refused here too" {
 }
 
 test "a rejection message with a quote is escaped rather than emitted raw" {
-    // The bug this action does not reproduce. On the shim, an id of `1'x`
-    // produces `…Reject('For input string: "1'x"')`, which does not parse — so
-    // evaluateJavascript runs nothing and the promise never settles.
+    // The bug that used to be one line away. Before #154 the shim turned an id
+    // of `1'x` into `…Reject('For input string: "1'x"')`, which does not parse
+    // — so evaluateJavascript ran nothing and the promise never settled.
     const payload = try rejectPayload(testing.allocator, "For input string: \"1'x\"");
     defer testing.allocator.free(payload);
 

--- a/packages/zig/test/android_reply_escaping_test.zig
+++ b/packages/zig/test/android_reply_escaping_test.zig
@@ -1,0 +1,148 @@
+//! How the answer gets back, and the one character that stops it.
+//!
+//! Android replies to the page by building JavaScript source and handing it to
+//! `WebView.evaluateJavascript`. Fifty-eight of those emissions interpolated a
+//! Kotlin value straight into a single-quoted JavaScript string:
+//!
+//! ```kotlin
+//! webView.evaluateJavascript(
+//!     "window._craftDeleteEventReject && window._craftDeleteEventReject('${e.message}')", null)
+//! ```
+//!
+//! An apostrophe in the value ends the string early, the script does not parse,
+//! and `evaluateJavascript` runs *nothing*. Not the reject, not the resolve —
+//! and because these promises are hand-built rather than made by
+//! `_createCallback`, there is no timeout behind them. The page waits forever
+//! with no console error, since the failure happens inside `evaluateJavascript`
+//! where nothing is watching.
+//!
+//! It is reachable from the page, because Java puts the offending input in the
+//! exception: `craft.calendar.delete("1'x")` throws `NumberFormatException: For
+//! input string: "1'x"`, and that message is what gets interpolated.
+//!
+//! ## Why a scanner and not a review
+//!
+//! The fix is `JSONObject.quote`, which is mechanical — and that is exactly the
+//! kind of fix that comes undone. The next reply path written by hand looks
+//! like the fifty-eight that were there before it, reads naturally, compiles,
+//! and works until someone types an apostrophe. So the rule is checked rather
+//! than remembered.
+//!
+//! ## The rule
+//!
+//! No Kotlin template may contain the two characters `'$`. That is narrower
+//! than "escape your JavaScript" and wider than the reply paths, and both are
+//! deliberate: it is trivially decidable, it has no false positives in this
+//! tree (every occurrence before this file existed was a JavaScript emission),
+//! and a value quoted with `jsQuote` cannot produce it.
+
+const std = @import("std");
+const testing = std.testing;
+
+/// Every Kotlin template in `packages/android/templates`, embedded rather than
+/// read from disk so the test is hermetic.
+///
+/// All eight, not just the four that talk to the WebView today — a file that
+/// starts emitting JavaScript should already be covered rather than needing
+/// someone to notice.
+///
+/// The list is hand-written, and that is a real limit: a ninth template is not
+/// scanned until it is added here. Generating the list from the directory was
+/// tried and removed, because `zig build` caches build.zig's evaluation against
+/// that file's contents — adding a template did not regenerate the list, and the
+/// completeness check passed by reading stale data. A check that cannot fail is
+/// worse than an acknowledged gap.
+const templates = [_]Template{
+    .{ .name = "CraftBridge.kt.template", .source = @embedFile("CraftBridge.kt.template") },
+    .{ .name = "CraftBridgeExtensions.kt.template", .source = @embedFile("CraftBridgeExtensions.kt.template") },
+    .{ .name = "CraftHealthConnect.kt.template", .source = @embedFile("CraftHealthConnect.kt.template") },
+    .{ .name = "CraftHealthConnectStub.kt.template", .source = @embedFile("CraftHealthConnectStub.kt.template") },
+    .{ .name = "CraftNative.kt.template", .source = @embedFile("CraftNative.kt.template") },
+    .{ .name = "CraftWidgetProvider.kt.template", .source = @embedFile("CraftWidgetProvider.kt.template") },
+    .{ .name = "LocationRecordingService.kt.template", .source = @embedFile("LocationRecordingService.kt.template") },
+    .{ .name = "MainActivity.kt.template", .source = @embedFile("MainActivity.kt.template") },
+};
+
+const Template = struct {
+    name: []const u8,
+    source: []const u8,
+};
+
+/// The offset of the first Kotlin interpolation opening immediately inside a
+/// single-quoted JavaScript string, or null if there is none.
+fn firstUnquotedInterpolation(source: []const u8) ?usize {
+    return std.mem.indexOf(u8, source, "'$");
+}
+
+fn sourceOf(name: []const u8) ?[]const u8 {
+    for (templates) |template| {
+        if (std.mem.eql(u8, template.name, name)) return template.source;
+    }
+    return null;
+}
+
+fn lineOf(source: []const u8, offset: usize) usize {
+    return std.mem.count(u8, source[0..offset], "\n") + 1;
+}
+
+test "the scanner recognises the shape it exists to catch" {
+    // Reading the guard below tells you nothing about whether it looks at
+    // anything. Three of this repository's tests have passed for the wrong
+    // reason and only deliberate mutation exposed them, so the scanner is
+    // handed both answers here before it is trusted with the real files.
+    try testing.expect(firstUnquotedInterpolation("f('${e.message}')") != null);
+    try testing.expect(firstUnquotedInterpolation("f('$id')") != null);
+    try testing.expect(firstUnquotedInterpolation("f({key: '$key'})") != null);
+
+    // And the fix must read as clean, or the guard is unsatisfiable.
+    try testing.expect(firstUnquotedInterpolation("f(${jsQuote(e.message)})") == null);
+    try testing.expect(firstUnquotedInterpolation("f($json)") == null);
+    try testing.expect(firstUnquotedInterpolation("window.$callback") == null);
+}
+
+test "no Kotlin template interpolates a value into a single-quoted JavaScript string" {
+    for (templates) |template| {
+        if (firstUnquotedInterpolation(template.source)) |offset| {
+            const line = lineOf(template.source, offset);
+            const start = if (std.mem.lastIndexOfScalar(u8, template.source[0..offset], '\n')) |nl|
+                nl + 1
+            else
+                0;
+            const excerpt = std.mem.trim(
+                u8,
+                std.mem.sliceTo(template.source[start..], '\n'),
+                " \t\r",
+            );
+            std.debug.print(
+                \\
+                \\{s}:{d} interpolates a value into a single-quoted JavaScript string:
+                \\
+                \\    {s}
+                \\
+                \\An apostrophe in that value makes the emitted script a syntax error,
+                \\`evaluateJavascript` runs nothing, and the page's promise never settles.
+                \\Use `jsQuote(value)` — it supplies its own quotes, so the surrounding
+                \\'...' comes out.
+                \\
+            , .{ template.name, line, excerpt });
+            return error.UnquotedInterpolation;
+        }
+    }
+}
+
+test "the templates that answer the page are actually in the scanned set" {
+    // A floor, not a count: `CraftBridge.kt` alone holds 119 of these. If this
+    // drops to zero the embed has gone stale — pointing at the wrong file, or
+    // at a file that no longer talks to the WebView — and the escaping guard
+    // above would pass on bytes nobody replies with.
+    var emissions: usize = 0;
+    for (templates) |template| {
+        emissions += std.mem.count(u8, template.source, "evaluateJavascript(");
+    }
+    try testing.expect(emissions >= 100);
+
+    // And the fix is present rather than the sites merely being deleted.
+    const bridge = sourceOf("CraftBridge.kt.template").?;
+    try testing.expect(std.mem.indexOf(u8, bridge, "private fun jsQuote(") != null);
+    try testing.expect(std.mem.count(u8, bridge, "jsQuote(") >= 50);
+}


### PR DESCRIPTION
Closes #154.

## The bug

Fifty-eight emissions in `CraftBridge.kt` interpolated a Kotlin value straight into a single-quoted JavaScript string:

```kotlin
"window._craftDeleteEventReject && window._craftDeleteEventReject('${e.message}')"
```

An apostrophe in the value ends the string early, the script does not parse, and `evaluateJavascript` runs **nothing** — not the reject, not the resolve. These promises are hand-built rather than made by `_createCallback`, so nothing times out behind them. The page waits forever with no console error, because the failure happens inside `evaluateJavascript` where nothing is watching.

It is reachable from the page, because Java puts the offending input in the exception:

```
craft.calendar.delete("1'x")
  → NumberFormatException: For input string: "1'x"
  → ...Reject('For input string: "1'x"')
                                    ^ string ends here
```

`dbExecute` and `dbQuery` echo the caller's SQL the same way; `addContact` and `createCalendarEvent` echo field values.

Not primarily a security issue: the script runs in the page's own context and the page can already call `eval`. The cost is the hang.

## What changed beyond the issue

The issue counted 21 reject paths. It is 58, because the **resolve** paths carry the same shape and the same caller-supplied text — `_craftSharedKeychainResolve` echoes both the key and the value, `_craftVoiceResolve` the phrase, `_craftSaveResolve` an absolute path. All 58 are converted.

`jsQuote` wraps `JSONObject.quote`, which this file already used correctly in exactly one place (`registerPush`). A Kotlin null still renders as the string `"null"`, matching what plain interpolation produced — whether it should be a JS `null` is a separate question from escaping and is left alone.

## The guard

A mechanical fix is exactly the kind that comes undone: the next reply path written by hand will look like the 58 before it, read naturally, compile, and work until someone types an apostrophe. `android_reply_escaping_test.zig` scans every Kotlin template for the two characters `'$` — narrower than "escape your JavaScript", trivially decidable, and with no false positives in this tree.

The scanner is handed a known-bad input before it is trusted with the real files, and the guard was mutation-tested:

```
error: 'no Kotlin template interpolates a value into a single-quoted JavaScript string' failed:
       CraftBridge.kt.template:2420 interpolates a value into a single-quoted JavaScript string:

           webView.evaluateJavascript("window._craftNotifReject && window._craftNotifReject('${e.message}')", null)
```

## One thing that did not work

Generating the template list by reading the directory in `build.zig` was tried and removed. `zig build` caches that script's evaluation against its own contents, so adding a template did **not** regenerate the list — the completeness check passed by reading stale data, which is the exact failure it existed to prevent. The list is hand-written now and the comment says so rather than implying coverage it does not have.

## Testing

`zig build test:android` passes. The full `zig build test` has one pre-existing failure unrelated to this change: `injected_js_test` cannot compile against `~/Documents/Libraries/zig-js`, whose sources predate this toolchain's `std.ArrayListUnmanaged` and `getLast` changes.