### PR TITLE
fix(android): jsQuote takes Any?, because three call sites are not strings

### DIFF
--- a/packages/android/templates/CraftBridge.kt.template
+++ b/packages/android/templates/CraftBridge.kt.template
@@ -170,15 +170,20 @@ class CraftBridge(
      * Quote a value for interpolation into JavaScript.
      *
      * The result carries its own quotes, so write `f($payload)` — leaving the
-     * surrounding `'...'` in place would quote it twice. A Kotlin null renders as
-     * the string "null", which is what plain interpolation produced before; whether
-     * that should instead be a JS null is a separate question from escaping.
+     * surrounding `'...'` in place would quote it twice.
      *
      * Without this, a value containing an apostrophe ends the JS string early, the
      * script fails to parse, and `evaluateJavascript` runs nothing at all — so a
      * hand-built promise with no timeout never settles.
+     *
+     * `Any?` rather than `String?`, because these call sites replaced string
+     * interpolation and interpolation accepts anything: `contactId` is the `Long`
+     * from `ContentUris.parseId`, `downloadId` the `Long` from
+     * `DownloadManager.enqueue`, and `errString` the `CharSequence` a
+     * `BiometricPrompt` error arrives as. `Any?.toString()` is exactly what `$x`
+     * did, null included — it renders as the string "null", the way it always has.
      */
-    private fun jsQuote(value: String?): String = JSONObject.quote(value ?: "null")
+    private fun jsQuote(value: Any?): String = JSONObject.quote(value.toString())
 
     fun injectBridge() {
         // Before the script, so a native callback arriving while the page is

--- a/packages/zig/test/android_reply_escaping_test.zig
+++ b/packages/zig/test/android_reply_escaping_test.zig
@@ -143,6 +143,14 @@ test "the templates that answer the page are actually in the scanned set" {
 
     // And the fix is present rather than the sites merely being deleted.
     const bridge = sourceOf("CraftBridge.kt.template").?;
-    try testing.expect(std.mem.indexOf(u8, bridge, "private fun jsQuote(") != null);
     try testing.expect(std.mem.count(u8, bridge, "jsQuote(") >= 50);
+
+    // `Any?`, not `String?`. The call sites replaced string interpolation,
+    // which accepts anything — `contactId` is a Long, `downloadId` is a Long,
+    // `errString` is a CharSequence — and narrowing the parameter back makes
+    // those three sites stop compiling. Nothing in CI compiles Kotlin, so this
+    // is the only thing that would say so. See #163.
+    try testing.expect(
+        std.mem.indexOf(u8, bridge, "private fun jsQuote(value: Any?): String") != null,
+    );
 }


### PR DESCRIPTION
A bug I shipped in #156, and the reason nothing caught it.

## The bug

#156 rewrote 58 `evaluateJavascript` call sites to route through a new helper typed `String?`. Three of them do not pass a `String`:

| site | expression | actual type |
| --- | --- | --- |
| `addContact` | `ContentUris.parseId(results[0].uri!!)` | `Long` |
| `downloadFile` | `downloadManager.enqueue(request)` | `Long` |
| `authenticate` | `onAuthenticationError(code, errString)` | `CharSequence` |

String interpolation accepted all three. A `String?` parameter does not, so `CraftBridge.kt` would not compile in a generated app.

## Why every check was green

Nothing in this repository compiles Kotlin. The only workflow that touches Android is `mobile-e2e.yml`, which is `workflow_dispatch`-only and whose Android job is guarded by `if [ -x "packages/android/gradlew" ]` — a file that does not exist; `packages/android` has no Gradle project at all. Filed as #163 with what it would take to change that, because adding an Android SDK and a Gradle build to CI is a cost the project should choose deliberately.

## The fix

`Any?` is what interpolation always was, and `Any?.toString()` renders null as the string `"null"` exactly as `'$x'` did. So the three sites work again and the other 55 are unchanged — same bytes emitted, same escaping.

## The interim guard

`android_reply_escaping_test.zig` asserted only that `private fun jsQuote(` existed. It now asserts the full signature and says why, so narrowing the parameter back fails a test rather than a user's build.

That covers exactly one regression. It is a note beside #163, not a substitute for compiling the language.