### PR TITLE
feat(android): getCalendarEvents and createCalendarEvent in Zig — ratchet 86 → 84

### DIFF
--- a/packages/android/templates/CraftBridge.kt.template
+++ b/packages/android/templates/CraftBridge.kt.template
@@ -2274,6 +2274,10 @@ class CraftBridge(
 
     @JavascriptInterface
     fun getCalendarEvents(startDateMs: Long, endDateMs: Long) {
+        // Zig answers through the reply channel, so returning here is what
+        // stops the promise being settled twice.
+        if (CraftNative.getCalendarEvents(activity, startDateMs, endDateMs)) return
+
         if (ContextCompat.checkSelfPermission(activity, Manifest.permission.READ_CALENDAR)
             != PackageManager.PERMISSION_GRANTED) {
             ActivityCompat.requestPermissions(activity, arrayOf(Manifest.permission.READ_CALENDAR), REQUEST_CALENDAR)

--- a/packages/android/templates/CraftBridge.kt.template
+++ b/packages/android/templates/CraftBridge.kt.template
@@ -2331,6 +2331,10 @@ class CraftBridge(
 
     @JavascriptInterface
     fun createCalendarEvent(eventJson: String) {
+        // Zig answers through the reply channel, so returning here is what
+        // stops the promise being settled twice.
+        if (CraftNative.createCalendarEvent(activity, eventJson)) return
+
         if (ContextCompat.checkSelfPermission(activity, Manifest.permission.WRITE_CALENDAR)
             != PackageManager.PERMISSION_GRANTED) {
             ActivityCompat.requestPermissions(activity, arrayOf(Manifest.permission.WRITE_CALENDAR), REQUEST_CALENDAR)

--- a/packages/android/templates/CraftNative.kt.template
+++ b/packages/android/templates/CraftNative.kt.template
@@ -108,6 +108,7 @@ object CraftNative {
     private external fun nativeCancelNotification(activity: Activity, id: String): Boolean
     private external fun nativeCancelAllNotifications(activity: Activity): Boolean
     private external fun nativeDeleteCalendarEvent(activity: Activity, eventId: String): Boolean
+    private external fun nativeGetCalendarEvents(activity: Activity, startDateMs: Long, endDateMs: Long): Boolean
 
     /**
      * `getDeviceInfo`, or null to use the Kotlin implementation.
@@ -346,6 +347,22 @@ object CraftNative {
         if (!isAvailable) return false
         return try {
             nativeDeleteCalendarEvent(activity, eventId)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    /**
+     * Returns whether Zig took the action, not whether the read found anything.
+     *
+     * An empty calendar still answers — with `[]`, through the reply channel —
+     * so a false here means Zig did not run, never that there was nothing to
+     * report.
+     */
+    fun getCalendarEvents(activity: Activity, startDateMs: Long, endDateMs: Long): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeGetCalendarEvents(activity, startDateMs, endDateMs)
         } catch (e: UnsatisfiedLinkError) {
             false
         }

--- a/packages/android/templates/CraftNative.kt.template
+++ b/packages/android/templates/CraftNative.kt.template
@@ -109,6 +109,7 @@ object CraftNative {
     private external fun nativeCancelAllNotifications(activity: Activity): Boolean
     private external fun nativeDeleteCalendarEvent(activity: Activity, eventId: String): Boolean
     private external fun nativeGetCalendarEvents(activity: Activity, startDateMs: Long, endDateMs: Long): Boolean
+    private external fun nativeCreateCalendarEvent(activity: Activity, eventJson: String): Boolean
 
     /**
      * `getDeviceInfo`, or null to use the Kotlin implementation.
@@ -363,6 +364,23 @@ object CraftNative {
         if (!isAvailable) return false
         return try {
             nativeGetCalendarEvents(activity, startDateMs, endDateMs)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    /**
+     * Returns whether Zig took the action.
+     *
+     * A false here is routine rather than exceptional: Zig serves the shape
+     * `NewCalendarEvent` declares and hands anything else back, because
+     * `org.json` coerces where a strict parser refuses. The Kotlin below is
+     * what answers those.
+     */
+    fun createCalendarEvent(activity: Activity, eventJson: String): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeCreateCalendarEvent(activity, eventJson)
         } catch (e: UnsatisfiedLinkError) {
             false
         }

--- a/packages/zig/src/android_dispatch.zig
+++ b/packages/zig/src/android_dispatch.zig
@@ -72,6 +72,9 @@ const backing = std.heap.page_allocator;
 /// asked for.
 const request_calendar: i32 = 1005;
 
+/// The shim's default event length: `System.currentTimeMillis() + 3600000`.
+const one_hour_ms: i64 = 60 * 60 * 1000;
+
 /// The VM, captured at load so a later callback on a framework thread can ask
 /// it for that thread's `JNIEnv`.
 ///
@@ -239,6 +242,11 @@ const natives = [_]jni.JNINativeMethod{
         .name = "nativeGetCalendarEvents",
         .signature = "(Landroid/app/Activity;JJ)Z",
         .fnPtr = @ptrCast(&nativeGetCalendarEvents),
+    },
+    .{
+        .name = "nativeCreateCalendarEvent",
+        .signature = "(Landroid/app/Activity;Ljava/lang/String;)Z",
+        .fnPtr = @ptrCast(&nativeCreateCalendarEvent),
     },
 };
 
@@ -719,6 +727,68 @@ fn nativeGetCalendarEvents(
     return jni.JNI_TRUE;
 }
 
+/// `nativeCreateCalendarEvent(activity, eventJson)`.
+///
+/// Returns false — leaving the shim to serve it — for any payload outside the
+/// shape `NewCalendarEvent` declares. `org.json` coerces a `startDate` sent as
+/// a string and a `title` sent as a number, and the string forms it produces
+/// for a `Double` are not something to reproduce from memory. Declining is
+/// cheap here because nothing has been sent yet.
+fn nativeCreateCalendarEvent(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+    event_json: jni.jstring,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const granted = permissions.isGranted(j, activity, permissions.write_calendar) catch |err| {
+        std.log.warn("craft: createCalendarEvent fell through to the shim ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+
+    if (!granted) {
+        permissions.request(j, activity, permissions.write_calendar, request_calendar) catch |err| {
+            std.log.warn("craft: createCalendarEvent fell through to the shim ({s})", .{@errorName(err)});
+            return jni.JNI_FALSE;
+        };
+        events.settle(allocator, calendar.create_reject_global, "\"Permission denied\"") catch return jni.JNI_FALSE;
+        return jni.JNI_TRUE;
+    }
+
+    const text = j.stringToUtf8(allocator, event_json) catch return jni.JNI_FALSE;
+
+    // `JSONTokener` is lenient where `std.json` is strict — unquoted keys,
+    // single quotes, a trailing comma. Everything strict JSON accepts it
+    // accepts too, so the difference only ever sends work back to the shim.
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, text, .{}) catch
+        return jni.JNI_FALSE;
+    defer parsed.deinit();
+
+    const start_default = calendar.currentTimeMillis(j) catch return jni.JNI_FALSE;
+    const end_default = calendar.currentTimeMillis(j) catch return jni.JNI_FALSE;
+    const event = calendar.parseNewEvent(
+        parsed.value,
+        start_default,
+        end_default +% one_hour_ms,
+    ) orelse return jni.JNI_FALSE;
+
+    const id = calendar.insertEvent(j, allocator, activity, event) catch |err| {
+        // The shim catches here and rejects with the exception's message. The
+        // throwable was described to logcat and cleared by `Jni.check` before
+        // this point, so the error name is what is left to say.
+        calendar.rejectOn(allocator, calendar.create_reject_global, @errorName(err)) catch {};
+        return jni.JNI_TRUE;
+    };
+
+    const payload = calendar.jsonString(allocator, id) catch return jni.JNI_FALSE;
+    events.settle(allocator, calendar.create_resolve_global, payload) catch return jni.JNI_FALSE;
+    return jni.JNI_TRUE;
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -830,7 +900,7 @@ test "the registered natives name methods the Kotlin actually declares" {
     // A descriptor is checked by the JVM at registration, so a wrong one fails
     // at load rather than at call — but only if the *name* matches something.
     // These two strings are the contract with CraftBridge.kt.
-    try testing.expectEqual(@as(usize, 18), natives.len);
+    try testing.expectEqual(@as(usize, 19), natives.len);
     try testing.expectEqualStrings("nativeGetDeviceInfo", std.mem.span(natives[0].name));
 
     // And the class they bind to is the fixed one, not the templated bridge.

--- a/packages/zig/src/android_dispatch.zig
+++ b/packages/zig/src/android_dispatch.zig
@@ -36,6 +36,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const jni = @import("jni_runtime.zig");
+const permissions = @import("android_permissions.zig");
 const device = @import("bridge_android_device.zig");
 const system = @import("bridge_android_system.zig");
 const clipboard = @import("bridge_android_clipboard.zig");
@@ -62,6 +63,14 @@ const Jni = jni.Jni;
 /// page per call rather than one per allocation, and nothing has to be freed
 /// individually on the way out.
 const backing = std.heap.page_allocator;
+
+/// `CraftBridge.REQUEST_CALENDAR`, the request code the shim passes.
+///
+/// It has to match, because it is the only thing that would tell an
+/// `onRequestPermissionsResult` which request it is answering — and if the
+/// shim ever grows one, a code Zig invented would arrive as a request nothing
+/// asked for.
+const request_calendar: i32 = 1005;
 
 /// The VM, captured at load so a later callback on a framework thread can ask
 /// it for that thread's `JNIEnv`.
@@ -225,6 +234,11 @@ const natives = [_]jni.JNINativeMethod{
         .name = "nativeDeleteCalendarEvent",
         .signature = "(Landroid/app/Activity;Ljava/lang/String;)Z",
         .fnPtr = @ptrCast(&nativeDeleteCalendarEvent),
+    },
+    .{
+        .name = "nativeGetCalendarEvents",
+        .signature = "(Landroid/app/Activity;JJ)Z",
+        .fnPtr = @ptrCast(&nativeGetCalendarEvents),
     },
 };
 
@@ -642,6 +656,69 @@ fn nativeDeleteCalendarEvent(
     return jni.JNI_TRUE;
 }
 
+/// `nativeGetCalendarEvents(activity, startDateMs, endDateMs)`.
+///
+/// Reads the calendar and settles `_craftCalendarResolve` with the array.
+///
+/// ## Where this returns false
+///
+/// Only before anything has been sent. A failure after the reply channel has
+/// been used would settle the page's promise twice, since a false sends the
+/// shim down the same path — so the JNI work runs to completion or reports
+/// nothing at all, and the shim answers instead.
+///
+/// That includes the case where the query itself throws. The shim wraps none
+/// of `getCalendarEvents` in a try/catch, so a `SecurityException` from a
+/// permission revoked between the check and the query propagates out of the
+/// `@JavascriptInterface` method and the promise hangs. Rejecting here would
+/// be kinder and would also be a divergence nothing records, so this falls
+/// through and lets the shim behave as it does. See #157.
+fn nativeGetCalendarEvents(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+    start_date_ms: jni.jlong,
+    end_date_ms: jni.jlong,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const granted = permissions.isGranted(j, activity, permissions.read_calendar) catch |err| {
+        std.log.warn("craft: getCalendarEvents fell through to the shim ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+
+    if (!granted) {
+        // The shim asks and rejects in the same breath: the answer arrives at
+        // `onRequestPermissionsResult`, which nothing here implements, so the
+        // request is what makes a *later* call work rather than this one.
+        permissions.request(j, activity, permissions.read_calendar, request_calendar) catch |err| {
+            std.log.warn("craft: getCalendarEvents fell through to the shim ({s})", .{@errorName(err)});
+            return jni.JNI_FALSE;
+        };
+        events.settle(allocator, calendar.list_reject_global, "\"Permission denied\"") catch return jni.JNI_FALSE;
+        return jni.JNI_TRUE;
+    }
+
+    const now = calendar.currentTimeMillis(j) catch |err| {
+        std.log.warn("craft: getCalendarEvents fell through to the shim ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+    const window = calendar.windowFor(start_date_ms, end_date_ms, now);
+
+    var payload: std.ArrayListUnmanaged(u8) = .empty;
+    defer payload.deinit(allocator);
+    calendar.queryEvents(j, allocator, activity, window, &payload) catch |err| {
+        std.log.warn("craft: getCalendarEvents fell through to the shim ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+
+    events.settle(allocator, calendar.list_resolve_global, payload.items) catch return jni.JNI_FALSE;
+    return jni.JNI_TRUE;
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -753,7 +830,7 @@ test "the registered natives name methods the Kotlin actually declares" {
     // A descriptor is checked by the JVM at registration, so a wrong one fails
     // at load rather than at call — but only if the *name* matches something.
     // These two strings are the contract with CraftBridge.kt.
-    try testing.expectEqual(@as(usize, 17), natives.len);
+    try testing.expectEqual(@as(usize, 18), natives.len);
     try testing.expectEqualStrings("nativeGetDeviceInfo", std.mem.span(natives[0].name));
 
     // And the class they bind to is the fixed one, not the templated bridge.

--- a/packages/zig/src/android_permissions.zig
+++ b/packages/zig/src/android_permissions.zig
@@ -1,0 +1,98 @@
+//! Runtime permissions, the two calls every guarded action starts with.
+//!
+//! The Kotlin reaches these through AndroidX:
+//!
+//! ```kotlin
+//! if (ContextCompat.checkSelfPermission(activity, Manifest.permission.READ_CALENDAR)
+//!     != PackageManager.PERMISSION_GRANTED) {
+//!     ActivityCompat.requestPermissions(activity, arrayOf(...), REQUEST_CALENDAR)
+//! ```
+//!
+//! Zig calls the framework methods those two delegate to. That is not a
+//! shortcut around a dependency — `ContextCompat.checkSelfPermission` *is*
+//! `Context.checkSelfPermission` from API 23, and `ActivityCompat`'s
+//! `requestPermissions` is `Activity.requestPermissions` from the same level,
+//! with the pre-23 branches dead on any modern `minSdk`. Going through the
+//! framework also means no `androidx.core` on the JNI side, which matters
+//! because `libcraft.so` is built with no NDK and links nothing.
+//!
+//! ## Which thread
+//!
+//! `requestPermissions` is documented as main-thread, and this is called from
+//! the WebView's JavaBridge thread — because the shim calls it from there too.
+//! Hoisting it onto the main looper here would be a divergence, and a silent
+//! one: the two would then differ in when the dialog appears relative to the
+//! rejection the page already received.
+
+const std = @import("std");
+const jni = @import("jni_runtime.zig");
+
+const Jni = jni.Jni;
+const jobject = jni.jobject;
+
+/// `PackageManager.PERMISSION_GRANTED`.
+///
+/// A compile-time constant in Java, so the shim's DEX holds the literal `0`
+/// rather than a field read — which is why it is a literal here as well.
+pub const granted: i32 = 0;
+
+pub const read_calendar = "android.permission.READ_CALENDAR";
+pub const write_calendar = "android.permission.WRITE_CALENDAR";
+
+/// `activity.checkSelfPermission(permission) == PERMISSION_GRANTED`.
+pub fn isGranted(j: Jni, activity: jobject, permission: [*:0]const u8) !bool {
+    try j.pushLocalFrame(8);
+    defer _ = j.popLocalFrame(null);
+
+    const name = try j.newStringUtf(permission);
+    const activity_cls = try j.objectClass(activity);
+    const result = try j.callIntMethodA(
+        activity,
+        try j.methodId(activity_cls, "checkSelfPermission", "(Ljava/lang/String;)I"),
+        &.{.{ .l = name }},
+    );
+    return result == granted;
+}
+
+/// `activity.requestPermissions(new String[]{permission}, code)`.
+///
+/// The result arrives at `onRequestPermissionsResult`, which the shim does not
+/// implement for these codes — so the request is what makes the *next* call
+/// succeed, and this one still fails. That is the shim's behaviour and the
+/// reason the caller rejects immediately after.
+pub fn request(j: Jni, activity: jobject, permission: [*:0]const u8, code: i32) !void {
+    try j.pushLocalFrame(8);
+    defer _ = j.popLocalFrame(null);
+
+    const string_cls = try j.findClass("java/lang/String");
+    const names = try j.newObjectArray(1, string_cls);
+    try j.setObjectArrayElement(names, 0, try j.newStringUtf(permission));
+
+    const activity_cls = try j.objectClass(activity);
+    try j.callVoidMethodA(
+        activity,
+        try j.methodId(activity_cls, "requestPermissions", "([Ljava/lang/String;I)V"),
+        &.{ .{ .l = names }, .{ .i = code } },
+    );
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+const testing = std.testing;
+
+test "the permission names match Manifest.permission exactly" {
+    // `Manifest.permission.READ_CALENDAR` is a compile-time constant, so the
+    // shim compares against these exact strings. A typo here is a permission
+    // that is never granted and an action that always rejects.
+    try testing.expectEqualStrings("android.permission.READ_CALENDAR", read_calendar);
+    try testing.expectEqualStrings("android.permission.WRITE_CALENDAR", write_calendar);
+}
+
+test "PERMISSION_GRANTED is zero, and PERMISSION_DENIED is not" {
+    // -1 is PERMISSION_DENIED. The comparison is `== granted` rather than
+    // `!= denied` because a future third value would then read as granted.
+    try testing.expectEqual(@as(i32, 0), granted);
+    try testing.expect(granted != -1);
+}

--- a/packages/zig/src/bridge_android_calendar.zig
+++ b/packages/zig/src/bridge_android_calendar.zig
@@ -41,6 +41,7 @@ const jobject = jni.jobject;
 pub const A = struct {
     pub const delete_calendar_event = "deleteCalendarEvent";
     pub const get_calendar_events = "getCalendarEvents";
+    pub const create_calendar_event = "createCalendarEvent";
 };
 
 /// The globals the injected JS assigns for each action.
@@ -52,6 +53,8 @@ pub const resolve_global = "_craftDeleteEventResolve";
 pub const reject_global = "_craftDeleteEventReject";
 pub const list_resolve_global = "_craftCalendarResolve";
 pub const list_reject_global = "_craftCalendarReject";
+pub const create_resolve_global = "_craftCreateEventResolve";
+pub const create_reject_global = "_craftCreateEventReject";
 
 /// `Long.parseLong(text)`, or null where Java would throw.
 ///
@@ -122,25 +125,26 @@ pub fn deleteEvent(j: Jni, activity: jobject, id: i64) !void {
 /// call being inline — `events.settle` sends the payload as written, so a raw
 /// message would emit a script that does not parse. See the module comment.
 pub fn rejectWith(allocator: std.mem.Allocator, message: []const u8) !void {
-    const payload = try rejectPayload(allocator, message);
-    defer allocator.free(payload);
-    try events.settle(allocator, reject_global, payload);
+    try rejectOn(allocator, reject_global, message);
 }
 
-/// `message` as a JSON string, quotes included.
+/// `text` as a JSON string, quotes included.
+///
+/// Used for a rejection message and for the id `createCalendarEvent` resolves
+/// with, both of which are page-visible text that has to survive a quote.
 ///
 /// Split out so the test exercises this rather than a copy of it. An earlier
-/// version inlined the escaping here and asserted on the same three lines
-/// rewritten in the test — which passed happily when the escaping was removed
-/// from the code, because the test was not calling the code.
-pub fn rejectPayload(allocator: std.mem.Allocator, message: []const u8) ![]u8 {
+/// version inlined the escaping at the call site and asserted on the same
+/// three lines rewritten in the test — which passed happily when the escaping
+/// was removed from the code, because the test was not calling the code.
+pub fn jsonString(allocator: std.mem.Allocator, text: []const u8) ![]u8 {
     var payload: std.ArrayListUnmanaged(u8) = .empty;
     errdefer payload.deinit(allocator);
 
     // The quotes are this caller's job: `appendJsonEscaped` escapes the
     // contents and writes no delimiters.
     try payload.append(allocator, '"');
-    try bridge_error.appendJsonEscaped(allocator, &payload, message);
+    try bridge_error.appendJsonEscaped(allocator, &payload, text);
     try payload.append(allocator, '"');
 
     return payload.toOwnedSlice(allocator);
@@ -417,6 +421,243 @@ fn columnText(
 }
 
 // =============================================================================
+// createCalendarEvent
+// =============================================================================
+//
+// ## Which payloads this serves, and which it hands back
+//
+// The shim reads the event through `org.json`, whose accessors coerce: a
+// `startDate` sent as the string "1700000000000" is a number to `optLong`, a
+// `title` sent as `1.5` is the string "1.5" to `optString`, and reproducing
+// `Double.toString` exactly is not something to guess at.
+//
+// So the rule here is narrow and stated rather than approximated: Zig serves
+// the shape `NewCalendarEvent` declares — strings for the text, numbers for
+// the dates, a boolean for the flag — plus absent keys and explicit nulls. A
+// payload of any other shape makes `parseNewEvent` return null, the native
+// returns false, and the shim reads it with the coercions it already has. The
+// page sees no difference; nothing has been settled at that point.
+//
+// The one coercion that *is* reproduced is the surprising one. `optString` on
+// an explicit JSON null returns the four characters "null", because
+// `JSONObject.NULL.toString()` is "null" and `JSON.toString` reaches for
+// `toString` on anything that is not already a String. `{"location":null}` is
+// an ordinary thing for `JSON.stringify` to produce, so this is a live path
+// and not a curiosity.
+
+/// `CalendarContract.Events.CALENDAR_ID`, `EVENT_TIMEZONE` — the two columns
+/// the shim fills without being asked.
+const col_calendar_id = "calendar_id";
+const col_event_timezone = "eventTimezone";
+
+/// The shim writes calendar 1 unconditionally.
+///
+/// Not the primary calendar, not the first visible one — the row whose `_id`
+/// is 1, whatever that happens to be on the device. Reproduced because it is
+/// what the shim does, and because an event landing in a different calendar
+/// than before would be a behaviour change nobody asked for.
+const default_calendar_id: i32 = 1;
+
+/// The event to insert, in the shape `NewCalendarEvent` declares.
+pub const NewEvent = struct {
+    title: []const u8,
+    notes: []const u8,
+    location: []const u8,
+    start_date: i64,
+    end_date: i64,
+    all_day: bool,
+};
+
+/// Read the declared shape, or null where only `org.json`'s coercions would.
+///
+/// `default_start` and `default_end` are the shim's two separate
+/// `System.currentTimeMillis()` calls — separate because Kotlin evaluates each
+/// argument as its `put` runs, so the default end really can be a millisecond
+/// more than `start + 3600000`.
+pub fn parseNewEvent(value: std.json.Value, default_start: i64, default_end: i64) ?NewEvent {
+    const object = switch (value) {
+        .object => |o| o,
+        else => return null,
+    };
+
+    return .{
+        .title = optString(object, "title") orelse return null,
+        .notes = optString(object, "notes") orelse return null,
+        .location = optString(object, "location") orelse return null,
+        .start_date = optLong(object, "startDate", default_start) orelse return null,
+        .end_date = optLong(object, "endDate", default_end) orelse return null,
+        .all_day = optBoolean(object, "isAllDay") orelse return null,
+    };
+}
+
+/// `event.optString(name, "")`, for the shapes this serves.
+///
+/// Outer null means "a shape the shim would coerce and this will not".
+fn optString(object: std.json.ObjectMap, name: []const u8) ?[]const u8 {
+    const value = object.get(name) orelse return "";
+    return switch (value) {
+        .string => |text| text,
+        // `JSONObject.NULL.toString()`. Not a typo and not a fallback: the
+        // shim really does store the four characters.
+        .null => "null",
+        else => null,
+    };
+}
+
+/// `event.optLong(name, fallback)`, for the shapes this serves.
+fn optLong(object: std.json.ObjectMap, name: []const u8, fallback: i64) ?i64 {
+    const value = object.get(name) orelse return fallback;
+    return switch (value) {
+        .integer => |n| n,
+        // `JSON.toLong(NULL)` is null, so the fallback wins — unlike
+        // `optString`, where the same null becomes text.
+        .null => fallback,
+        else => null,
+    };
+}
+
+/// `event.optBoolean(name, false)`, for the shapes this serves.
+fn optBoolean(object: std.json.ObjectMap, name: []const u8) ?bool {
+    const value = object.get(name) orelse return false;
+    return switch (value) {
+        .bool => |b| b,
+        .null => false,
+        else => null,
+    };
+}
+
+/// `contentResolver.insert(Events.CONTENT_URI, values)`, and the id it lands at.
+///
+/// Returns `uri?.lastPathSegment ?: ""` — so a provider that refuses the insert
+/// resolves the page's promise with an empty string rather than rejecting,
+/// which is the shim's answer and not an improvement on it.
+pub fn insertEvent(j: Jni, allocator: std.mem.Allocator, activity: jobject, event: NewEvent) ![]u8 {
+    try j.pushLocalFrame(32);
+    defer _ = j.popLocalFrame(null);
+
+    const values_cls = try j.findClass("android/content/ContentValues");
+    const values = try j.newObjectA(values_cls, try j.methodId(values_cls, "<init>", "()V"), &.{});
+
+    // `ContentValues.put` is overloaded on the *boxed* types, so each number
+    // has to be boxed before it can be put.
+    const put_string = try j.methodId(values_cls, "put", "(Ljava/lang/String;Ljava/lang/String;)V");
+    const put_long = try j.methodId(values_cls, "put", "(Ljava/lang/String;Ljava/lang/Long;)V");
+    const put_int = try j.methodId(values_cls, "put", "(Ljava/lang/String;Ljava/lang/Integer;)V");
+
+    try putString(j, allocator, values, put_string, col_title, event.title);
+    try putString(j, allocator, values, put_string, col_description, event.notes);
+    try putString(j, allocator, values, put_string, col_event_location, event.location);
+    try putLong(j, values, put_long, col_dtstart, event.start_date);
+    try putLong(j, values, put_long, col_dtend, event.end_date);
+    try putInt(j, values, put_int, col_all_day, if (event.all_day) 1 else 0);
+    try putInt(j, values, put_int, col_calendar_id, default_calendar_id);
+
+    // `TimeZone.getDefault().id`. The provider needs one, and an event
+    // inserted without it reads back at the wrong hour.
+    const timezone_cls = try j.findClass("java/util/TimeZone");
+    const timezone = try j.callStaticObjectMethodA(
+        timezone_cls,
+        try j.staticMethodId(timezone_cls, "getDefault", "()Ljava/util/TimeZone;"),
+        &.{},
+    );
+    const timezone_id = try j.callObjectMethod(
+        timezone,
+        try j.methodId(try j.objectClass(timezone), "getID", "()Ljava/lang/String;"),
+    );
+    try j.callVoidMethodA(values, put_string, &.{
+        .{ .l = try j.newStringUtf(col_event_timezone) },
+        .{ .l = timezone_id },
+    });
+
+    const events_cls = try j.findClass("android/provider/CalendarContract$Events");
+    const content_uri = try j.staticObjectField(
+        events_cls,
+        try j.staticFieldId(events_cls, "CONTENT_URI", "Landroid/net/Uri;"),
+    );
+
+    const activity_cls = try j.objectClass(activity);
+    const resolver = try j.callObjectMethod(
+        activity,
+        try j.methodId(activity_cls, "getContentResolver", "()Landroid/content/ContentResolver;"),
+    );
+
+    const uri = try j.callObjectMethodA(
+        resolver,
+        try j.methodId(
+            try j.objectClass(resolver),
+            "insert",
+            "(Landroid/net/Uri;Landroid/content/ContentValues;)Landroid/net/Uri;",
+        ),
+        &.{ .{ .l = content_uri }, .{ .l = values } },
+    );
+
+    if (uri == null) return allocator.dupe(u8, "");
+
+    const segment = try j.callObjectMethod(
+        uri,
+        try j.methodId(try j.objectClass(uri), "getLastPathSegment", "()Ljava/lang/String;"),
+    );
+    if (segment == null) return allocator.dupe(u8, "");
+    return j.stringToUtf8(allocator, segment);
+}
+
+fn putString(
+    j: Jni,
+    allocator: std.mem.Allocator,
+    values: jobject,
+    put: jni.jmethodID,
+    column: [:0]const u8,
+    text: []const u8,
+) !void {
+    try j.pushLocalFrame(4);
+    defer _ = j.popLocalFrame(null);
+
+    // `NewStringUTF` needs a NUL terminator, and a title is arbitrary page
+    // text — so it is copied rather than pointed at.
+    const terminated = try allocator.allocSentinel(u8, text.len, 0);
+    defer allocator.free(terminated);
+    @memcpy(terminated, text);
+
+    try j.callVoidMethodA(values, put, &.{
+        .{ .l = try j.newStringUtf(column) },
+        .{ .l = try j.newStringUtf(terminated.ptr) },
+    });
+}
+
+fn putLong(j: Jni, values: jobject, put: jni.jmethodID, column: [:0]const u8, value: i64) !void {
+    try j.pushLocalFrame(4);
+    defer _ = j.popLocalFrame(null);
+
+    const long_cls = try j.findClass("java/lang/Long");
+    const boxed = try j.callStaticObjectMethodA(
+        long_cls,
+        try j.staticMethodId(long_cls, "valueOf", "(J)Ljava/lang/Long;"),
+        &.{.{ .j = value }},
+    );
+    try j.callVoidMethodA(values, put, &.{ .{ .l = try j.newStringUtf(column) }, .{ .l = boxed } });
+}
+
+fn putInt(j: Jni, values: jobject, put: jni.jmethodID, column: [:0]const u8, value: i32) !void {
+    try j.pushLocalFrame(4);
+    defer _ = j.popLocalFrame(null);
+
+    const integer_cls = try j.findClass("java/lang/Integer");
+    const boxed = try j.callStaticObjectMethodA(
+        integer_cls,
+        try j.staticMethodId(integer_cls, "valueOf", "(I)Ljava/lang/Integer;"),
+        &.{.{ .i = value }},
+    );
+    try j.callVoidMethodA(values, put, &.{ .{ .l = try j.newStringUtf(column) }, .{ .l = boxed } });
+}
+
+/// `message` as a JSON string, for whichever reject global the caller owns.
+pub fn rejectOn(allocator: std.mem.Allocator, global: []const u8, message: []const u8) !void {
+    const payload = try jsonString(allocator, message);
+    defer allocator.free(payload);
+    try events.settle(allocator, global, payload);
+}
+
+// =============================================================================
 // Tests
 // =============================================================================
 
@@ -450,7 +691,7 @@ test "a rejection message with a quote is escaped rather than emitted raw" {
     // The bug that used to be one line away. Before #154 the shim turned an id
     // of `1'x` into `…Reject('For input string: "1'x"')`, which does not parse
     // — so evaluateJavascript ran nothing and the promise never settled.
-    const payload = try rejectPayload(testing.allocator, "For input string: \"1'x\"");
+    const payload = try jsonString(testing.allocator, "For input string: \"1'x\"");
     defer testing.allocator.free(payload);
 
     // Valid JSON, and it round-trips to exactly the original message.
@@ -622,4 +863,147 @@ test "getCalendarEvents names its action and globals as the shim does" {
     try testing.expectEqualStrings("getCalendarEvents", A.get_calendar_events);
     try testing.expectEqualStrings("_craftCalendarResolve", list_resolve_global);
     try testing.expectEqualStrings("_craftCalendarReject", list_reject_global);
+}
+
+// --- createCalendarEvent ---------------------------------------------------
+
+fn parseEvent(json: []const u8, default_start: i64, default_end: i64) !?NewEvent {
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+
+    // The strings borrow from `parsed`, so anything a caller keeps has to be
+    // read before this returns. Every test below asserts inside its own call.
+    const event = parseNewEvent(parsed.value, default_start, default_end) orelse return null;
+    return NewEvent{
+        .title = try testing.allocator.dupe(u8, event.title),
+        .notes = try testing.allocator.dupe(u8, event.notes),
+        .location = try testing.allocator.dupe(u8, event.location),
+        .start_date = event.start_date,
+        .end_date = event.end_date,
+        .all_day = event.all_day,
+    };
+}
+
+fn freeEvent(event: NewEvent) void {
+    testing.allocator.free(event.title);
+    testing.allocator.free(event.notes);
+    testing.allocator.free(event.location);
+}
+
+test "the declared shape reads straight through" {
+    const event = (try parseEvent(
+        \\{"title":"Standup","notes":"daily","location":"Room 2",
+        \\ "startDate":1700000000000,"endDate":1700000900000,"isAllDay":false}
+    , 1, 2)).?;
+    defer freeEvent(event);
+
+    try testing.expectEqualStrings("Standup", event.title);
+    try testing.expectEqualStrings("daily", event.notes);
+    try testing.expectEqualStrings("Room 2", event.location);
+    try testing.expectEqual(@as(i64, 1700000000000), event.start_date);
+    try testing.expectEqual(@as(i64, 1700000900000), event.end_date);
+    try testing.expect(!event.all_day);
+}
+
+test "absent keys take the shim's defaults" {
+    // `optString(name, "")`, `optLong(name, now)`, `optBoolean(name, false)`.
+    // The two date defaults are separate arguments because the shim calls
+    // System.currentTimeMillis() twice, once per put.
+    const event = (try parseEvent("{}", 111, 222)).?;
+    defer freeEvent(event);
+
+    try testing.expectEqualStrings("", event.title);
+    try testing.expectEqualStrings("", event.notes);
+    try testing.expectEqualStrings("", event.location);
+    try testing.expectEqual(@as(i64, 111), event.start_date);
+    try testing.expectEqual(@as(i64, 222), event.end_date);
+    try testing.expect(!event.all_day);
+}
+
+test "an explicit null is text to optString and a fallback to optLong" {
+    // The org.json quirk, and the reason it is worth a test rather than a
+    // comment: `JSONObject.NULL.toString()` is "null", so `optString` hands
+    // back four characters where every other accessor hands back the default.
+    // `JSON.stringify({location: null})` produces this every day.
+    const event = (try parseEvent(
+        \\{"title":null,"notes":null,"location":null,"startDate":null,"endDate":null,"isAllDay":null}
+    , 111, 222)).?;
+    defer freeEvent(event);
+
+    try testing.expectEqualStrings("null", event.title);
+    try testing.expectEqualStrings("null", event.notes);
+    try testing.expectEqualStrings("null", event.location);
+    try testing.expectEqual(@as(i64, 111), event.start_date);
+    try testing.expectEqual(@as(i64, 222), event.end_date);
+    try testing.expect(!event.all_day);
+}
+
+test "a shape only org.json would coerce is handed back rather than guessed at" {
+    // Each of these is something `optString`/`optLong`/`optBoolean` reads
+    // happily and this does not. Returning null sends the native down its
+    // false path, the shim reads it, and the page cannot tell — which is the
+    // whole reason the rule can be this narrow.
+    for ([_][]const u8{
+        // A number where NewCalendarEvent declares a string: optString would
+        // give "1.5", and reproducing Double.toString is not a guess to make.
+        \\{"title":1.5}
+        ,
+        \\{"title":7}
+        ,
+        \\{"location":true}
+        ,
+        // A string where it declares a number: optLong parses it as a double
+        // and truncates, so "1.9" is 1.
+        \\{"startDate":"1700000000000"}
+        ,
+        \\{"endDate":"1.9"}
+        ,
+        // A float where it declares a number: optLong truncates toward zero.
+        \\{"startDate":1.9}
+        ,
+        // optBoolean reads "true" and "false" case-insensitively.
+        \\{"isAllDay":"true"}
+        ,
+        \\{"isAllDay":1}
+        ,
+        // Not an object at all.
+        \\[]
+        ,
+        \\"title"
+        ,
+    }) |payload| {
+        const event = try parseEvent(payload, 1, 2);
+        if (event) |kept| {
+            freeEvent(kept);
+            std.debug.print("payload was served rather than handed back: {s}\n", .{payload});
+            return error.CoercedShapeAccepted;
+        }
+    }
+}
+
+test "the columns createCalendarEvent fills are the shim's" {
+    try testing.expectEqualStrings("calendar_id", col_calendar_id);
+    try testing.expectEqualStrings("eventTimezone", col_event_timezone);
+
+    // The shim writes calendar 1 unconditionally — not the primary calendar,
+    // the row whose _id is 1. Written down because it looks like a bug and is
+    // instead a faithful port of one.
+    try testing.expectEqual(@as(i32, 1), default_calendar_id);
+}
+
+test "createCalendarEvent names its action and globals as the shim does" {
+    try testing.expectEqualStrings("createCalendarEvent", A.create_calendar_event);
+    try testing.expectEqualStrings("_craftCreateEventResolve", create_resolve_global);
+    try testing.expectEqualStrings("_craftCreateEventReject", create_reject_global);
+}
+
+test "an id carrying a quote resolves as JSON rather than breaking the reply" {
+    // `uri.lastPathSegment` is provider-controlled text, and it goes to the
+    // page through the same channel a rejection does.
+    const payload = try jsonString(testing.allocator, "17'x");
+    defer testing.allocator.free(payload);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, payload, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("17'x", parsed.value.string);
 }

--- a/packages/zig/src/bridge_android_calendar.zig
+++ b/packages/zig/src/bridge_android_calendar.zig
@@ -1,5 +1,5 @@
-//! `deleteCalendarEvent` on Android — the first action here that answers
-//! through the reply channel rather than by returning.
+//! The calendar actions on Android, both of which answer through the reply
+//! channel rather than by returning.
 //!
 //! ## What the shim does
 //!
@@ -40,11 +40,18 @@ const jobject = jni.jobject;
 
 pub const A = struct {
     pub const delete_calendar_event = "deleteCalendarEvent";
+    pub const get_calendar_events = "getCalendarEvents";
 };
 
-/// The globals the injected JS assigns for this action.
+/// The globals the injected JS assigns for each action.
+///
+/// `getCalendarEvents` uses `_craftCalendar*` rather than a name of its own,
+/// which is worth noticing rather than tidying: the injected JS assigns them,
+/// and renaming one side is a promise that never settles.
 pub const resolve_global = "_craftDeleteEventResolve";
 pub const reject_global = "_craftDeleteEventReject";
+pub const list_resolve_global = "_craftCalendarResolve";
+pub const list_reject_global = "_craftCalendarReject";
 
 /// `Long.parseLong(text)`, or null where Java would throw.
 ///
@@ -140,6 +147,276 @@ pub fn rejectPayload(allocator: std.mem.Allocator, message: []const u8) ![]u8 {
 }
 
 // =============================================================================
+// getCalendarEvents
+// =============================================================================
+//
+// The column names are literals rather than static field reads, and that is
+// the faithful choice rather than the lazy one: `CalendarContract.Events.TITLE`
+// is `public static final String TITLE = "title"`, a compile-time constant, so
+// javac folds it into the shim's DEX. The shim never reads those fields at
+// runtime either. `CONTENT_URI` is a `Uri` object and so is read through JNI,
+// the way `deleteEvent` reads it.
+
+const col_id = "_id";
+const col_title = "title";
+const col_description = "description";
+const col_dtstart = "dtstart";
+const col_dtend = "dtend";
+const col_event_location = "eventLocation";
+const col_all_day = "allDay";
+
+/// The projection, in the order the shim lists it — which is also the order
+/// the cursor indices below depend on.
+const projection = [_][:0]const u8{
+    col_id,
+    col_title,
+    col_description,
+    col_dtstart,
+    col_dtend,
+    col_event_location,
+    col_all_day,
+};
+
+const selection = "(" ++ col_dtstart ++ " >= ?) AND (" ++ col_dtstart ++ " <= ?)";
+const sort_order = col_dtstart ++ " ASC";
+
+/// Thirty days, the shim's default window: `30L * 24 * 60 * 60 * 1000`.
+const thirty_days_ms: i64 = 30 * 24 * 60 * 60 * 1000;
+
+pub const Window = struct { start: i64, end: i64 };
+
+/// The shim's defaulting, including the arithmetic that can wrap.
+///
+/// `startTime + (30L * 24 * 60 * 60 * 1000)` is Kotlin `Long` addition, which
+/// wraps silently rather than throwing — so `+%` is the faithful operator and
+/// `+` would panic in a debug build where the shim quietly returns nothing.
+pub fn windowFor(start_ms: i64, end_ms: i64, now_ms: i64) Window {
+    const start = if (start_ms > 0) start_ms else now_ms;
+    return .{
+        .start = start,
+        // A caller passing an end before the start gets an empty result rather
+        // than an error, because that is what the query does. Not corrected
+        // here: the shim does not correct it either.
+        .end = if (end_ms > 0) end_ms else start +% thirty_days_ms,
+    };
+}
+
+/// One row, as the cursor gives it.
+///
+/// The strings are optional because `Cursor.getString` returns null for a null
+/// column, and the shim treats that differently per field — `?: ""` for five of
+/// them, and nothing at all for the id.
+pub const Event = struct {
+    id: ?[]const u8,
+    title: ?[]const u8,
+    notes: ?[]const u8,
+    start_date: i64,
+    end_date: i64,
+    location: ?[]const u8,
+    all_day: i32,
+};
+
+/// One event as the shim's `JSONObject` would print it.
+///
+/// Two behaviours here are `org.json`'s rather than anything chosen:
+///
+///  - `put(name, null)` **removes** the mapping, so a null id leaves the key
+///    out of the object entirely rather than emitting `"id":null`;
+///  - insertion order is preserved, because `JSONObject` is backed by a
+///    `LinkedHashMap` — so the key order is the order of the shim's `apply`
+///    block and not alphabetical.
+pub fn appendEvent(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), event: Event) !void {
+    try out.append(allocator, '{');
+
+    if (event.id) |id| {
+        try appendStringMember(allocator, out, "id", id);
+        try out.append(allocator, ',');
+    }
+    try appendStringMember(allocator, out, "title", event.title orelse "");
+    try out.append(allocator, ',');
+    try appendStringMember(allocator, out, "notes", event.notes orelse "");
+    try out.append(allocator, ',');
+    try out.appendSlice(allocator, "\"startDate\":");
+    try appendInt(allocator, out, event.start_date);
+    try out.appendSlice(allocator, ",\"endDate\":");
+    try appendInt(allocator, out, event.end_date);
+    try out.append(allocator, ',');
+    try appendStringMember(allocator, out, "location", event.location orelse "");
+
+    // `it.getInt(6) == 1`, so 0 and 2 are both false. Reproduced rather than
+    // relaxed to `!= 0`: `allDay` is only ever 0 or 1, and a bridge that
+    // disagreed with the shim about a third value would disagree silently.
+    try out.appendSlice(allocator, ",\"isAllDay\":");
+    try out.appendSlice(allocator, if (event.all_day == 1) "true" else "false");
+
+    try out.append(allocator, '}');
+}
+
+fn appendStringMember(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    name: []const u8,
+    value: []const u8,
+) !void {
+    try out.append(allocator, '"');
+    try out.appendSlice(allocator, name);
+    try out.appendSlice(allocator, "\":\"");
+    try bridge_error.appendJsonEscaped(allocator, out, value);
+    try out.append(allocator, '"');
+}
+
+fn appendInt(allocator: std.mem.Allocator, out: *std.ArrayListUnmanaged(u8), value: i64) !void {
+    var buf: [32]u8 = undefined;
+    try out.appendSlice(allocator, try std.fmt.bufPrint(&buf, "{d}", .{value}));
+}
+
+/// `Long.toString(value)` as a NUL-terminated string, for `NewStringUTF`.
+///
+/// Decimal with a leading `-` and nothing else, which is what `Long.toString`
+/// produces and what the provider parses back out of a selection argument.
+fn decimalZ(buf: []u8, value: i64) ![*:0]const u8 {
+    const text = try std.fmt.bufPrint(buf[0 .. buf.len - 1], "{d}", .{value});
+    buf[text.len] = 0;
+    return @ptrCast(text.ptr);
+}
+
+/// `System.currentTimeMillis()`.
+///
+/// Through JNI rather than a host clock, because it is what the shim's default
+/// window is measured from — and because `std.time` on this toolchain has no
+/// wall-clock call that works without libc. Belongs in a shared Android helper
+/// the moment a second action needs it.
+pub fn currentTimeMillis(j: Jni) !i64 {
+    try j.pushLocalFrame(4);
+    defer _ = j.popLocalFrame(null);
+
+    const system_cls = try j.findClass("java/lang/System");
+    return j.callStaticLongMethodA(
+        system_cls,
+        try j.staticMethodId(system_cls, "currentTimeMillis", "()J"),
+        &.{},
+    );
+}
+
+/// `contentResolver.query(...)`, every row appended to `out` as JSON.
+///
+/// `out` receives the array including its brackets, so a query returning no
+/// cursor at all produces `[]` — which is what `cursor?.use` does in the shim
+/// when the provider hands back null.
+pub fn queryEvents(
+    j: Jni,
+    allocator: std.mem.Allocator,
+    activity: jobject,
+    window: Window,
+    out: *std.ArrayListUnmanaged(u8),
+) !void {
+    try j.pushLocalFrame(24);
+    defer _ = j.popLocalFrame(null);
+
+    const string_cls = try j.findClass("java/lang/String");
+
+    const projection_array = try j.newObjectArray(projection.len, string_cls);
+    inline for (projection, 0..) |name, i| {
+        try j.setObjectArrayElement(projection_array, i, try j.newStringUtf(name));
+    }
+
+    // `startTime.toString()` — `Long.toString`, which is decimal with a
+    // leading `-` and nothing else, so `bufPrintIntToSlice` matches it.
+    var start_buf: [24]u8 = undefined;
+    var end_buf: [24]u8 = undefined;
+    const args_array = try j.newObjectArray(2, string_cls);
+    try j.setObjectArrayElement(args_array, 0, try j.newStringUtf(try decimalZ(&start_buf, window.start)));
+    try j.setObjectArrayElement(args_array, 1, try j.newStringUtf(try decimalZ(&end_buf, window.end)));
+
+    const events_cls = try j.findClass("android/provider/CalendarContract$Events");
+    const content_uri = try j.staticObjectField(
+        events_cls,
+        try j.staticFieldId(events_cls, "CONTENT_URI", "Landroid/net/Uri;"),
+    );
+
+    const activity_cls = try j.objectClass(activity);
+    const resolver = try j.callObjectMethod(
+        activity,
+        try j.methodId(activity_cls, "getContentResolver", "()Landroid/content/ContentResolver;"),
+    );
+
+    const resolver_cls = try j.objectClass(resolver);
+    const cursor = try j.callObjectMethodA(
+        resolver,
+        try j.methodId(
+            resolver_cls,
+            "query",
+            "(Landroid/net/Uri;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;)Landroid/database/Cursor;",
+        ),
+        &.{
+            .{ .l = content_uri },
+            .{ .l = projection_array },
+            .{ .l = try j.newStringUtf(selection) },
+            .{ .l = args_array },
+            .{ .l = try j.newStringUtf(sort_order) },
+        },
+    );
+
+    try out.append(allocator, '[');
+    defer out.append(allocator, ']') catch {};
+
+    // A provider that cannot answer returns null rather than an empty cursor,
+    // and `cursor?.use` skips the loop. An empty array is the honest reply:
+    // the shim resolves with one too.
+    if (cursor == null) return;
+
+    const cursor_cls = try j.objectClass(cursor);
+    const move_to_next = try j.methodId(cursor_cls, "moveToNext", "()Z");
+    const get_string = try j.methodId(cursor_cls, "getString", "(I)Ljava/lang/String;");
+    const get_long = try j.methodId(cursor_cls, "getLong", "(I)J");
+    const get_int = try j.methodId(cursor_cls, "getInt", "(I)I");
+    const close = try j.methodId(cursor_cls, "close", "()V");
+
+    // `use` closes the cursor however the block leaves — including on the way
+    // out of an error, which is what leaks a provider connection otherwise.
+    defer j.callVoidMethodA(cursor, close, &.{}) catch {};
+
+    var count: usize = 0;
+    while (try j.callBooleanMethodA(cursor, move_to_next, &.{})) {
+        // Each row's strings are local references, and the JVM guarantees only
+        // sixteen slots. A frame per row is what keeps a long calendar from
+        // overflowing the table, which aborts the process rather than throwing.
+        try j.pushLocalFrame(8);
+        defer _ = j.popLocalFrame(null);
+
+        const event: Event = .{
+            .id = try columnText(j, allocator, cursor, get_string, 0),
+            .title = try columnText(j, allocator, cursor, get_string, 1),
+            .notes = try columnText(j, allocator, cursor, get_string, 2),
+            .start_date = try j.callLongMethodA(cursor, get_long, &.{.{ .i = 3 }}),
+            .end_date = try j.callLongMethodA(cursor, get_long, &.{.{ .i = 4 }}),
+            .location = try columnText(j, allocator, cursor, get_string, 5),
+            .all_day = try j.callIntMethodA(cursor, get_int, &.{.{ .i = 6 }}),
+        };
+
+        if (count != 0) try out.append(allocator, ',');
+        try appendEvent(allocator, out, event);
+        count += 1;
+    }
+}
+
+/// `cursor.getString(index)`, null included.
+///
+/// The allocation outlives the row's local frame because `stringToUtf8` copies
+/// into `allocator` — the `jstring` itself does not.
+fn columnText(
+    j: Jni,
+    allocator: std.mem.Allocator,
+    cursor: jobject,
+    get_string: jni.jmethodID,
+    index: i32,
+) !?[]const u8 {
+    const value = try j.callObjectMethodA(cursor, get_string, &.{.{ .i = index }});
+    if (value == null) return null;
+    return try j.stringToUtf8(allocator, value);
+}
+
+// =============================================================================
 // Tests
 // =============================================================================
 
@@ -192,4 +469,157 @@ test "the action name and its globals match the shim exactly" {
     try testing.expectEqualStrings("deleteCalendarEvent", A.delete_calendar_event);
     try testing.expectEqualStrings("_craftDeleteEventResolve", resolve_global);
     try testing.expectEqualStrings("_craftDeleteEventReject", reject_global);
+}
+
+test "an absent window falls back the way the shim's does" {
+    const now: i64 = 1_700_000_000_000;
+
+    // Both supplied: used as given, including an end before the start. The
+    // shim does not correct that and neither does this.
+    try testing.expectEqual(Window{ .start = 10, .end = 20 }, windowFor(10, 20, now));
+    try testing.expectEqual(Window{ .start = 30, .end = 20 }, windowFor(30, 20, now));
+
+    // `if (startDateMs > 0)` — zero and negative both mean "now", which is why
+    // this is not `>= 0`.
+    try testing.expectEqual(now, windowFor(0, 20, now).start);
+    try testing.expectEqual(now, windowFor(-1, 20, now).start);
+
+    // Thirty days, in milliseconds.
+    try testing.expectEqual(now + 2_592_000_000, windowFor(0, 0, now).end);
+    try testing.expectEqual(@as(i64, 10 + 2_592_000_000), windowFor(10, 0, now).end);
+}
+
+test "a window whose default end overflows wraps rather than trapping" {
+    // Kotlin `Long` addition wraps. A page passing a start near Long.MAX_VALUE
+    // gets a nonsensical window and an empty result from the shim; a `+` here
+    // would instead panic in a debug build, which is a different bug.
+    const near_max: i64 = std.math.maxInt(i64) - 5;
+    try testing.expectEqual(near_max +% 2_592_000_000, windowFor(near_max, 0, 0).end);
+}
+
+fn renderEvents(events_in: []const Event) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(testing.allocator);
+    try out.append(testing.allocator, '[');
+    for (events_in, 0..) |event, i| {
+        if (i != 0) try out.append(testing.allocator, ',');
+        try appendEvent(testing.allocator, &out, event);
+    }
+    try out.append(testing.allocator, ']');
+    return out.toOwnedSlice(testing.allocator);
+}
+
+const sample: Event = .{
+    .id = "17",
+    .title = "Standup",
+    .notes = "",
+    .start_date = 1_700_000_000_000,
+    .end_date = 1_700_000_900_000,
+    .location = "Room 2",
+    .all_day = 0,
+};
+
+test "an event prints the keys the shim's JSONObject prints, in that order" {
+    const json = try renderEvents(&.{sample});
+    defer testing.allocator.free(json);
+
+    // JSONObject is a LinkedHashMap, so the shim emits insertion order — the
+    // order of its `apply` block. Asserted as a whole string rather than key
+    // by key, because the order is the part that a rewrite would lose.
+    try testing.expectEqualStrings(
+        \\[{"id":"17","title":"Standup","notes":"","startDate":1700000000000,"endDate":1700000900000,"location":"Room 2","isAllDay":false}]
+    , json);
+}
+
+test "a null id leaves the key out, and null text becomes empty" {
+    // `put(name, null)` removes the mapping rather than storing JSON null, so
+    // the shim's object has no `id` at all. The other five columns are read
+    // with `?: ""`, which is a different answer to the same null.
+    const json = try renderEvents(&.{.{
+        .id = null,
+        .title = null,
+        .notes = null,
+        .start_date = 0,
+        .end_date = 0,
+        .location = null,
+        .all_day = 1,
+    }});
+    defer testing.allocator.free(json);
+
+    try testing.expectEqualStrings(
+        \\[{"title":"","notes":"","startDate":0,"endDate":0,"location":"","isAllDay":true}]
+    , json);
+}
+
+test "isAllDay is the shim's == 1 and not a truthiness test" {
+    for ([_]struct { value: i32, expected: []const u8 }{
+        .{ .value = 0, .expected = "\"isAllDay\":false" },
+        .{ .value = 1, .expected = "\"isAllDay\":true" },
+        // `getInt(6) == 1` says false here, and a `!= 0` would say true. The
+        // column only ever holds 0 or 1, so this row is the one that would go
+        // unnoticed — which is why it is written down.
+        .{ .value = 2, .expected = "\"isAllDay\":false" },
+        .{ .value = -1, .expected = "\"isAllDay\":false" },
+    }) |case| {
+        var event = sample;
+        event.all_day = case.value;
+        const json = try renderEvents(&.{event});
+        defer testing.allocator.free(json);
+
+        try testing.expect(std.mem.indexOf(u8, json, case.expected) != null);
+    }
+}
+
+test "a title carrying a quote survives as JSON rather than breaking the reply" {
+    // The payload goes to `events.settle`, which sends it as written. An event
+    // called `Bob's "1:1"` is ordinary, and it is exactly what an unescaped
+    // build would turn into a script that does not parse.
+    var event = sample;
+    event.title = "Bob's \"1:1\"";
+    event.location = "line\nbreak";
+
+    const json = try renderEvents(&.{event});
+    defer testing.allocator.free(json);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+
+    const first = parsed.value.array.items[0].object;
+    try testing.expectEqualStrings("Bob's \"1:1\"", first.get("title").?.string);
+    try testing.expectEqualStrings("line\nbreak", first.get("location").?.string);
+    try testing.expect(first.get("id") != null);
+}
+
+test "an empty calendar and a full one both parse" {
+    const empty = try renderEvents(&.{});
+    defer testing.allocator.free(empty);
+    try testing.expectEqualStrings("[]", empty);
+
+    var second = sample;
+    second.id = "18";
+    const two = try renderEvents(&.{ sample, second });
+    defer testing.allocator.free(two);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, two, .{});
+    defer parsed.deinit();
+    try testing.expectEqual(@as(usize, 2), parsed.value.array.items.len);
+}
+
+test "the query strings are the shim's, character for character" {
+    // The selection and sort order are built from the same column constants
+    // the projection uses, so a typo would have to be in one place. Asserted
+    // against literals anyway: these are what the provider parses, and the
+    // constants they are built from are not independently checked.
+    try testing.expectEqualStrings("(dtstart >= ?) AND (dtstart <= ?)", selection);
+    try testing.expectEqualStrings("dtstart ASC", sort_order);
+    try testing.expectEqual(@as(usize, 7), projection.len);
+    try testing.expectEqualStrings("_id", projection[0]);
+    try testing.expectEqualStrings("eventLocation", projection[5]);
+    try testing.expectEqualStrings("allDay", projection[6]);
+}
+
+test "getCalendarEvents names its action and globals as the shim does" {
+    try testing.expectEqualStrings("getCalendarEvents", A.get_calendar_events);
+    try testing.expectEqualStrings("_craftCalendarResolve", list_resolve_global);
+    try testing.expectEqualStrings("_craftCalendarReject", list_reject_global);
 }

--- a/packages/zig/src/jni_runtime.zig
+++ b/packages/zig/src/jni_runtime.zig
@@ -642,6 +642,14 @@ pub const Jni = struct {
         return result != JNI_FALSE;
     }
 
+    pub fn callLongMethodA(self: Self, obj: jobject, id: jmethodID, args: []const jvalue) JniError!jlong {
+        const call: *const fn (JNIEnv, jobject, jmethodID, [*]const jvalue) callconv(.c) jlong =
+            @ptrCast(self.table().CallLongMethodA orelse return JniError.NotFound);
+        const result = call(self.env, obj, id, args.ptr);
+        try self.check();
+        return result;
+    }
+
     pub fn callVoidMethodA(self: Self, obj: jobject, id: jmethodID, args: []const jvalue) JniError!void {
         const call: *const fn (JNIEnv, jobject, jmethodID, [*]const jvalue) callconv(.c) void =
             @ptrCast(self.table().CallVoidMethodA orelse return JniError.NotFound);
@@ -706,10 +714,14 @@ pub const Jni = struct {
 
     // --- Arrays -----------------------------------------------------------
     //
-    // Only `long[]` so far, because only `VibrationEffect.createWaveform`
-    // needs one. `SetLongArrayRegion` copies from a Zig slice in one call
-    // rather than element by element, which is both faster and the only form
-    // that cannot leave a partially-filled array behind on an error.
+    // `long[]` for `VibrationEffect.createWaveform`, and `String[]` for the
+    // projection and selection arguments a `ContentResolver.query` takes.
+    //
+    // The two are shaped differently because JNI is: a primitive array can be
+    // filled from a Zig slice in one `SetLongArrayRegion` call, which is both
+    // faster and the only form that cannot leave a partially-filled array
+    // behind on an error. An object array has no region form and has to be
+    // written a slot at a time.
 
     pub fn newLongArray(self: Self, values: []const jlong) JniError!jobject {
         const new: *const fn (JNIEnv, jsize) callconv(.c) jobject =
@@ -726,6 +738,29 @@ pub const Jni = struct {
         set(self.env, array, 0, @intCast(values.len), values.ptr);
         try self.check();
         return array;
+    }
+
+    /// `new <element_class>[len]`, every slot null.
+    ///
+    /// `NewObjectArray` takes an initial element for every slot; null is what
+    /// the Kotlin's `arrayOf(...)` starts from before its entries are written,
+    /// and every caller here fills the array immediately.
+    pub fn newObjectArray(self: Self, len: usize, element_class: jclass) JniError!jobject {
+        const new: *const fn (JNIEnv, jsize, jclass, jobject) callconv(.c) jobject =
+            @ptrCast(self.table().NewObjectArray orelse return JniError.NotFound);
+        const array = new(self.env, @intCast(len), element_class, null) orelse {
+            try self.check();
+            return JniError.OutOfMemory;
+        };
+        try self.check();
+        return array;
+    }
+
+    pub fn setObjectArrayElement(self: Self, array: jobject, index: usize, value: jobject) JniError!void {
+        const set: *const fn (JNIEnv, jobject, jsize, jobject) callconv(.c) void =
+            @ptrCast(self.table().SetObjectArrayElement orelse return JniError.NotFound);
+        set(self.env, array, @intCast(index), value);
+        try self.check();
     }
 
     /// Make a Java `String` from UTF-8.
@@ -778,6 +813,14 @@ pub const Jni = struct {
     pub fn callStaticObjectMethodA(self: Self, cls: jclass, id: jmethodID, args: []const jvalue) JniError!jobject {
         const call: *const fn (JNIEnv, jclass, jmethodID, [*]const jvalue) callconv(.c) jobject =
             @ptrCast(self.table().CallStaticObjectMethodA orelse return JniError.NotFound);
+        const result = call(self.env, cls, id, args.ptr);
+        try self.check();
+        return result;
+    }
+
+    pub fn callStaticLongMethodA(self: Self, cls: jclass, id: jmethodID, args: []const jvalue) JniError!jlong {
+        const call: *const fn (JNIEnv, jclass, jmethodID, [*]const jvalue) callconv(.c) jlong =
+            @ptrCast(self.table().CallStaticLongMethodA orelse return JniError.NotFound);
         const result = call(self.env, cls, id, args.ptr);
         try self.check();
         return result;

--- a/packages/zig/test/android_conformance_test.zig
+++ b/packages/zig/test/android_conformance_test.zig
@@ -65,8 +65,8 @@ const zig_sources = [_][]const u8{
 /// notification cancels; 86 with deleteCalendarEvent, the first to answer
 /// through the reply channel rather than by returning; 85 with
 /// getCalendarEvents, the first to send the page a payload it built rather
-/// than a constant.
-const max_not_yet_migrated: usize = 85;
+/// than a constant; 84 with createCalendarEvent, the first to read one.
+const max_not_yet_migrated: usize = 84;
 
 /// Every `@JavascriptInterface fun <name>(` in the Kotlin bridge.
 ///

--- a/packages/zig/test/android_conformance_test.zig
+++ b/packages/zig/test/android_conformance_test.zig
@@ -63,8 +63,10 @@ const zig_sources = [_][]const u8{
 /// 91 with the secure-storage quartet, the first to take a Kotlin-held object
 /// rather than the Activity; 89 with haptic and vibrate; 87 with the
 /// notification cancels; 86 with deleteCalendarEvent, the first to answer
-/// through the reply channel rather than by returning.
-const max_not_yet_migrated: usize = 86;
+/// through the reply channel rather than by returning; 85 with
+/// getCalendarEvents, the first to send the page a payload it built rather
+/// than a constant.
+const max_not_yet_migrated: usize = 85;
 
 /// Every `@JavascriptInterface fun <name>(` in the Kotlin bridge.
 ///


### PR DESCRIPTION
Two actions, sharing the JNI surface the first one needed. `deleteCalendarEvent` proved the reply channel could carry `true`; these carry a payload built from a `ContentProvider` and a payload read from the page, which is where the encoding decisions actually start.

## getCalendarEvents — what the shim's JSON does that is not obvious

Three behaviours here are `org.json`'s rather than anything chosen, and all three are reproduced:

- **`put(name, null)` removes the mapping.** A row whose `_id` is null produces an object with no `id` key at all — not `"id":null`. The other five text columns are read with `?: ""`, which is a different answer to the same null.
- **Key order is insertion order**, because `JSONObject` is a `LinkedHashMap`. The test asserts the rendered object as one whole string, because the order is the part a rewrite would quietly lose.
- **`isAllDay` is `getInt(6) == 1`**, so a 2 is false. Kept as `== 1` rather than relaxed to `!= 0` — the column only ever holds 0 or 1, which is exactly why a disagreement about a third value would go unnoticed. That row is in the table.

The column names are literals, and that is the faithful choice: `CalendarContract.Events.TITLE` is `public static final String TITLE = "title"`, a compile-time constant, so javac folds it into the shim's DEX and the shim never reads that field at runtime either. `CONTENT_URI` is a `Uri` object, so it is still read through JNI.

The default window wraps. `startTime + (30L * 24 * 60 * 60 * 1000)` is Kotlin `Long` addition, which wraps silently — so `+%` is the faithful operator, and a plain `+` would panic in a debug build where the shim quietly returns an empty result.

## createCalendarEvent — which payloads Zig is allowed to answer

The shim reads the event through `org.json`, whose accessors coerce: a `startDate` sent as the string `"1700000000000"` is a number to `optLong`, a `title` sent as `1.5` is the string `"1.5"` to `optString`, a `"true"` is a boolean to `optBoolean`. Reproducing `Double.toString` from memory is not a thing to guess at.

So the rule is narrow and written down rather than approximated: **Zig serves the shape `NewCalendarEvent` declares** — strings for the text, numbers for the dates, a boolean for the flag — plus absent keys and explicit nulls. Anything else makes `parseNewEvent` return null, the native returns false, and the shim reads it with the coercions it already has. Nothing has been settled at that point, so the page cannot tell.

That also covers the parsers disagreeing: `JSONTokener` is lenient where `std.json` is strict — unquoted keys, single quotes, a trailing comma — and the difference only ever sends work back to the shim, never the other way.

**The one coercion that is reproduced** is the surprising one. `optString` on an explicit JSON null returns the four characters `"null"`, because `JSONObject.NULL.toString()` is `"null"` and `JSON.toString` reaches for `toString` on anything that is not already a String. `optLong` on the same null takes the fallback instead. `JSON.stringify({location: null})` produces this every day, so it is a live path — and it has a test that fails when the quirk is removed.

**Two things ported faithfully that look like bugs:** the shim writes `CALENDAR_ID = 1` unconditionally (not the primary calendar — the row whose `_id` is 1), and its two date defaults are separate `System.currentTimeMillis()` calls, so the default end really can be a millisecond more than `start + 3600000`. That is why `parseNewEvent` takes two defaults rather than computing the second from the first.

## New JNI surface

- `String[]` arrays: `NewObjectArray` / `SetObjectArrayElement`. Unlike `long[]` these have no region form, so they are written a slot at a time — the arrays comment now says why the two shapes differ.
- `CallLongMethodA` and `CallStaticLongMethodA`.
- Each cursor row runs inside its own local frame. The JVM guarantees only sixteen local slots, and overflowing the table **aborts the process** rather than throwing, so a long calendar is a real hazard.
- `ContentValues.put` is overloaded on the boxed types, so every number goes through `Long.valueOf` / `Integer.valueOf`.
- `android_permissions.zig` calls `Context.checkSelfPermission` and `Activity.requestPermissions` directly. Not a shortcut around AndroidX: those are exactly the methods `ContextCompat` and `ActivityCompat` delegate to from API 23, and staying on the framework keeps `androidx.core` off a library that builds with no NDK.

`System.currentTimeMillis()` goes through JNI rather than a host clock, because it is what the shim's defaults are measured from — and because `std.time` on this toolchain has no wall-clock call that works without libc.

## Where getCalendarEvents declines to serve

If the query throws, the native returns false and the shim runs instead. The shim has **no try/catch** around `getCalendarEvents`, so the exception escapes the `@JavascriptInterface` method and the promise hangs — the fourth instance of the family in #127/#148/#154. Rejecting here would be kinder and would also be a divergence nothing records, so it is filed as #157 and left to be fixed on the Kotlin side.

## One thing noticed in passing

`CalendarEvent` in `craft.d.ts` declares `description?: string; // Android`, but Android emits `notes` and reads `notes` — `description` is never written or read by either bridge. Left alone here rather than folded into a calendar PR; it belongs with the rest of #140.

## Testing

`zig build test:android` passes with the ratchet at 84. Both mutation checks fired before this was committed: removing the `"null"` quirk and accepting a float `startDate` each fail a named test. Both `libcraft.so` targets still build with no NDK, and `JNI_OnLoad` is still the only export.