### PR TITLE
feat(android): dbExecute and dbQuery in Zig — ratchet 84 → 82

### DIFF
--- a/packages/android/templates/CraftBridge.kt.template
+++ b/packages/android/templates/CraftBridge.kt.template
@@ -2843,6 +2843,12 @@ class CraftBridge(
                 database = activity.openOrCreateDatabase("craft.db", Context.MODE_PRIVATE, null)
             }
 
+            // After the open, so Zig borrows this connection rather than
+            // starting a second one against the same file. Zig answers through
+            // the reply channel, so returning is what stops the promise being
+            // settled twice.
+            database?.let { if (CraftNative.dbExecute(it, sql, paramsJson)) return }
+
             val params = JSONArray(paramsJson)
             val args = Array(params.length()) { params.getString(it) }
 
@@ -2870,6 +2876,8 @@ class CraftBridge(
             if (database == null) {
                 database = activity.openOrCreateDatabase("craft.db", Context.MODE_PRIVATE, null)
             }
+
+            database?.let { if (CraftNative.dbQuery(it, sql, paramsJson)) return }
 
             val params = JSONArray(paramsJson)
             val args = Array(params.length()) { params.getString(it) }

--- a/packages/android/templates/CraftNative.kt.template
+++ b/packages/android/templates/CraftNative.kt.template
@@ -2,6 +2,7 @@ package com.craft.runtime
 
 import android.app.Activity
 import android.content.SharedPreferences
+import android.database.sqlite.SQLiteDatabase
 import org.json.JSONObject
 
 /**
@@ -110,6 +111,8 @@ object CraftNative {
     private external fun nativeDeleteCalendarEvent(activity: Activity, eventId: String): Boolean
     private external fun nativeGetCalendarEvents(activity: Activity, startDateMs: Long, endDateMs: Long): Boolean
     private external fun nativeCreateCalendarEvent(activity: Activity, eventJson: String): Boolean
+    private external fun nativeDbExecute(database: SQLiteDatabase, sql: String, paramsJson: String): Boolean
+    private external fun nativeDbQuery(database: SQLiteDatabase, sql: String, paramsJson: String): Boolean
 
     /**
      * `getDeviceInfo`, or null to use the Kotlin implementation.
@@ -381,6 +384,33 @@ object CraftNative {
         if (!isAvailable) return false
         return try {
             nativeCreateCalendarEvent(activity, eventJson)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    /**
+     * Returns whether Zig took the statement.
+     *
+     * The connection is passed in rather than opened: the Kotlin caches one
+     * `SQLiteDatabase` so that a BEGIN in one call and a COMMIT in the next
+     * reach the same connection, and a second one opened by Zig would take
+     * locks against the first for no visible reason.
+     */
+    fun dbExecute(database: SQLiteDatabase, sql: String, paramsJson: String): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeDbExecute(database, sql, paramsJson)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    /** The same, for a statement that returns rows. */
+    fun dbQuery(database: SQLiteDatabase, sql: String, paramsJson: String): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeDbQuery(database, sql, paramsJson)
         } catch (e: UnsatisfiedLinkError) {
             false
         }

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -458,6 +458,9 @@ pub fn build(b: *std.Build) void {
     android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_calendar.zig", .{
         .root_source_file = b.path("src/bridge_android_calendar.zig"),
     });
+    android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_db.zig", .{
+        .root_source_file = b.path("src/bridge_android_db.zig"),
+    });
     const run_android_conformance_tests = b.addRunArtifact(android_conformance_tests);
 
     // The page surface, across both bridges. Not folded into the iOS

--- a/packages/zig/src/android_dispatch.zig
+++ b/packages/zig/src/android_dispatch.zig
@@ -47,6 +47,7 @@ const haptics = @import("bridge_android_haptics.zig");
 const notifcancel = @import("bridge_android_notifcancel.zig");
 const events = @import("android_events.zig");
 const calendar = @import("bridge_android_calendar.zig");
+const db = @import("bridge_android_db.zig");
 
 const Jni = jni.Jni;
 
@@ -247,6 +248,19 @@ const natives = [_]jni.JNINativeMethod{
         .name = "nativeCreateCalendarEvent",
         .signature = "(Landroid/app/Activity;Ljava/lang/String;)Z",
         .fnPtr = @ptrCast(&nativeCreateCalendarEvent),
+    },
+    // The database arrives as an argument rather than being opened here, so
+    // one connection serves both languages — the same shape the secure store
+    // uses for its SharedPreferences.
+    .{
+        .name = "nativeDbExecute",
+        .signature = "(Landroid/database/sqlite/SQLiteDatabase;Ljava/lang/String;Ljava/lang/String;)Z",
+        .fnPtr = @ptrCast(&nativeDbExecute),
+    },
+    .{
+        .name = "nativeDbQuery",
+        .signature = "(Landroid/database/sqlite/SQLiteDatabase;Ljava/lang/String;Ljava/lang/String;)Z",
+        .fnPtr = @ptrCast(&nativeDbQuery),
     },
 };
 
@@ -789,6 +803,85 @@ fn nativeCreateCalendarEvent(
     return jni.JNI_TRUE;
 }
 
+/// The parameters and SQL both actions start from, or null to decline.
+///
+/// Declining costs nothing here because it happens before any JNI call that
+/// could change the database — the shim then runs the whole method, including
+/// its own parse.
+fn dbCall(
+    j: Jni,
+    allocator: std.mem.Allocator,
+    sql: jni.jstring,
+    params_json: jni.jstring,
+    parsed: *std.json.Parsed(std.json.Value),
+) !?struct { sql: []const u8, args: [][]const u8 } {
+    const sql_text = try j.stringToUtf8(allocator, sql);
+    const params_text = try j.stringToUtf8(allocator, params_json);
+
+    parsed.* = std.json.parseFromSlice(std.json.Value, allocator, params_text, .{}) catch
+        return null;
+
+    const args = (try db.bindArgs(allocator, parsed.value)) orelse return null;
+    return .{ .sql = sql_text, .args = args };
+}
+
+/// `nativeDbExecute(database, sql, paramsJson)`.
+fn nativeDbExecute(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    database: jni.jobject,
+    sql: jni.jstring,
+    params_json: jni.jstring,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var parsed: std.json.Parsed(std.json.Value) = undefined;
+    const call = (dbCall(j, allocator, sql, params_json, &parsed) catch return jni.JNI_FALSE) orelse
+        return jni.JNI_FALSE;
+
+    db.execute(j, allocator, database, call.sql, call.args) catch |err| {
+        // The shim catches and rejects with the exception's message; the
+        // throwable was described to logcat and cleared by `Jni.check` before
+        // this point, so the error name is what is left to say.
+        calendar.rejectOn(allocator, db.exec_reject_global, @errorName(err)) catch {};
+        return jni.JNI_TRUE;
+    };
+
+    events.settle(allocator, db.exec_resolve_global, db.exec_result) catch return jni.JNI_FALSE;
+    return jni.JNI_TRUE;
+}
+
+/// `nativeDbQuery(database, sql, paramsJson)`.
+fn nativeDbQuery(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    database: jni.jobject,
+    sql: jni.jstring,
+    params_json: jni.jstring,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var parsed: std.json.Parsed(std.json.Value) = undefined;
+    const call = (dbCall(j, allocator, sql, params_json, &parsed) catch return jni.JNI_FALSE) orelse
+        return jni.JNI_FALSE;
+
+    var payload: std.ArrayListUnmanaged(u8) = .empty;
+    defer payload.deinit(allocator);
+    db.query(j, allocator, database, call.sql, call.args, &payload) catch |err| {
+        calendar.rejectOn(allocator, db.query_reject_global, @errorName(err)) catch {};
+        return jni.JNI_TRUE;
+    };
+
+    events.settle(allocator, db.query_resolve_global, payload.items) catch return jni.JNI_FALSE;
+    return jni.JNI_TRUE;
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -900,7 +993,7 @@ test "the registered natives name methods the Kotlin actually declares" {
     // A descriptor is checked by the JVM at registration, so a wrong one fails
     // at load rather than at call — but only if the *name* matches something.
     // These two strings are the contract with CraftBridge.kt.
-    try testing.expectEqual(@as(usize, 19), natives.len);
+    try testing.expectEqual(@as(usize, 21), natives.len);
     try testing.expectEqualStrings("nativeGetDeviceInfo", std.mem.span(natives[0].name));
 
     // And the class they bind to is the fixed one, not the templated bridge.

--- a/packages/zig/src/bridge_android_db.zig
+++ b/packages/zig/src/bridge_android_db.zig
@@ -1,0 +1,386 @@
+//! `dbExecute` and `dbQuery` on Android.
+//!
+//! ## The connection stays Kotlin's
+//!
+//! The shim caches one `SQLiteDatabase` in a field and reuses it, which is
+//! what makes `BEGIN` in one call and `COMMIT` in the next work at all. Zig
+//! could open its own — `Context.openOrCreateDatabase` hands out a new
+//! connection each call — and then a page that mixed a served call with a
+//! declined one would have two connections to one file, taking each other's
+//! locks for no reason a reader could see.
+//!
+//! So the database arrives as an argument, the way `SharedPreferences` does
+//! for the secure store. The Kotlin opens it, the Kotlin owns it, and Zig
+//! borrows it for the length of one call.
+//!
+//! ## Which parameter shapes this serves
+//!
+//! The shim turns every parameter into a string with `JSONArray.getString`,
+//! which coerces: `1` becomes "1", `true` becomes "true", and an explicit null
+//! becomes the four characters "null" — the same `JSONObject.NULL.toString()`
+//! quirk the calendar module documents.
+//!
+//! Those four are reproduced. A float is not, because `Double.toString` picks
+//! the shortest form that round-trips and matching it exactly is not something
+//! to reproduce from memory; nor is a nested object or array, whose string
+//! form is `org.json`'s own printer. Those make `bindArgs` return null, the
+//! native returns false, and the shim binds them with the coercions it has.
+//!
+//! ## A NULL column disappears from its row
+//!
+//! `row.put(col, cursor.getString(index))` with a null value **removes** the
+//! mapping rather than storing a JSON null, so a row with a NULL column comes
+//! back with that key missing. It is not a rounding of the truth to say a page
+//! cannot tell a NULL column from an absent one — that is what the shim sends.
+
+const std = @import("std");
+const jni = @import("jni_runtime.zig");
+const bridge_error = @import("bridge_error.zig");
+
+const Jni = jni.Jni;
+const jobject = jni.jobject;
+
+pub const A = struct {
+    pub const db_execute = "dbExecute";
+    pub const db_query = "dbQuery";
+};
+
+pub const exec_resolve_global = "_craftDbExecResolve";
+pub const exec_reject_global = "_craftDbExecReject";
+pub const query_resolve_global = "_craftDbQueryResolve";
+pub const query_reject_global = "_craftDbQueryReject";
+
+/// What `dbExecute` resolves with, exactly as the shim writes it.
+///
+/// The 1 is a literal in the Kotlin, not a row count — `execSQL` returns void,
+/// so nothing here knows how many rows were touched. A `DELETE` matching
+/// nothing reports the same 1 as an `INSERT`. Ported rather than corrected,
+/// because correcting it means a different number reaching pages that already
+/// read this one. See #159.
+pub const exec_result = "{\"rowsAffected\":1}";
+
+/// `Array(params.length()) { params.getString(it) }`, or null to decline.
+///
+/// Most results borrow from `value`, which has to outlive the JNI calls that
+/// bind them; an integer is printed and so is allocated. Nothing is freed
+/// individually, because every caller is inside the per-call arena — passing a
+/// tracking allocator here reports the printed integers as leaks.
+pub fn bindArgs(allocator: std.mem.Allocator, value: std.json.Value) !?[][]const u8 {
+    const items = switch (value) {
+        .array => |a| a.items,
+        // `JSONArray(paramsJson)` throws on anything that is not an array, and
+        // the shim's catch rejects. Declining sends it there.
+        else => return null,
+    };
+
+    const args = try allocator.alloc([]const u8, items.len);
+    errdefer allocator.free(args);
+
+    for (items, 0..) |item, i| {
+        args[i] = switch (item) {
+            .string => |text| text,
+            .bool => |b| if (b) "true" else "false",
+            // `JSONObject.NULL.toString()`. A page sending `[null]` binds the
+            // four characters, not SQL NULL — which is worth knowing, and is
+            // the shim's behaviour either way.
+            .null => "null",
+            .integer => |n| try std.fmt.allocPrint(allocator, "{d}", .{n}),
+            // Double.toString, org.json's printer, and a number too large for
+            // an i64. Each has an exact answer that is not worth guessing.
+            .float, .object, .array, .number_string => {
+                allocator.free(args);
+                return null;
+            },
+        };
+    }
+    return args;
+}
+
+/// One row of a query result, as the shim's `JSONObject` would print it.
+///
+/// A null value removes its key rather than storing a JSON null, so `values`
+/// carrying a null emits an object without that column.
+pub fn appendRow(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    columns: []const []const u8,
+    values: []const ?[]const u8,
+) !void {
+    std.debug.assert(columns.len == values.len);
+
+    try out.append(allocator, '{');
+    var written: usize = 0;
+    for (columns, values) |column, value| {
+        const text = value orelse continue;
+        if (written != 0) try out.append(allocator, ',');
+        try out.append(allocator, '"');
+        try bridge_error.appendJsonEscaped(allocator, out, column);
+        try out.appendSlice(allocator, "\":\"");
+        try bridge_error.appendJsonEscaped(allocator, out, text);
+        try out.append(allocator, '"');
+        written += 1;
+    }
+    try out.append(allocator, '}');
+}
+
+/// `database.execSQL(sql, args)`.
+pub fn execute(j: Jni, allocator: std.mem.Allocator, db: jobject, sql: []const u8, args: []const []const u8) !void {
+    try j.pushLocalFrame(16);
+    defer _ = j.popLocalFrame(null);
+
+    const bind = try stringArray(j, allocator, args);
+    const db_cls = try j.objectClass(db);
+
+    // `execSQL(String, Object[])` — a `String[]` is an `Object[]`, which is
+    // what the Kotlin passes too.
+    try j.callVoidMethodA(
+        db,
+        try j.methodId(db_cls, "execSQL", "(Ljava/lang/String;[Ljava/lang/Object;)V"),
+        &.{ .{ .l = try javaString(j, allocator, sql) }, .{ .l = bind } },
+    );
+}
+
+/// `database.rawQuery(sql, args)`, every row appended to `out` as JSON.
+pub fn query(
+    j: Jni,
+    allocator: std.mem.Allocator,
+    db: jobject,
+    sql: []const u8,
+    args: []const []const u8,
+    out: *std.ArrayListUnmanaged(u8),
+) !void {
+    try j.pushLocalFrame(24);
+    defer _ = j.popLocalFrame(null);
+
+    const bind = try stringArray(j, allocator, args);
+    const db_cls = try j.objectClass(db);
+    const cursor = try j.callObjectMethodA(
+        db,
+        try j.methodId(
+            db_cls,
+            "rawQuery",
+            "(Ljava/lang/String;[Ljava/lang/String;)Landroid/database/Cursor;",
+        ),
+        &.{ .{ .l = try javaString(j, allocator, sql) }, .{ .l = bind } },
+    );
+
+    try out.append(allocator, '[');
+    defer out.append(allocator, ']') catch {};
+
+    if (cursor == null) return;
+
+    const cursor_cls = try j.objectClass(cursor);
+    const move_to_next = try j.methodId(cursor_cls, "moveToNext", "()Z");
+    const get_string = try j.methodId(cursor_cls, "getString", "(I)Ljava/lang/String;");
+    const close = try j.methodId(cursor_cls, "close", "()V");
+
+    // `use` closes however the block leaves, error included.
+    defer j.callVoidMethodA(cursor, close, &.{}) catch {};
+
+    const names = try j.callObjectMethodA(
+        cursor,
+        try j.methodId(cursor_cls, "getColumnNames", "()[Ljava/lang/String;"),
+        &.{},
+    );
+    const column_count: usize = @intCast(try j.arrayLength(names));
+
+    const columns = try allocator.alloc([]const u8, column_count);
+    defer allocator.free(columns);
+    for (columns, 0..) |*column, i| {
+        const element = try j.objectArrayElement(names, i);
+        column.* = if (element == null) "" else try j.stringToUtf8(allocator, element);
+    }
+
+    const values = try allocator.alloc(?[]const u8, column_count);
+    defer allocator.free(values);
+
+    var row_count: usize = 0;
+    while (try j.callBooleanMethodA(cursor, move_to_next, &.{})) {
+        // Sixteen local slots is all the JVM guarantees, and a wide table
+        // makes one reference per column.
+        try j.pushLocalFrame(8);
+        defer _ = j.popLocalFrame(null);
+
+        for (values, 0..) |*slot, i| {
+            const text = try j.callObjectMethodA(cursor, get_string, &.{.{ .i = @intCast(i) }});
+            slot.* = if (text == null) null else try j.stringToUtf8(allocator, text);
+        }
+
+        if (row_count != 0) try out.append(allocator, ',');
+        try appendRow(allocator, out, columns, values);
+        row_count += 1;
+    }
+}
+
+fn javaString(j: Jni, allocator: std.mem.Allocator, text: []const u8) !jni.jstring {
+    const terminated = try allocator.allocSentinel(u8, text.len, 0);
+    defer allocator.free(terminated);
+    @memcpy(terminated, text);
+    return j.newStringUtf(terminated.ptr);
+}
+
+fn stringArray(j: Jni, allocator: std.mem.Allocator, values: []const []const u8) !jobject {
+    const string_cls = try j.findClass("java/lang/String");
+    const array = try j.newObjectArray(values.len, string_cls);
+    for (values, 0..) |value, i| {
+        try j.pushLocalFrame(4);
+        defer _ = j.popLocalFrame(null);
+        try j.setObjectArrayElement(array, i, try javaString(j, allocator, value));
+    }
+    return array;
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+const testing = std.testing;
+
+fn boundArgs(json: []const u8) !?[][]const u8 {
+    // An arena, because that is what the native passes — `bindArgs` prints
+    // integers into it and frees nothing individually.
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, json, .{});
+    defer parsed.deinit();
+
+    const args = try bindArgs(allocator, parsed.value) orelse return null;
+
+    // Copied out, because everything above dies with the arena.
+    const copy = try testing.allocator.alloc([]const u8, args.len);
+    for (args, 0..) |arg, i| copy[i] = try testing.allocator.dupe(u8, arg);
+    return copy;
+}
+
+fn freeArgs(args: [][]const u8) void {
+    for (args) |arg| testing.allocator.free(arg);
+    testing.allocator.free(args);
+}
+
+test "the parameter shapes this serves are the strings getString would produce" {
+    const args = (try boundArgs(
+        \\["a", 1, -2, true, false, null, ""]
+    )).?;
+    defer freeArgs(args);
+
+    try testing.expectEqual(@as(usize, 7), args.len);
+    try testing.expectEqualStrings("a", args[0]);
+    try testing.expectEqualStrings("1", args[1]);
+    try testing.expectEqualStrings("-2", args[2]);
+    try testing.expectEqualStrings("true", args[3]);
+    try testing.expectEqualStrings("false", args[4]);
+    // `JSONArray.getString` on an explicit null gives the text, not SQL NULL.
+    try testing.expectEqualStrings("null", args[5]);
+    try testing.expectEqualStrings("", args[6]);
+}
+
+test "an empty parameter list is served rather than declined" {
+    // `execSQL(sql, arrayOf())` is the common case — a statement with no
+    // placeholders — so this is the path most calls take.
+    const args = (try boundArgs("[]")).?;
+    defer freeArgs(args);
+    try testing.expectEqual(@as(usize, 0), args.len);
+}
+
+test "a shape only org.json would stringify is handed back" {
+    for ([_][]const u8{
+        // Double.toString picks the shortest round-tripping form.
+        \\[1.5]
+        ,
+        \\[1.0]
+        ,
+        // org.json's own printer, key order included.
+        \\[{"a":1}]
+        ,
+        \\[[1,2]]
+        ,
+        // Past i64, where std.json hands back the text and org.json a Double.
+        \\[99999999999999999999]
+        ,
+        // JSONArray(paramsJson) throws on anything that is not an array.
+        \\{"0":"a"}
+        ,
+        \\"a"
+        ,
+        \\null
+        ,
+    }) |payload| {
+        if (try boundArgs(payload)) |args| {
+            freeArgs(args);
+            std.debug.print("payload was served rather than handed back: {s}\n", .{payload});
+            return error.CoercedShapeAccepted;
+        }
+    }
+}
+
+fn renderRow(columns: []const []const u8, values: []const ?[]const u8) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(testing.allocator);
+    try appendRow(testing.allocator, &out, columns, values);
+    return out.toOwnedSlice(testing.allocator);
+}
+
+test "a row prints its columns in cursor order" {
+    const json = try renderRow(
+        &.{ "id", "name" },
+        &.{ "1", "Ada" },
+    );
+    defer testing.allocator.free(json);
+    try testing.expectEqualStrings("{\"id\":\"1\",\"name\":\"Ada\"}", json);
+}
+
+test "a NULL column is absent from the row rather than null" {
+    // `put(col, null)` removes the mapping. A page cannot tell a NULL column
+    // from one the query never selected, and that is what the shim sends.
+    const json = try renderRow(
+        &.{ "id", "name", "note" },
+        &.{ "1", null, "hi" },
+    );
+    defer testing.allocator.free(json);
+    try testing.expectEqualStrings("{\"id\":\"1\",\"note\":\"hi\"}", json);
+
+    // Including when it is the first column, where a naive comma would show.
+    const leading = try renderRow(&.{ "a", "b" }, &.{ null, "x" });
+    defer testing.allocator.free(leading);
+    try testing.expectEqualStrings("{\"b\":\"x\"}", leading);
+
+    // And when every column is null.
+    const all_null = try renderRow(&.{ "a", "b" }, &.{ null, null });
+    defer testing.allocator.free(all_null);
+    try testing.expectEqualStrings("{}", all_null);
+}
+
+test "a column name or value carrying a quote survives as JSON" {
+    // Column names come from the caller's own SQL — `select 1 as "a\"b"` is
+    // legal — and values are whatever is in the database.
+    const json = try renderRow(
+        &.{"a\"b"},
+        &.{"it's \"fine\""},
+    );
+    defer testing.allocator.free(json);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("it's \"fine\"", parsed.value.object.get("a\"b").?.string);
+}
+
+test "dbExecute resolves with the shim's constant, not a row count" {
+    // `execSQL` returns void, so the 1 is a literal in the Kotlin and stays a
+    // literal here. Asserted as the exact bytes because the page parses them.
+    try testing.expectEqualStrings("{\"rowsAffected\":1}", exec_result);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, exec_result, .{});
+    defer parsed.deinit();
+    try testing.expectEqual(@as(i64, 1), parsed.value.object.get("rowsAffected").?.integer);
+}
+
+test "the actions and globals match the shim exactly" {
+    try testing.expectEqualStrings("dbExecute", A.db_execute);
+    try testing.expectEqualStrings("dbQuery", A.db_query);
+    try testing.expectEqualStrings("_craftDbExecResolve", exec_resolve_global);
+    try testing.expectEqualStrings("_craftDbExecReject", exec_reject_global);
+    try testing.expectEqualStrings("_craftDbQueryResolve", query_resolve_global);
+    try testing.expectEqualStrings("_craftDbQueryReject", query_reject_global);
+}

--- a/packages/zig/src/jni_runtime.zig
+++ b/packages/zig/src/jni_runtime.zig
@@ -756,6 +756,22 @@ pub const Jni = struct {
         return array;
     }
 
+    pub fn arrayLength(self: Self, array: jobject) JniError!usize {
+        const len: *const fn (JNIEnv, jobject) callconv(.c) jsize =
+            @ptrCast(self.table().GetArrayLength orelse return JniError.NotFound);
+        const result = len(self.env, array);
+        try self.check();
+        return @intCast(result);
+    }
+
+    pub fn objectArrayElement(self: Self, array: jobject, index: usize) JniError!jobject {
+        const get: *const fn (JNIEnv, jobject, jsize) callconv(.c) jobject =
+            @ptrCast(self.table().GetObjectArrayElement orelse return JniError.NotFound);
+        const value = get(self.env, array, @intCast(index));
+        try self.check();
+        return value;
+    }
+
     pub fn setObjectArrayElement(self: Self, array: jobject, index: usize, value: jobject) JniError!void {
         const set: *const fn (JNIEnv, jobject, jsize, jobject) callconv(.c) void =
             @ptrCast(self.table().SetObjectArrayElement orelse return JniError.NotFound);

--- a/packages/zig/test/android_conformance_test.zig
+++ b/packages/zig/test/android_conformance_test.zig
@@ -48,6 +48,7 @@ const zig_sources = [_][]const u8{
     @embedFile("src/bridge_android_haptics.zig"),
     @embedFile("src/bridge_android_notifcancel.zig"),
     @embedFile("src/bridge_android_calendar.zig"),
+    @embedFile("src/bridge_android_db.zig"),
 };
 
 /// How many spec actions Zig does not serve yet.
@@ -65,8 +66,9 @@ const zig_sources = [_][]const u8{
 /// notification cancels; 86 with deleteCalendarEvent, the first to answer
 /// through the reply channel rather than by returning; 85 with
 /// getCalendarEvents, the first to send the page a payload it built rather
-/// than a constant; 84 with createCalendarEvent, the first to read one.
-const max_not_yet_migrated: usize = 84;
+/// than a constant; 84 with createCalendarEvent, the first to read one; 82
+/// with the database pair, the first to borrow a connection the Kotlin owns.
+const max_not_yet_migrated: usize = 82;
 
 /// Every `@JavascriptInterface fun <name>(` in the Kotlin bridge.
 ///


### PR DESCRIPTION
The local database pair, and the first natives to borrow a handle the Kotlin owns rather than build their own.

## The connection stays Kotlin's

The shim caches one `SQLiteDatabase` in a field, which is what makes a `BEGIN` in one call and a `COMMIT` in the next reach the same connection. Zig could open its own — `Context.openOrCreateDatabase` hands out a fresh connection every call — and then a page that mixed a served call with a declined one would have **two connections to one file**, taking each other's locks for no reason a reader could see.

So the database arrives as an argument, the way `SharedPreferences` does for the secure store. The delegation sits *after* the open for the same reason:

```kotlin
if (database == null) {
    database = activity.openOrCreateDatabase("craft.db", Context.MODE_PRIVATE, null)
}

database?.let { if (CraftNative.dbExecute(it, sql, paramsJson)) return }
```

## Which parameter shapes this serves

`JSONArray.getString` coerces, so the shim binds `"1"` for `1`, `"true"` for `true`, and the four characters `"null"` for an explicit null — the same `JSONObject.NULL.toString()` quirk the calendar module documents. Worth stating plainly: `craft.db.execute("… WHERE x = ?", [null])` binds the *text* `null`, not SQL NULL. That is the shim's behaviour, and it is reproduced rather than fixed.

A float is not served, because `Double.toString` picks the shortest form that round-trips; nor is a nested object or array, whose string form is `org.json`'s own printer; nor is an integer past `i64`. Those make `bindArgs` return null **before any JNI call has touched the database**, and the shim binds them with the coercions it has.

## A NULL column disappears from its row

`row.put(col, cursor.getString(index))` with a null value removes the mapping rather than storing a JSON null, so a row with a NULL column comes back without that key. A page genuinely cannot tell a NULL column from one the query never selected.

The test covers the leading, middle, and every-column cases — a naive comma shows up in exactly the first of those, and only there.

## rowsAffected is a literal

`execSQL` returns `void`, so the `1` the shim resolves with is not a count: a `DELETE` matching nothing reports the same `1` as an `INSERT`, and `CREATE TABLE` reports it too. Ported as a named `exec_result` constant with the reasoning attached rather than corrected — changing it is a behaviour change for any page that checked `=== 1`. Filed as #159.

## Testing

`zig build test:android` passes with the ratchet at 82. Both mutations fired before this was committed: making a NULL column emit `null`, and accepting a float parameter, each fail a named test. Both `libcraft.so` targets still build with no NDK.