### PR TITLE
feat(android): the shared-item trio in Zig — ratchet 82 → 79

### DIFF
--- a/packages/android/templates/CraftBridge.kt.template
+++ b/packages/android/templates/CraftBridge.kt.template
@@ -3333,6 +3333,10 @@ class CraftBridge(
 
     @JavascriptInterface
     fun setSharedItem(key: String, value: String, group: String) {
+        // Zig answers through the reply channel, so returning here is what
+        // stops the promise being settled twice.
+        if (CraftNative.setSharedItem(activity, key, value, group)) return
+
         try {
             val prefsName = if (group.isNotEmpty()) "craft_shared_$group" else "craft_shared"
             val prefs = activity.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
@@ -3356,6 +3360,10 @@ class CraftBridge(
 
     @JavascriptInterface
     fun getSharedItem(key: String, group: String) {
+        // Zig answers through the reply channel, so returning here is what
+        // stops the promise being settled twice.
+        if (CraftNative.getSharedItem(activity, key, group)) return
+
         try {
             val prefsName = if (group.isNotEmpty()) "craft_shared_$group" else "craft_shared"
             val prefs = activity.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
@@ -3386,6 +3394,10 @@ class CraftBridge(
 
     @JavascriptInterface
     fun removeSharedItem(key: String, group: String) {
+        // Zig answers through the reply channel, so returning here is what
+        // stops the promise being settled twice.
+        if (CraftNative.removeSharedItem(activity, key, group)) return
+
         try {
             val prefsName = if (group.isNotEmpty()) "craft_shared_$group" else "craft_shared"
             val prefs = activity.getSharedPreferences(prefsName, Context.MODE_PRIVATE)

--- a/packages/android/templates/CraftNative.kt.template
+++ b/packages/android/templates/CraftNative.kt.template
@@ -113,6 +113,9 @@ object CraftNative {
     private external fun nativeCreateCalendarEvent(activity: Activity, eventJson: String): Boolean
     private external fun nativeDbExecute(database: SQLiteDatabase, sql: String, paramsJson: String): Boolean
     private external fun nativeDbQuery(database: SQLiteDatabase, sql: String, paramsJson: String): Boolean
+    private external fun nativeSetSharedItem(activity: Activity, key: String, value: String, group: String): Boolean
+    private external fun nativeGetSharedItem(activity: Activity, key: String, group: String): Boolean
+    private external fun nativeRemoveSharedItem(activity: Activity, key: String, group: String): Boolean
 
     /**
      * `getDeviceInfo`, or null to use the Kotlin implementation.
@@ -411,6 +414,38 @@ object CraftNative {
         if (!isAvailable) return false
         return try {
             nativeDbQuery(database, sql, paramsJson)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    /**
+     * The shared-preferences trio behind the page's `_craftSharedKeychain*`
+     * globals. Each returns whether Zig took the action; the outcome reaches
+     * the page through the reply channel.
+     */
+    fun setSharedItem(activity: Activity, key: String, value: String, group: String): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeSetSharedItem(activity, key, value, group)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    fun getSharedItem(activity: Activity, key: String, group: String): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeGetSharedItem(activity, key, group)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    fun removeSharedItem(activity: Activity, key: String, group: String): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeRemoveSharedItem(activity, key, group)
         } catch (e: UnsatisfiedLinkError) {
             false
         }

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -461,6 +461,9 @@ pub fn build(b: *std.Build) void {
     android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_db.zig", .{
         .root_source_file = b.path("src/bridge_android_db.zig"),
     });
+    android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_shareditem.zig", .{
+        .root_source_file = b.path("src/bridge_android_shareditem.zig"),
+    });
     const run_android_conformance_tests = b.addRunArtifact(android_conformance_tests);
 
     // The page surface, across both bridges. Not folded into the iOS

--- a/packages/zig/src/android_dispatch.zig
+++ b/packages/zig/src/android_dispatch.zig
@@ -48,6 +48,7 @@ const notifcancel = @import("bridge_android_notifcancel.zig");
 const events = @import("android_events.zig");
 const calendar = @import("bridge_android_calendar.zig");
 const db = @import("bridge_android_db.zig");
+const shareditem = @import("bridge_android_shareditem.zig");
 
 const Jni = jni.Jni;
 
@@ -261,6 +262,21 @@ const natives = [_]jni.JNINativeMethod{
         .name = "nativeDbQuery",
         .signature = "(Landroid/database/sqlite/SQLiteDatabase;Ljava/lang/String;Ljava/lang/String;)Z",
         .fnPtr = @ptrCast(&nativeDbQuery),
+    },
+    .{
+        .name = "nativeSetSharedItem",
+        .signature = "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z",
+        .fnPtr = @ptrCast(&nativeSetSharedItem),
+    },
+    .{
+        .name = "nativeGetSharedItem",
+        .signature = "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)Z",
+        .fnPtr = @ptrCast(&nativeGetSharedItem),
+    },
+    .{
+        .name = "nativeRemoveSharedItem",
+        .signature = "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)Z",
+        .fnPtr = @ptrCast(&nativeRemoveSharedItem),
     },
 };
 
@@ -882,6 +898,90 @@ fn nativeDbQuery(
     return jni.JNI_TRUE;
 }
 
+/// `nativeSetSharedItem(activity, key, value, group)`.
+fn nativeSetSharedItem(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+    key: jni.jstring,
+    value: jni.jstring,
+    group: jni.jstring,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const key_text = j.stringToUtf8(allocator, key) catch return jni.JNI_FALSE;
+    const value_text = j.stringToUtf8(allocator, value) catch return jni.JNI_FALSE;
+    const group_text = j.stringToUtf8(allocator, group) catch return jni.JNI_FALSE;
+
+    shareditem.set(j, allocator, activity, group_text, key_text, value_text) catch |err| {
+        calendar.rejectOn(allocator, shareditem.reject_global, @errorName(err)) catch {};
+        return jni.JNI_TRUE;
+    };
+
+    const payload = shareditem.successPayload(allocator, key_text) catch return jni.JNI_FALSE;
+    events.settle(allocator, shareditem.resolve_global, payload) catch return jni.JNI_FALSE;
+    return jni.JNI_TRUE;
+}
+
+/// `nativeGetSharedItem(activity, key, group)`.
+///
+/// An absent key resolves with `{value: null}` rather than rejecting, which is
+/// the shim's answer: a page reading a key it never wrote has done nothing
+/// wrong.
+fn nativeGetSharedItem(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+    key: jni.jstring,
+    group: jni.jstring,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const key_text = j.stringToUtf8(allocator, key) catch return jni.JNI_FALSE;
+    const group_text = j.stringToUtf8(allocator, group) catch return jni.JNI_FALSE;
+
+    const value = shareditem.get(j, allocator, activity, group_text, key_text) catch |err| {
+        calendar.rejectOn(allocator, shareditem.reject_global, @errorName(err)) catch {};
+        return jni.JNI_TRUE;
+    };
+
+    const payload = shareditem.valuePayload(allocator, key_text, value) catch return jni.JNI_FALSE;
+    events.settle(allocator, shareditem.resolve_global, payload) catch return jni.JNI_FALSE;
+    return jni.JNI_TRUE;
+}
+
+/// `nativeRemoveSharedItem(activity, key, group)`.
+fn nativeRemoveSharedItem(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+    key: jni.jstring,
+    group: jni.jstring,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const key_text = j.stringToUtf8(allocator, key) catch return jni.JNI_FALSE;
+    const group_text = j.stringToUtf8(allocator, group) catch return jni.JNI_FALSE;
+
+    shareditem.remove(j, allocator, activity, group_text, key_text) catch |err| {
+        calendar.rejectOn(allocator, shareditem.reject_global, @errorName(err)) catch {};
+        return jni.JNI_TRUE;
+    };
+
+    const payload = shareditem.successPayload(allocator, key_text) catch return jni.JNI_FALSE;
+    events.settle(allocator, shareditem.resolve_global, payload) catch return jni.JNI_FALSE;
+    return jni.JNI_TRUE;
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -993,7 +1093,7 @@ test "the registered natives name methods the Kotlin actually declares" {
     // A descriptor is checked by the JVM at registration, so a wrong one fails
     // at load rather than at call — but only if the *name* matches something.
     // These two strings are the contract with CraftBridge.kt.
-    try testing.expectEqual(@as(usize, 21), natives.len);
+    try testing.expectEqual(@as(usize, 24), natives.len);
     try testing.expectEqualStrings("nativeGetDeviceInfo", std.mem.span(natives[0].name));
 
     // And the class they bind to is the fixed one, not the templated bridge.

--- a/packages/zig/src/bridge_android_shareditem.zig
+++ b/packages/zig/src/bridge_android_shareditem.zig
@@ -1,0 +1,308 @@
+//! `setSharedItem`, `getSharedItem` and `removeSharedItem` on Android.
+//!
+//! The iOS side of this is a keychain access group, which is why the page's
+//! globals are called `_craftSharedKeychain*`. Android has no such thing, so
+//! the shim uses a `SharedPreferences` file per group — plain, not encrypted,
+//! which is worth knowing given the name the page sees. That is the shim's
+//! choice and is ported rather than changed here.
+//!
+//! ## The group is a filename
+//!
+//! `"craft_shared_" + group` becomes the preferences file's name, and `group`
+//! is whatever the page passed. A group containing a path separator does not
+//! land where a reader would guess, and `getSharedPreferences` is what decides
+//! what happens then. Reproduced exactly: the naming is the only part of this
+//! that can silently disagree between the two implementations, and it is
+//! decided before any JNI call.
+//!
+//! ## Every reply carries the key back
+//!
+//! Both the resolve shapes name the key, so a page can tell which of several
+//! outstanding calls settled — which matters here more than elsewhere, since
+//! all three actions share one pair of globals and a second call overwrites
+//! the first's resolve function.
+
+const std = @import("std");
+const jni = @import("jni_runtime.zig");
+const bridge_error = @import("bridge_error.zig");
+
+const Jni = jni.Jni;
+const jobject = jni.jobject;
+
+pub const A = struct {
+    pub const set_shared_item = "setSharedItem";
+    pub const get_shared_item = "getSharedItem";
+    pub const remove_shared_item = "removeSharedItem";
+};
+
+pub const resolve_global = "_craftSharedKeychainResolve";
+pub const reject_global = "_craftSharedKeychainReject";
+
+/// `Context.MODE_PRIVATE`, a compile-time constant the shim's DEX holds as 0.
+const mode_private: i32 = 0;
+
+const prefix = "craft_shared";
+
+/// `if (group.isNotEmpty()) "craft_shared_$group" else "craft_shared"`.
+pub fn prefsName(allocator: std.mem.Allocator, group: []const u8) ![:0]u8 {
+    if (group.len == 0) {
+        const name = try allocator.allocSentinel(u8, prefix.len, 0);
+        @memcpy(name, prefix);
+        return name;
+    }
+
+    const name = try allocator.allocSentinel(u8, prefix.len + 1 + group.len, 0);
+    @memcpy(name[0..prefix.len], prefix);
+    name[prefix.len] = '_';
+    @memcpy(name[prefix.len + 1 ..], group);
+    return name;
+}
+
+/// `{success: true, key: "<key>"}` — what `setSharedItem` and
+/// `removeSharedItem` resolve with.
+pub fn successPayload(allocator: std.mem.Allocator, key: []const u8) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.appendSlice(allocator, "{\"success\":true,\"key\":\"");
+    try bridge_error.appendJsonEscaped(allocator, &out, key);
+    try out.appendSlice(allocator, "\"}");
+    return out.toOwnedSlice(allocator);
+}
+
+/// `{value: <value>, key: "<key>"}`, where a missing value is a JSON null.
+///
+/// The shim writes the two branches as two separate `evaluateJavascript`
+/// calls; the only difference between them is this argument, so they are one
+/// function here and the null is a value rather than a branch.
+pub fn valuePayload(allocator: std.mem.Allocator, key: []const u8, value: ?[]const u8) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.appendSlice(allocator, "{\"value\":");
+    if (value) |text| {
+        try out.append(allocator, '"');
+        try bridge_error.appendJsonEscaped(allocator, &out, text);
+        try out.append(allocator, '"');
+    } else {
+        try out.appendSlice(allocator, "null");
+    }
+    try out.appendSlice(allocator, ",\"key\":\"");
+    try bridge_error.appendJsonEscaped(allocator, &out, key);
+    try out.appendSlice(allocator, "\"}");
+    return out.toOwnedSlice(allocator);
+}
+
+/// `activity.getSharedPreferences(prefsName(group), MODE_PRIVATE)`.
+fn openPrefs(j: Jni, allocator: std.mem.Allocator, activity: jobject, group: []const u8) !jobject {
+    const name = try prefsName(allocator, group);
+    defer allocator.free(name);
+
+    const activity_cls = try j.objectClass(activity);
+    return j.callObjectMethodA(
+        activity,
+        try j.methodId(
+            activity_cls,
+            "getSharedPreferences",
+            "(Ljava/lang/String;I)Landroid/content/SharedPreferences;",
+        ),
+        &.{ .{ .l = try j.newStringUtf(name.ptr) }, .{ .i = mode_private } },
+    );
+}
+
+/// `prefs.edit().putString(key, value).apply()`.
+pub fn set(
+    j: Jni,
+    allocator: std.mem.Allocator,
+    activity: jobject,
+    group: []const u8,
+    key: []const u8,
+    value: []const u8,
+) !void {
+    try j.pushLocalFrame(16);
+    defer _ = j.popLocalFrame(null);
+
+    const prefs = try openPrefs(j, allocator, activity, group);
+    const editor = try editorFor(j, prefs);
+    const editor_cls = try j.objectClass(editor);
+
+    _ = try j.callObjectMethodA(
+        editor,
+        try j.methodId(
+            editor_cls,
+            "putString",
+            "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;",
+        ),
+        &.{
+            .{ .l = try javaString(j, allocator, key) },
+            .{ .l = try javaString(j, allocator, value) },
+        },
+    );
+
+    // `apply` rather than `commit`: it writes on a background thread and
+    // returns void, so a failure is not observable here — which is exactly
+    // what the shim's resolve already promises regardless.
+    try j.callVoidMethodA(editor, try j.methodId(editor_cls, "apply", "()V"), &.{});
+}
+
+/// `prefs.edit().remove(key).apply()`.
+pub fn remove(
+    j: Jni,
+    allocator: std.mem.Allocator,
+    activity: jobject,
+    group: []const u8,
+    key: []const u8,
+) !void {
+    try j.pushLocalFrame(16);
+    defer _ = j.popLocalFrame(null);
+
+    const prefs = try openPrefs(j, allocator, activity, group);
+    const editor = try editorFor(j, prefs);
+    const editor_cls = try j.objectClass(editor);
+
+    _ = try j.callObjectMethodA(
+        editor,
+        try j.methodId(
+            editor_cls,
+            "remove",
+            "(Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;",
+        ),
+        &.{.{ .l = try javaString(j, allocator, key) }},
+    );
+    try j.callVoidMethodA(editor, try j.methodId(editor_cls, "apply", "()V"), &.{});
+}
+
+/// `prefs.getString(key, null)`, null included.
+///
+/// The caller owns the returned bytes; null means the key is absent, which is
+/// the answer the page gets as `{value: null}` rather than as a rejection.
+pub fn get(
+    j: Jni,
+    allocator: std.mem.Allocator,
+    activity: jobject,
+    group: []const u8,
+    key: []const u8,
+) !?[]u8 {
+    try j.pushLocalFrame(16);
+    defer _ = j.popLocalFrame(null);
+
+    const prefs = try openPrefs(j, allocator, activity, group);
+    const value = try j.callObjectMethodA(
+        prefs,
+        try j.methodId(
+            try j.objectClass(prefs),
+            "getString",
+            "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;",
+        ),
+        &.{ .{ .l = try javaString(j, allocator, key) }, .{ .l = null } },
+    );
+
+    if (value == null) return null;
+    return try j.stringToUtf8(allocator, value);
+}
+
+fn editorFor(j: Jni, prefs: jobject) !jobject {
+    return j.callObjectMethod(
+        prefs,
+        try j.methodId(
+            try j.objectClass(prefs),
+            "edit",
+            "()Landroid/content/SharedPreferences$Editor;",
+        ),
+    );
+}
+
+fn javaString(j: Jni, allocator: std.mem.Allocator, text: []const u8) !jni.jstring {
+    const terminated = try allocator.allocSentinel(u8, text.len, 0);
+    defer allocator.free(terminated);
+    @memcpy(terminated, text);
+    return j.newStringUtf(terminated.ptr);
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+const testing = std.testing;
+
+test "the preferences file is named the way the shim names it" {
+    const plain = try prefsName(testing.allocator, "");
+    defer testing.allocator.free(plain);
+    try testing.expectEqualStrings("craft_shared", plain);
+
+    const grouped = try prefsName(testing.allocator, "team");
+    defer testing.allocator.free(grouped);
+    try testing.expectEqualStrings("craft_shared_team", grouped);
+
+    // `isNotEmpty()` is a length check, not a blank check — a group of one
+    // space is a group, and its file is named with the space in it.
+    const spaced = try prefsName(testing.allocator, " ");
+    defer testing.allocator.free(spaced);
+    try testing.expectEqualStrings("craft_shared_ ", spaced);
+}
+
+test "the name is NUL-terminated, because FindClass's neighbour needs it" {
+    // `NewStringUTF` takes a C string. A slice that merely looks right here
+    // would read past the end at the call site instead.
+    const name = try prefsName(testing.allocator, "team");
+    defer testing.allocator.free(name);
+    try testing.expectEqual(@as(u8, 0), name.ptr[name.len]);
+}
+
+test "a set or remove resolves with the key it was given" {
+    const payload = try successPayload(testing.allocator, "token");
+    defer testing.allocator.free(payload);
+    try testing.expectEqualStrings("{\"success\":true,\"key\":\"token\"}", payload);
+}
+
+test "a get resolves with the value, or with a JSON null" {
+    const found = try valuePayload(testing.allocator, "token", "abc");
+    defer testing.allocator.free(found);
+    try testing.expectEqualStrings("{\"value\":\"abc\",\"key\":\"token\"}", found);
+
+    // The absent case is a resolve, not a rejection: a page reading a key it
+    // never wrote has done nothing wrong.
+    const missing = try valuePayload(testing.allocator, "token", null);
+    defer testing.allocator.free(missing);
+    try testing.expectEqualStrings("{\"value\":null,\"key\":\"token\"}", missing);
+
+    // And an empty string is not the absent case.
+    const empty = try valuePayload(testing.allocator, "token", "");
+    defer testing.allocator.free(empty);
+    try testing.expectEqualStrings("{\"value\":\"\",\"key\":\"token\"}", empty);
+}
+
+test "a key or value carrying a quote survives as JSON" {
+    // Both are page text, and both go through the reply channel — the same
+    // shape that hung the promise before #154 was fixed.
+    const payload = try valuePayload(testing.allocator, "it's", "a \"quoted\" value\nwith a newline");
+    defer testing.allocator.free(payload);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, payload, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("it's", parsed.value.object.get("key").?.string);
+    try testing.expectEqualStrings(
+        "a \"quoted\" value\nwith a newline",
+        parsed.value.object.get("value").?.string,
+    );
+
+    const success = try successPayload(testing.allocator, "it's");
+    defer testing.allocator.free(success);
+    var parsed_success = try std.json.parseFromSlice(std.json.Value, testing.allocator, success, .{});
+    defer parsed_success.deinit();
+    try testing.expectEqualStrings("it's", parsed_success.value.object.get("key").?.string);
+    try testing.expect(parsed_success.value.object.get("success").?.bool);
+}
+
+test "MODE_PRIVATE is zero" {
+    // A compile-time constant in Java, so the shim's DEX holds the literal.
+    try testing.expectEqual(@as(i32, 0), mode_private);
+}
+
+test "the actions and globals match the shim exactly" {
+    try testing.expectEqualStrings("setSharedItem", A.set_shared_item);
+    try testing.expectEqualStrings("getSharedItem", A.get_shared_item);
+    try testing.expectEqualStrings("removeSharedItem", A.remove_shared_item);
+    try testing.expectEqualStrings("_craftSharedKeychainResolve", resolve_global);
+    try testing.expectEqualStrings("_craftSharedKeychainReject", reject_global);
+}

--- a/packages/zig/test/android_conformance_test.zig
+++ b/packages/zig/test/android_conformance_test.zig
@@ -49,6 +49,7 @@ const zig_sources = [_][]const u8{
     @embedFile("src/bridge_android_notifcancel.zig"),
     @embedFile("src/bridge_android_calendar.zig"),
     @embedFile("src/bridge_android_db.zig"),
+    @embedFile("src/bridge_android_shareditem.zig"),
 };
 
 /// How many spec actions Zig does not serve yet.
@@ -67,8 +68,9 @@ const zig_sources = [_][]const u8{
 /// through the reply channel rather than by returning; 85 with
 /// getCalendarEvents, the first to send the page a payload it built rather
 /// than a constant; 84 with createCalendarEvent, the first to read one; 82
-/// with the database pair, the first to borrow a connection the Kotlin owns.
-const max_not_yet_migrated: usize = 82;
+/// with the database pair, the first to borrow a connection the Kotlin owns;
+/// 79 with the shared-item trio.
+const max_not_yet_migrated: usize = 79;
 
 /// Every `@JavascriptInterface fun <name>(` in the Kotlin bridge.
 ///


### PR DESCRIPTION
`setSharedItem`, `getSharedItem` and `removeSharedItem` — the three actions behind the page's `_craftSharedKeychain*` globals.

## The name is iOS's, and it promises more than Android delivers

On iOS this is a keychain access group. Android has no such thing, so the shim uses a plain `SharedPreferences` file per group — **not encrypted**, unlike `secureSet`/`secureGet` next door, which do use `EncryptedSharedPreferences`. Worth stating given what the page-facing name suggests. Ported as-is rather than changed: making it encrypted would silently strand anything already written.

## The group is a filename

```kotlin
val prefsName = if (group.isNotEmpty()) "craft_shared_$group" else "craft_shared"
```

`group` is whatever the page passed, and it becomes the preferences file's name. `isNotEmpty()` is a length check rather than a blank check, so a group of one space is a group and its file is named with the space in it.

That naming is the only part of this that can silently disagree between the two implementations — everything else is a JNI call whose result the JVM decides — so it is a pure function with its own test, and it is computed before any JNI call happens.

## An absent key resolves rather than rejects

`prefs.getString(key, null)` returning null becomes `{value: null}`, not an error: a page reading a key it never wrote has done nothing wrong. The shim writes that as two separate `evaluateJavascript` calls differing only in the argument, so here it is one function and the null is a value rather than a branch.

An empty string is not the absent case, and the test says so — that distinction is the one a rewrite would lose.

## `apply` rather than `commit`

Both writers use `apply`, which writes on a background thread and returns void. A failure is not observable at the call site in either language, so the resolve the shim sends is a promise about having *asked*, not about having written. Reproduced, and written down rather than quietly upgraded to `commit`.

## Testing

`zig build test:android` passes with the ratchet at 79. Both mutations fired before this was committed: collapsing the `{value: null}` branch into the string branch, and dropping the group from the file name, each fail a named test. Both `libcraft.so` targets still build with no NDK.