### PR TITLE
feat(android): the contacts pair in Zig — ratchet 79 → 77

### DIFF
--- a/packages/android/templates/CraftBridge.kt.template
+++ b/packages/android/templates/CraftBridge.kt.template
@@ -2141,6 +2141,10 @@ class CraftBridge(
 
     @JavascriptInterface
     fun getContacts() {
+        // Zig answers through the reply channel, so returning here is what
+        // stops the promise being settled twice.
+        if (CraftNative.getContacts(activity)) return
+
         if (ContextCompat.checkSelfPermission(activity, Manifest.permission.READ_CONTACTS)
             != PackageManager.PERMISSION_GRANTED) {
             ActivityCompat.requestPermissions(activity, arrayOf(Manifest.permission.READ_CONTACTS), REQUEST_CONTACTS)

--- a/packages/android/templates/CraftBridge.kt.template
+++ b/packages/android/templates/CraftBridge.kt.template
@@ -2216,6 +2216,10 @@ class CraftBridge(
 
     @JavascriptInterface
     fun addContact(contactJson: String) {
+        // Zig answers through the reply channel, so returning here is what
+        // stops the promise being settled twice.
+        if (CraftNative.addContact(activity, contactJson)) return
+
         if (ContextCompat.checkSelfPermission(activity, Manifest.permission.WRITE_CONTACTS)
             != PackageManager.PERMISSION_GRANTED) {
             ActivityCompat.requestPermissions(activity, arrayOf(Manifest.permission.WRITE_CONTACTS), REQUEST_CONTACTS)

--- a/packages/android/templates/CraftNative.kt.template
+++ b/packages/android/templates/CraftNative.kt.template
@@ -117,6 +117,7 @@ object CraftNative {
     private external fun nativeGetSharedItem(activity: Activity, key: String, group: String): Boolean
     private external fun nativeRemoveSharedItem(activity: Activity, key: String, group: String): Boolean
     private external fun nativeGetContacts(activity: Activity): Boolean
+    private external fun nativeAddContact(activity: Activity, contactJson: String): Boolean
 
     /**
      * `getDeviceInfo`, or null to use the Kotlin implementation.
@@ -462,6 +463,22 @@ object CraftNative {
         if (!isAvailable) return false
         return try {
             nativeGetContacts(activity)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    /**
+     * Returns whether Zig took the write.
+     *
+     * A false is routine rather than exceptional: Zig serves the shape the
+     * page's own SDK sends and hands anything else back, because `org.json`
+     * coerces where a strict parser refuses.
+     */
+    fun addContact(activity: Activity, contactJson: String): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeAddContact(activity, contactJson)
         } catch (e: UnsatisfiedLinkError) {
             false
         }

--- a/packages/android/templates/CraftNative.kt.template
+++ b/packages/android/templates/CraftNative.kt.template
@@ -116,6 +116,7 @@ object CraftNative {
     private external fun nativeSetSharedItem(activity: Activity, key: String, value: String, group: String): Boolean
     private external fun nativeGetSharedItem(activity: Activity, key: String, group: String): Boolean
     private external fun nativeRemoveSharedItem(activity: Activity, key: String, group: String): Boolean
+    private external fun nativeGetContacts(activity: Activity): Boolean
 
     /**
      * `getDeviceInfo`, or null to use the Kotlin implementation.
@@ -446,6 +447,21 @@ object CraftNative {
         if (!isAvailable) return false
         return try {
             nativeRemoveSharedItem(activity, key, group)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    /**
+     * Returns whether Zig took the read, not whether it found anyone.
+     *
+     * An empty address book still answers — with `[]`, through the reply
+     * channel — so a false here means Zig did not run.
+     */
+    fun getContacts(activity: Activity): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeGetContacts(activity)
         } catch (e: UnsatisfiedLinkError) {
             false
         }

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -464,6 +464,9 @@ pub fn build(b: *std.Build) void {
     android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_shareditem.zig", .{
         .root_source_file = b.path("src/bridge_android_shareditem.zig"),
     });
+    android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_contacts.zig", .{
+        .root_source_file = b.path("src/bridge_android_contacts.zig"),
+    });
     const run_android_conformance_tests = b.addRunArtifact(android_conformance_tests);
 
     // The page surface, across both bridges. Not folded into the iOS

--- a/packages/zig/src/android_dispatch.zig
+++ b/packages/zig/src/android_dispatch.zig
@@ -287,6 +287,11 @@ const natives = [_]jni.JNINativeMethod{
         .signature = "(Landroid/app/Activity;)Z",
         .fnPtr = @ptrCast(&nativeGetContacts),
     },
+    .{
+        .name = "nativeAddContact",
+        .signature = "(Landroid/app/Activity;Ljava/lang/String;)Z",
+        .fnPtr = @ptrCast(&nativeAddContact),
+    },
 };
 
 /// How binding went. A value rather than a log line, so every path is
@@ -1033,6 +1038,55 @@ fn nativeGetContacts(
     return jni.JNI_TRUE;
 }
 
+/// `nativeAddContact(activity, contactJson)`.
+///
+/// Resolves with the new contact's id as a JSON *string*, because the shim
+/// interpolated a `Long` into a quoted JavaScript string and the page has
+/// always received text.
+fn nativeAddContact(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+    contact_json: jni.jstring,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const granted = permissions.isGranted(j, activity, permissions.write_contacts) catch |err| {
+        std.log.warn("craft: addContact fell through to the shim ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+
+    if (!granted) {
+        permissions.request(j, activity, permissions.write_contacts, request_contacts) catch |err| {
+            std.log.warn("craft: addContact fell through to the shim ({s})", .{@errorName(err)});
+            return jni.JNI_FALSE;
+        };
+        events.settle(allocator, contacts.add_reject_global, "\"Permission denied\"") catch return jni.JNI_FALSE;
+        return jni.JNI_TRUE;
+    }
+
+    const text = j.stringToUtf8(allocator, contact_json) catch return jni.JNI_FALSE;
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, text, .{}) catch
+        return jni.JNI_FALSE;
+    defer parsed.deinit();
+
+    const contact = contacts.parseNewContact(parsed.value) orelse return jni.JNI_FALSE;
+
+    const id = contacts.addContact(j, allocator, activity, contact) catch |err| {
+        calendar.rejectOn(allocator, contacts.add_reject_global, @errorName(err)) catch {};
+        return jni.JNI_TRUE;
+    };
+
+    var buf: [24]u8 = undefined;
+    const digits = std.fmt.bufPrint(&buf, "{d}", .{id}) catch return jni.JNI_FALSE;
+    const payload = calendar.jsonString(allocator, digits) catch return jni.JNI_FALSE;
+    events.settle(allocator, contacts.add_resolve_global, payload) catch return jni.JNI_FALSE;
+    return jni.JNI_TRUE;
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -1144,7 +1198,7 @@ test "the registered natives name methods the Kotlin actually declares" {
     // A descriptor is checked by the JVM at registration, so a wrong one fails
     // at load rather than at call — but only if the *name* matches something.
     // These two strings are the contract with CraftBridge.kt.
-    try testing.expectEqual(@as(usize, 25), natives.len);
+    try testing.expectEqual(@as(usize, 26), natives.len);
     try testing.expectEqualStrings("nativeGetDeviceInfo", std.mem.span(natives[0].name));
 
     // And the class they bind to is the fixed one, not the templated bridge.

--- a/packages/zig/src/android_dispatch.zig
+++ b/packages/zig/src/android_dispatch.zig
@@ -49,6 +49,7 @@ const events = @import("android_events.zig");
 const calendar = @import("bridge_android_calendar.zig");
 const db = @import("bridge_android_db.zig");
 const shareditem = @import("bridge_android_shareditem.zig");
+const contacts = @import("bridge_android_contacts.zig");
 
 const Jni = jni.Jni;
 
@@ -76,6 +77,9 @@ const request_calendar: i32 = 1005;
 
 /// The shim's default event length: `System.currentTimeMillis() + 3600000`.
 const one_hour_ms: i64 = 60 * 60 * 1000;
+
+/// `CraftBridge.REQUEST_CONTACTS`.
+const request_contacts: i32 = 1004;
 
 /// The VM, captured at load so a later callback on a framework thread can ask
 /// it for that thread's `JNIEnv`.
@@ -277,6 +281,11 @@ const natives = [_]jni.JNINativeMethod{
         .name = "nativeRemoveSharedItem",
         .signature = "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)Z",
         .fnPtr = @ptrCast(&nativeRemoveSharedItem),
+    },
+    .{
+        .name = "nativeGetContacts",
+        .signature = "(Landroid/app/Activity;)Z",
+        .fnPtr = @ptrCast(&nativeGetContacts),
     },
 };
 
@@ -982,6 +991,48 @@ fn nativeRemoveSharedItem(
     return jni.JNI_TRUE;
 }
 
+/// `nativeGetContacts(activity)`.
+///
+/// Falls through when the query fails, for the reason `getCalendarEvents`
+/// does: the shim wraps none of `getContacts` in a try/catch, so an exception
+/// escapes the `@JavascriptInterface` method and the promise hangs. Inventing
+/// a rejection here would be kinder and would be a divergence nothing
+/// records. See #157.
+fn nativeGetContacts(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const granted = permissions.isGranted(j, activity, permissions.read_contacts) catch |err| {
+        std.log.warn("craft: getContacts fell through to the shim ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+
+    if (!granted) {
+        permissions.request(j, activity, permissions.read_contacts, request_contacts) catch |err| {
+            std.log.warn("craft: getContacts fell through to the shim ({s})", .{@errorName(err)});
+            return jni.JNI_FALSE;
+        };
+        events.settle(allocator, contacts.reject_global, "\"Permission denied\"") catch return jni.JNI_FALSE;
+        return jni.JNI_TRUE;
+    }
+
+    var payload: std.ArrayListUnmanaged(u8) = .empty;
+    defer payload.deinit(allocator);
+    contacts.queryContacts(j, allocator, activity, &payload) catch |err| {
+        std.log.warn("craft: getContacts fell through to the shim ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+
+    events.settle(allocator, contacts.resolve_global, payload.items) catch return jni.JNI_FALSE;
+    return jni.JNI_TRUE;
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -1093,7 +1144,7 @@ test "the registered natives name methods the Kotlin actually declares" {
     // A descriptor is checked by the JVM at registration, so a wrong one fails
     // at load rather than at call — but only if the *name* matches something.
     // These two strings are the contract with CraftBridge.kt.
-    try testing.expectEqual(@as(usize, 24), natives.len);
+    try testing.expectEqual(@as(usize, 25), natives.len);
     try testing.expectEqualStrings("nativeGetDeviceInfo", std.mem.span(natives[0].name));
 
     // And the class they bind to is the fixed one, not the templated bridge.

--- a/packages/zig/src/android_permissions.zig
+++ b/packages/zig/src/android_permissions.zig
@@ -39,6 +39,7 @@ pub const granted: i32 = 0;
 pub const read_calendar = "android.permission.READ_CALENDAR";
 pub const write_calendar = "android.permission.WRITE_CALENDAR";
 pub const read_contacts = "android.permission.READ_CONTACTS";
+pub const write_contacts = "android.permission.WRITE_CONTACTS";
 
 /// `activity.checkSelfPermission(permission) == PERMISSION_GRANTED`.
 pub fn isGranted(j: Jni, activity: jobject, permission: [*:0]const u8) !bool {
@@ -90,6 +91,7 @@ test "the permission names match Manifest.permission exactly" {
     try testing.expectEqualStrings("android.permission.READ_CALENDAR", read_calendar);
     try testing.expectEqualStrings("android.permission.WRITE_CALENDAR", write_calendar);
     try testing.expectEqualStrings("android.permission.READ_CONTACTS", read_contacts);
+    try testing.expectEqualStrings("android.permission.WRITE_CONTACTS", write_contacts);
 }
 
 test "PERMISSION_GRANTED is zero, and PERMISSION_DENIED is not" {

--- a/packages/zig/src/android_permissions.zig
+++ b/packages/zig/src/android_permissions.zig
@@ -38,6 +38,7 @@ pub const granted: i32 = 0;
 
 pub const read_calendar = "android.permission.READ_CALENDAR";
 pub const write_calendar = "android.permission.WRITE_CALENDAR";
+pub const read_contacts = "android.permission.READ_CONTACTS";
 
 /// `activity.checkSelfPermission(permission) == PERMISSION_GRANTED`.
 pub fn isGranted(j: Jni, activity: jobject, permission: [*:0]const u8) !bool {
@@ -88,6 +89,7 @@ test "the permission names match Manifest.permission exactly" {
     // that is never granted and an action that always rejects.
     try testing.expectEqualStrings("android.permission.READ_CALENDAR", read_calendar);
     try testing.expectEqualStrings("android.permission.WRITE_CALENDAR", write_calendar);
+    try testing.expectEqualStrings("android.permission.READ_CONTACTS", read_contacts);
 }
 
 test "PERMISSION_GRANTED is zero, and PERMISSION_DENIED is not" {

--- a/packages/zig/src/bridge_android_contacts.zig
+++ b/packages/zig/src/bridge_android_contacts.zig
@@ -41,10 +41,13 @@ const jobject = jni.jobject;
 
 pub const A = struct {
     pub const get_contacts = "getContacts";
+    pub const add_contact = "addContact";
 };
 
 pub const resolve_global = "_craftContactsResolve";
 pub const reject_global = "_craftContactsReject";
+pub const add_resolve_global = "_craftAddContactResolve";
+pub const add_reject_global = "_craftAddContactReject";
 
 const col_id = "_id";
 const col_display_name = "display_name";
@@ -321,6 +324,279 @@ fn javaString(j: Jni, allocator: std.mem.Allocator, text: []const u8) !jni.jstri
 }
 
 // =============================================================================
+// addContact
+// =============================================================================
+//
+// ## The MIME types are read, where the column names are written
+//
+// Every constant elsewhere in this file is a literal, because a wrong column
+// name fails loudly — the provider throws or the cursor comes back empty. A
+// wrong MIMETYPE does not: `applyBatch` accepts it, the row is written, and it
+// simply never shows up as a name or a phone number anywhere. There is no
+// error and nothing to notice until someone opens the address book.
+//
+// So `CONTENT_ITEM_TYPE` is read through JNI. The value is identical to what
+// javac folded into the shim, and reading it is one static field access that
+// cannot be misremembered.
+//
+// ## What the batch builds
+//
+// A raw contact with a null account, then up to three data rows pointing back
+// at it by index rather than by id — `withValueBackReference(RAW_CONTACT_ID,
+// 0)` means "whatever the first operation inserted", which is the only way to
+// reference a row that does not exist yet.
+//
+// Each data row is skipped when its field is empty, so a contact with no phone
+// gets no phone row rather than an empty one.
+
+const col_account_type = "account_type";
+const col_account_name = "account_name";
+const col_raw_contact_id = "raw_contact_id";
+const col_mimetype = "mimetype";
+
+/// `Phone.TYPE` and `Email.TYPE`, both of which are `DATA2`.
+const col_data2 = "data2";
+
+/// `Phone.TYPE_MOBILE` and `Email.TYPE_HOME`.
+const phone_type_mobile: i32 = 2;
+const email_type_home: i32 = 1;
+
+/// `ContactsContract.AUTHORITY`.
+const contacts_authority = "com.android.contacts";
+
+/// The three optional fields the shim reads out of the payload.
+pub const NewContact = struct {
+    display_name: []const u8,
+    phone: []const u8,
+    email: []const u8,
+};
+
+/// Read the declared shape, or null where only `org.json` would.
+///
+/// The same rule `createCalendarEvent` uses and for the same reason: the shim
+/// reads these with `optString`, which coerces a number or a boolean into its
+/// string form, and `Double.toString` is not something to reproduce from
+/// memory. An explicit null is the one coercion carried over — it becomes the
+/// four characters "null", which then passes `isNotEmpty()` and is written to
+/// the address book as a contact named "null". That is what the shim does.
+pub fn parseNewContact(value: std.json.Value) ?NewContact {
+    const object = switch (value) {
+        .object => |o| o,
+        else => return null,
+    };
+
+    return .{
+        .display_name = optString(object, "displayName") orelse return null,
+        .phone = optString(object, "phone") orelse return null,
+        .email = optString(object, "email") orelse return null,
+    };
+}
+
+fn optString(object: std.json.ObjectMap, name: []const u8) ?[]const u8 {
+    const value = object.get(name) orelse return "";
+    return switch (value) {
+        .string => |text| text,
+        .null => "null",
+        else => null,
+    };
+}
+
+/// `contentResolver.applyBatch(AUTHORITY, ops)`, and the id it lands at.
+///
+/// Returns `ContentUris.parseId(results[0].uri!!)`. A batch that produced no
+/// result, or a first result with no uri, is the Kotlin's `!!` throwing — an
+/// error here, a rejection there, the same outcome for the page.
+pub fn addContact(j: Jni, allocator: std.mem.Allocator, activity: jobject, contact: NewContact) !i64 {
+    try j.pushLocalFrame(32);
+    defer _ = j.popLocalFrame(null);
+
+    const list_cls = try j.findClass("java/util/ArrayList");
+    const ops = try j.newObjectA(list_cls, try j.methodId(list_cls, "<init>", "()V"), &.{});
+    const add = try j.methodId(list_cls, "add", "(Ljava/lang/Object;)Z");
+
+    const raw_contacts_cls = try j.findClass("android/provider/ContactsContract$RawContacts");
+    const raw_uri = try j.staticObjectField(
+        raw_contacts_cls,
+        try j.staticFieldId(raw_contacts_cls, "CONTENT_URI", "Landroid/net/Uri;"),
+    );
+
+    {
+        // The raw contact itself, with a null account — a local-only contact,
+        // which is what the shim creates.
+        try j.pushLocalFrame(8);
+        defer _ = j.popLocalFrame(null);
+
+        const builder = try newInsert(j, raw_uri);
+        _ = try withValue(j, allocator, builder, col_account_type, null);
+        _ = try withValue(j, allocator, builder, col_account_name, null);
+        _ = try j.callBooleanMethodA(ops, add, &.{.{ .l = try build(j, builder) }});
+    }
+
+    const data_cls = try j.findClass("android/provider/ContactsContract$Data");
+    const data_uri = try j.staticObjectField(
+        data_cls,
+        try j.staticFieldId(data_cls, "CONTENT_URI", "Landroid/net/Uri;"),
+    );
+
+    if (contact.display_name.len != 0) {
+        try appendDataRow(j, allocator, ops, add, data_uri, "StructuredName", .{
+            .value_column = col_data1,
+            .value = contact.display_name,
+            .type_value = null,
+        });
+    }
+
+    if (contact.phone.len != 0) {
+        try appendDataRow(j, allocator, ops, add, data_uri, "Phone", .{
+            .value_column = col_data1,
+            .value = contact.phone,
+            .type_value = phone_type_mobile,
+        });
+    }
+
+    if (contact.email.len != 0) {
+        try appendDataRow(j, allocator, ops, add, data_uri, "Email", .{
+            .value_column = col_data1,
+            .value = contact.email,
+            .type_value = email_type_home,
+        });
+    }
+
+    const resolver = try contentResolver(j, activity);
+    const results = try j.callObjectMethodA(
+        resolver,
+        try j.methodId(
+            try j.objectClass(resolver),
+            "applyBatch",
+            "(Ljava/lang/String;Ljava/util/ArrayList;)[Landroid/content/ContentProviderResult;",
+        ),
+        &.{
+            .{ .l = try javaString(j, allocator, contacts_authority) },
+            .{ .l = ops },
+        },
+    );
+
+    if (results == null) return error.BatchProducedNothing;
+    if (try j.arrayLength(results) == 0) return error.BatchProducedNothing;
+
+    const first = try j.objectArrayElement(results, 0);
+    if (first == null) return error.BatchProducedNothing;
+
+    // `ContentProviderResult.uri` is a public field, not a getter.
+    const uri = try j.objectField(
+        first,
+        try j.fieldId(try j.objectClass(first), "uri", "Landroid/net/Uri;"),
+    );
+    if (uri == null) return error.BatchProducedNothing;
+
+    const content_uris_cls = try j.findClass("android/content/ContentUris");
+    return j.callStaticLongMethodA(
+        content_uris_cls,
+        try j.staticMethodId(content_uris_cls, "parseId", "(Landroid/net/Uri;)J"),
+        &.{.{ .l = uri }},
+    );
+}
+
+const DataRow = struct {
+    value_column: []const u8,
+    value: []const u8,
+    /// `Phone.TYPE` / `Email.TYPE`, absent for a structured name.
+    type_value: ?i32,
+};
+
+fn appendDataRow(
+    j: Jni,
+    allocator: std.mem.Allocator,
+    ops: jobject,
+    add: jni.jmethodID,
+    data_uri: jobject,
+    comptime kind: []const u8,
+    row: DataRow,
+) !void {
+    try j.pushLocalFrame(16);
+    defer _ = j.popLocalFrame(null);
+
+    // Comptime, so the class name is a string literal the linker holds rather
+    // than something assembled per call.
+    const kind_cls = try j.findClass("android/provider/ContactsContract$CommonDataKinds$" ++ kind);
+    const item_type = try j.staticObjectField(
+        kind_cls,
+        try j.staticFieldId(kind_cls, "CONTENT_ITEM_TYPE", "Ljava/lang/String;"),
+    );
+
+    const builder = try newInsert(j, data_uri);
+
+    // Index 0 is the raw contact this batch opened with; the row it inserts
+    // has no id until the batch runs, so it is referenced by position.
+    _ = try j.callObjectMethodA(
+        builder,
+        try j.methodId(
+            try j.objectClass(builder),
+            "withValueBackReference",
+            "(Ljava/lang/String;I)Landroid/content/ContentProviderOperation$Builder;",
+        ),
+        &.{ .{ .l = try javaString(j, allocator, col_raw_contact_id) }, .{ .i = 0 } },
+    );
+
+    _ = try withValue(j, allocator, builder, col_mimetype, item_type);
+    _ = try withValue(j, allocator, builder, row.value_column, try javaString(j, allocator, row.value));
+
+    if (row.type_value) |type_value| {
+        const integer_cls = try j.findClass("java/lang/Integer");
+        const boxed = try j.callStaticObjectMethodA(
+            integer_cls,
+            try j.staticMethodId(integer_cls, "valueOf", "(I)Ljava/lang/Integer;"),
+            &.{.{ .i = type_value }},
+        );
+        _ = try withValue(j, allocator, builder, col_data2, boxed);
+    }
+
+    _ = try j.callBooleanMethodA(ops, add, &.{.{ .l = try build(j, builder) }});
+}
+
+fn newInsert(j: Jni, uri: jobject) !jobject {
+    const op_cls = try j.findClass("android/content/ContentProviderOperation");
+    return j.callStaticObjectMethodA(
+        op_cls,
+        try j.staticMethodId(
+            op_cls,
+            "newInsert",
+            "(Landroid/net/Uri;)Landroid/content/ContentProviderOperation$Builder;",
+        ),
+        &.{.{ .l = uri }},
+    );
+}
+
+fn withValue(
+    j: Jni,
+    allocator: std.mem.Allocator,
+    builder: jobject,
+    column: []const u8,
+    value: jobject,
+) !jobject {
+    return j.callObjectMethodA(
+        builder,
+        try j.methodId(
+            try j.objectClass(builder),
+            "withValue",
+            "(Ljava/lang/String;Ljava/lang/Object;)Landroid/content/ContentProviderOperation$Builder;",
+        ),
+        &.{ .{ .l = try javaString(j, allocator, column) }, .{ .l = value } },
+    );
+}
+
+fn build(j: Jni, builder: jobject) !jobject {
+    return j.callObjectMethod(
+        builder,
+        try j.methodId(
+            try j.objectClass(builder),
+            "build",
+            "()Landroid/content/ContentProviderOperation;",
+        ),
+    );
+}
+
+// =============================================================================
 // Tests
 // =============================================================================
 
@@ -434,4 +710,108 @@ test "getContacts names its action and globals as the shim does" {
     try testing.expectEqualStrings("getContacts", A.get_contacts);
     try testing.expectEqualStrings("_craftContactsResolve", resolve_global);
     try testing.expectEqualStrings("_craftContactsReject", reject_global);
+}
+
+// --- addContact ------------------------------------------------------------
+
+fn parsedContact(json: []const u8) !?NewContact {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, arena.allocator(), json, .{});
+    defer parsed.deinit();
+
+    const contact = parseNewContact(parsed.value) orelse return null;
+    return NewContact{
+        .display_name = try testing.allocator.dupe(u8, contact.display_name),
+        .phone = try testing.allocator.dupe(u8, contact.phone),
+        .email = try testing.allocator.dupe(u8, contact.email),
+    };
+}
+
+fn freeContact(contact: NewContact) void {
+    testing.allocator.free(contact.display_name);
+    testing.allocator.free(contact.phone);
+    testing.allocator.free(contact.email);
+}
+
+test "the declared shape reads straight through" {
+    const contact = (try parsedContact(
+        \\{"displayName":"Ada","phone":"+441234567890","email":"ada@example.com"}
+    )).?;
+    defer freeContact(contact);
+
+    try testing.expectEqualStrings("Ada", contact.display_name);
+    try testing.expectEqualStrings("+441234567890", contact.phone);
+    try testing.expectEqualStrings("ada@example.com", contact.email);
+}
+
+test "absent fields are empty, and an empty field writes no row" {
+    // `optString(name, "")`, and then `if (x.isNotEmpty())` decides whether the
+    // batch gets a row at all. An empty phone is not a phone row with an empty
+    // number — it is no phone row.
+    const contact = (try parsedContact("{}")).?;
+    defer freeContact(contact);
+
+    try testing.expectEqualStrings("", contact.display_name);
+    try testing.expectEqualStrings("", contact.phone);
+    try testing.expectEqualStrings("", contact.email);
+}
+
+test "an explicit null becomes a contact named null" {
+    // Not a joke and not a rounding: `optString` on JSON null returns the four
+    // characters "null", which passes `isNotEmpty()` and is written to the
+    // address book. `JSON.stringify({displayName: null})` produces it, and the
+    // shim behaves this way today.
+    const contact = (try parsedContact(
+        \\{"displayName":null}
+    )).?;
+    defer freeContact(contact);
+
+    try testing.expectEqualStrings("null", contact.display_name);
+    try testing.expectEqualStrings("", contact.phone);
+}
+
+test "a shape only org.json would coerce is handed back" {
+    for ([_][]const u8{
+        \\{"displayName":1.5}
+        ,
+        \\{"phone":447700900000}
+        ,
+        \\{"email":true}
+        ,
+        \\[]
+        ,
+        \\"Ada"
+        ,
+    }) |payload| {
+        if (try parsedContact(payload)) |contact| {
+            freeContact(contact);
+            std.debug.print("payload was served rather than handed back: {s}\n", .{payload});
+            return error.CoercedShapeAccepted;
+        }
+    }
+}
+
+test "the batch's column names and types are the shim's" {
+    try testing.expectEqualStrings("account_type", col_account_type);
+    try testing.expectEqualStrings("account_name", col_account_name);
+    try testing.expectEqualStrings("raw_contact_id", col_raw_contact_id);
+    try testing.expectEqualStrings("mimetype", col_mimetype);
+    try testing.expectEqualStrings("com.android.contacts", contacts_authority);
+
+    // Phone.TYPE and Email.TYPE are both DATA2, the same way NUMBER and
+    // ADDRESS are both DATA1.
+    try testing.expectEqualStrings("data2", col_data2);
+
+    // Phone.TYPE_MOBILE and Email.TYPE_HOME. Different numbers in different
+    // enumerations that happen to sit in the same column.
+    try testing.expectEqual(@as(i32, 2), phone_type_mobile);
+    try testing.expectEqual(@as(i32, 1), email_type_home);
+}
+
+test "addContact names its action and globals as the shim does" {
+    try testing.expectEqualStrings("addContact", A.add_contact);
+    try testing.expectEqualStrings("_craftAddContactResolve", add_resolve_global);
+    try testing.expectEqualStrings("_craftAddContactReject", add_reject_global);
 }

--- a/packages/zig/src/bridge_android_contacts.zig
+++ b/packages/zig/src/bridge_android_contacts.zig
@@ -1,0 +1,437 @@
+//! `getContacts` on Android.
+//!
+//! ## The column names are literals, and that is the faithful choice
+//!
+//! `ContactsContract.Contacts.DISPLAY_NAME` and its neighbours are
+//! `public static final String` — compile-time constants, so javac folds them
+//! into the shim's DEX and the shim never reads those fields at runtime
+//! either. The `CONTENT_URI`s are `Uri` objects and so are still read through
+//! JNI, the same split the calendar module makes.
+//!
+//! Two of them are the same string and it is not a mistake: `Phone.NUMBER` and
+//! `Email.ADDRESS` are both `DATA1`, because a data row's meaning comes from
+//! its MIMETYPE and the generic `data1` column holds whichever value that row
+//! is. Writing "data1" twice is what the shim compiles to.
+//!
+//! ## One query per contact, twice over
+//!
+//! The shim runs a query for the contact list and then two more *per contact*,
+//! one for phones and one for emails, each on the JavaBridge thread. A device
+//! with two thousand contacts makes four thousand and one queries for a single
+//! `craft.contacts.getAll()`. Reproduced rather than improved: the same rows
+//! could be fetched in three queries and grouped, but that changes what a
+//! concurrent edit to the address book produces, and this port is meant to be
+//! auditable against the Kotlin line by line. See #165.
+//!
+//! ## A null is not the same absence twice
+//!
+//! `put("id", id)` with a null **removes** the key, so a contact with no `_id`
+//! arrives without one. `put("displayName", name ?: "")` turns the same null
+//! into an empty string. And a null phone number is appended to its array as a
+//! JSON `null`, because `JSONArray.put` stores it and `JSONStringer` writes it
+//! out. Three different answers to the same missing value, all of them the
+//! shim's.
+
+const std = @import("std");
+const jni = @import("jni_runtime.zig");
+const bridge_error = @import("bridge_error.zig");
+
+const Jni = jni.Jni;
+const jobject = jni.jobject;
+
+pub const A = struct {
+    pub const get_contacts = "getContacts";
+};
+
+pub const resolve_global = "_craftContactsResolve";
+pub const reject_global = "_craftContactsReject";
+
+const col_id = "_id";
+const col_display_name = "display_name";
+
+/// `Phone.CONTACT_ID` and `Email.CONTACT_ID`, the join back to the contact.
+const col_contact_id = "contact_id";
+
+/// `Phone.NUMBER` and `Email.ADDRESS`, both of which are `DATA1`.
+const col_data1 = "data1";
+
+const contacts_sort_order = col_display_name ++ " ASC";
+const data_selection = col_contact_id ++ " = ?";
+
+/// One contact, as the two cursors give it.
+pub const Contact = struct {
+    id: ?[]const u8,
+    display_name: ?[]const u8,
+    phone_numbers: []const ?[]const u8,
+    email_addresses: []const ?[]const u8,
+};
+
+/// One contact as the shim's `JSONObject` would print it.
+pub fn appendContact(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    contact: Contact,
+) !void {
+    try out.append(allocator, '{');
+
+    // `put("id", null)` removes the mapping, so a null id is an absent key
+    // rather than a JSON null — and the comma has to go with it.
+    if (contact.id) |id| {
+        try appendStringMember(allocator, out, "id", id);
+        try out.append(allocator, ',');
+    }
+
+    // `?: ""` — the same null, answered differently one line later.
+    try appendStringMember(allocator, out, "displayName", contact.display_name orelse "");
+
+    try out.appendSlice(allocator, ",\"phoneNumbers\":");
+    try appendStrings(allocator, out, contact.phone_numbers);
+    try out.appendSlice(allocator, ",\"emailAddresses\":");
+    try appendStrings(allocator, out, contact.email_addresses);
+
+    try out.append(allocator, '}');
+}
+
+/// A `JSONArray` of strings, where a null element is a JSON null.
+///
+/// `JSONArray.put(Object)` stores the null and `JSONStringer` writes `null`
+/// for it, so unlike a `JSONObject` member the element is not dropped — the
+/// array keeps its length and the page sees a hole.
+fn appendStrings(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    values: []const ?[]const u8,
+) !void {
+    try out.append(allocator, '[');
+    for (values, 0..) |value, i| {
+        if (i != 0) try out.append(allocator, ',');
+        if (value) |text| {
+            try out.append(allocator, '"');
+            try bridge_error.appendJsonEscaped(allocator, out, text);
+            try out.append(allocator, '"');
+        } else {
+            try out.appendSlice(allocator, "null");
+        }
+    }
+    try out.append(allocator, ']');
+}
+
+fn appendStringMember(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    name: []const u8,
+    value: []const u8,
+) !void {
+    try out.append(allocator, '"');
+    try out.appendSlice(allocator, name);
+    try out.appendSlice(allocator, "\":\"");
+    try bridge_error.appendJsonEscaped(allocator, out, value);
+    try out.append(allocator, '"');
+}
+
+/// The whole address book, appended to `out` as a JSON array.
+pub fn queryContacts(
+    j: Jni,
+    allocator: std.mem.Allocator,
+    activity: jobject,
+    out: *std.ArrayListUnmanaged(u8),
+) !void {
+    try j.pushLocalFrame(24);
+    defer _ = j.popLocalFrame(null);
+
+    const resolver = try contentResolver(j, activity);
+    const contacts_cls = try j.findClass("android/provider/ContactsContract$Contacts");
+    const content_uri = try j.staticObjectField(
+        contacts_cls,
+        try j.staticFieldId(contacts_cls, "CONTENT_URI", "Landroid/net/Uri;"),
+    );
+
+    // `query(uri, null, null, null, "display_name ASC")` — a null projection
+    // selects every column of a wide table, which is the shim's call and is
+    // half of why #165 exists.
+    const cursor = try queryUri(j, allocator, resolver, content_uri, null, null, contacts_sort_order);
+
+    try out.append(allocator, '[');
+    defer out.append(allocator, ']') catch {};
+
+    if (cursor == null) return;
+
+    const cursor_cls = try j.objectClass(cursor);
+    const move_to_next = try j.methodId(cursor_cls, "moveToNext", "()Z");
+    const get_string = try j.methodId(cursor_cls, "getString", "(I)Ljava/lang/String;");
+    const close = try j.methodId(cursor_cls, "close", "()V");
+    defer j.callVoidMethodA(cursor, close, &.{}) catch {};
+
+    // `getColumnIndexOrThrow` is resolved once rather than per row. The shim
+    // calls it inside the loop; the answer cannot change while a cursor is
+    // open, and the difference is not observable.
+    const id_index = try columnIndex(j, allocator, cursor, col_id);
+    const name_index = try columnIndex(j, allocator, cursor, col_display_name);
+
+    var count: usize = 0;
+    while (try j.callBooleanMethodA(cursor, move_to_next, &.{})) {
+        try j.pushLocalFrame(8);
+        defer _ = j.popLocalFrame(null);
+
+        const id = try columnText(j, allocator, cursor, get_string, id_index);
+        const name = try columnText(j, allocator, cursor, get_string, name_index);
+
+        // The two extra queries per contact. They need the id as text, and a
+        // contact without one cannot be joined to — the shim passes the null
+        // straight to `arrayOf(contactId)`, where it becomes a selection
+        // argument of null and the provider matches nothing.
+        const phones = try relatedValues(j, allocator, resolver, "Phone", id);
+        const emails = try relatedValues(j, allocator, resolver, "Email", id);
+
+        if (count != 0) try out.append(allocator, ',');
+        try appendContact(allocator, out, .{
+            .id = id,
+            .display_name = name,
+            .phone_numbers = phones,
+            .email_addresses = emails,
+        });
+        count += 1;
+    }
+}
+
+/// `getContactPhones` / `getContactEmails`, which differ only in the class
+/// holding the `CONTENT_URI`.
+fn relatedValues(
+    j: Jni,
+    allocator: std.mem.Allocator,
+    resolver: jobject,
+    comptime kind: []const u8,
+    contact_id: ?[]const u8,
+) ![]const ?[]const u8 {
+    try j.pushLocalFrame(16);
+    defer _ = j.popLocalFrame(null);
+
+    const cls = try j.findClass("android/provider/ContactsContract$CommonDataKinds$" ++ kind);
+    const content_uri = try j.staticObjectField(
+        cls,
+        try j.staticFieldId(cls, "CONTENT_URI", "Landroid/net/Uri;"),
+    );
+
+    const args = [_]?[]const u8{contact_id};
+    const cursor = try queryUri(j, allocator, resolver, content_uri, data_selection, &args, null);
+
+    var values: std.ArrayListUnmanaged(?[]const u8) = .empty;
+    errdefer values.deinit(allocator);
+
+    if (cursor == null) return values.toOwnedSlice(allocator);
+
+    const cursor_cls = try j.objectClass(cursor);
+    const move_to_next = try j.methodId(cursor_cls, "moveToNext", "()Z");
+    const get_string = try j.methodId(cursor_cls, "getString", "(I)Ljava/lang/String;");
+    const close = try j.methodId(cursor_cls, "close", "()V");
+    defer j.callVoidMethodA(cursor, close, &.{}) catch {};
+
+    const value_index = try columnIndex(j, allocator, cursor, col_data1);
+
+    while (try j.callBooleanMethodA(cursor, move_to_next, &.{})) {
+        try j.pushLocalFrame(8);
+        defer _ = j.popLocalFrame(null);
+        try values.append(allocator, try columnText(j, allocator, cursor, get_string, value_index));
+    }
+    return values.toOwnedSlice(allocator);
+}
+
+fn contentResolver(j: Jni, activity: jobject) !jobject {
+    return j.callObjectMethod(
+        activity,
+        try j.methodId(
+            try j.objectClass(activity),
+            "getContentResolver",
+            "()Landroid/content/ContentResolver;",
+        ),
+    );
+}
+
+/// `resolver.query(uri, null, selection, selectionArgs, sortOrder)`.
+///
+/// The projection is always null here because both of the shim's queries pass
+/// null; a caller wanting one would pass the array rather than this taking a
+/// parameter nothing sets.
+fn queryUri(
+    j: Jni,
+    allocator: std.mem.Allocator,
+    resolver: jobject,
+    uri: jobject,
+    selection: ?[]const u8,
+    selection_args: ?[]const ?[]const u8,
+    sort_order: ?[]const u8,
+) !jobject {
+    const args_array: jobject = if (selection_args) |args| blk: {
+        const string_cls = try j.findClass("java/lang/String");
+        const array = try j.newObjectArray(args.len, string_cls);
+        for (args, 0..) |arg, i| {
+            // A null argument is a null element, which is what
+            // `arrayOf(contactId)` produces when the id was null.
+            const value: jni.jstring = if (arg) |text| try javaString(j, allocator, text) else null;
+            try j.setObjectArrayElement(array, i, value);
+        }
+        break :blk array;
+    } else null;
+
+    return j.callObjectMethodA(
+        resolver,
+        try j.methodId(
+            try j.objectClass(resolver),
+            "query",
+            "(Landroid/net/Uri;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;)Landroid/database/Cursor;",
+        ),
+        &.{
+            .{ .l = uri },
+            .{ .l = null },
+            .{ .l = if (selection) |text| try javaString(j, allocator, text) else null },
+            .{ .l = args_array },
+            .{ .l = if (sort_order) |text| try javaString(j, allocator, text) else null },
+        },
+    );
+}
+
+fn columnIndex(j: Jni, allocator: std.mem.Allocator, cursor: jobject, name: []const u8) !i32 {
+    try j.pushLocalFrame(4);
+    defer _ = j.popLocalFrame(null);
+
+    return j.callIntMethodA(
+        cursor,
+        try j.methodId(try j.objectClass(cursor), "getColumnIndexOrThrow", "(Ljava/lang/String;)I"),
+        &.{.{ .l = try javaString(j, allocator, name) }},
+    );
+}
+
+fn columnText(
+    j: Jni,
+    allocator: std.mem.Allocator,
+    cursor: jobject,
+    get_string: jni.jmethodID,
+    index: i32,
+) !?[]const u8 {
+    const value = try j.callObjectMethodA(cursor, get_string, &.{.{ .i = index }});
+    if (value == null) return null;
+    return try j.stringToUtf8(allocator, value);
+}
+
+fn javaString(j: Jni, allocator: std.mem.Allocator, text: []const u8) !jni.jstring {
+    const terminated = try allocator.allocSentinel(u8, text.len, 0);
+    defer allocator.free(terminated);
+    @memcpy(terminated, text);
+    return j.newStringUtf(terminated.ptr);
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+const testing = std.testing;
+
+fn renderContacts(contacts: []const Contact) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(testing.allocator);
+    try out.append(testing.allocator, '[');
+    for (contacts, 0..) |contact, i| {
+        if (i != 0) try out.append(testing.allocator, ',');
+        try appendContact(testing.allocator, &out, contact);
+    }
+    try out.append(testing.allocator, ']');
+    return out.toOwnedSlice(testing.allocator);
+}
+
+test "a contact prints the keys the shim's JSONObject prints, in that order" {
+    const json = try renderContacts(&.{.{
+        .id = "7",
+        .display_name = "Ada Lovelace",
+        .phone_numbers = &.{ "+441234567890", "555" },
+        .email_addresses = &.{"ada@example.com"},
+    }});
+    defer testing.allocator.free(json);
+
+    // JSONObject is a LinkedHashMap, so this is the order of the shim's
+    // `apply` block. Asserted whole, because the order is what a rewrite loses.
+    try testing.expectEqualStrings(
+        \\[{"id":"7","displayName":"Ada Lovelace","phoneNumbers":["+441234567890","555"],"emailAddresses":["ada@example.com"]}]
+    , json);
+}
+
+test "a contact with no phones or emails still carries both arrays" {
+    // `getContactPhones` always returns a JSONArray, so the keys are present
+    // and empty rather than missing — a page can iterate without checking.
+    const json = try renderContacts(&.{.{
+        .id = "7",
+        .display_name = "Nobody",
+        .phone_numbers = &.{},
+        .email_addresses = &.{},
+    }});
+    defer testing.allocator.free(json);
+
+    try testing.expectEqualStrings(
+        \\[{"id":"7","displayName":"Nobody","phoneNumbers":[],"emailAddresses":[]}]
+    , json);
+}
+
+test "the same null is answered three different ways" {
+    // `put("id", null)` removes the key; `?: ""` makes the name empty; and a
+    // null array element is written as JSON null rather than dropped, so the
+    // array keeps its length.
+    const json = try renderContacts(&.{.{
+        .id = null,
+        .display_name = null,
+        .phone_numbers = &.{ null, "555" },
+        .email_addresses = &.{null},
+    }});
+    defer testing.allocator.free(json);
+
+    try testing.expectEqualStrings(
+        \\[{"displayName":"","phoneNumbers":[null,"555"],"emailAddresses":[null]}]
+    , json);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    const first = parsed.value.array.items[0].object;
+    try testing.expect(first.get("id") == null);
+    try testing.expectEqual(@as(usize, 2), first.get("phoneNumbers").?.array.items.len);
+}
+
+test "a name or number carrying a quote survives as JSON" {
+    // Contact names are arbitrary user text and go to the page through the
+    // reply channel — the shape that hung the promise before #154.
+    const json = try renderContacts(&.{.{
+        .id = "it's",
+        .display_name = "O'Brien \"Bob\"",
+        .phone_numbers = &.{"+1 (555) \"x\""},
+        .email_addresses = &.{"a\nb@example.com"},
+    }});
+    defer testing.allocator.free(json);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    const first = parsed.value.array.items[0].object;
+    try testing.expectEqualStrings("it's", first.get("id").?.string);
+    try testing.expectEqualStrings("O'Brien \"Bob\"", first.get("displayName").?.string);
+    try testing.expectEqualStrings("+1 (555) \"x\"", first.get("phoneNumbers").?.array.items[0].string);
+    try testing.expectEqualStrings("a\nb@example.com", first.get("emailAddresses").?.array.items[0].string);
+}
+
+test "an empty address book is an empty array" {
+    const json = try renderContacts(&.{});
+    defer testing.allocator.free(json);
+    try testing.expectEqualStrings("[]", json);
+}
+
+test "the query strings are the shim's, character for character" {
+    try testing.expectEqualStrings("display_name ASC", contacts_sort_order);
+    try testing.expectEqualStrings("contact_id = ?", data_selection);
+
+    // Phone.NUMBER and Email.ADDRESS really are the same column: a data row's
+    // meaning comes from its MIMETYPE, and data1 holds whichever value it is.
+    try testing.expectEqualStrings("data1", col_data1);
+    try testing.expectEqualStrings("_id", col_id);
+    try testing.expectEqualStrings("display_name", col_display_name);
+}
+
+test "getContacts names its action and globals as the shim does" {
+    try testing.expectEqualStrings("getContacts", A.get_contacts);
+    try testing.expectEqualStrings("_craftContactsResolve", resolve_global);
+    try testing.expectEqualStrings("_craftContactsReject", reject_global);
+}

--- a/packages/zig/test/android_conformance_test.zig
+++ b/packages/zig/test/android_conformance_test.zig
@@ -70,8 +70,8 @@ const zig_sources = [_][]const u8{
 /// getCalendarEvents, the first to send the page a payload it built rather
 /// than a constant; 84 with createCalendarEvent, the first to read one; 82
 /// with the database pair, the first to borrow a connection the Kotlin owns;
-/// 79 with the shared-item trio; 78 with getContacts.
-const max_not_yet_migrated: usize = 78;
+/// 79 with the shared-item trio; 77 with the contacts pair.
+const max_not_yet_migrated: usize = 77;
 
 /// Every `@JavascriptInterface fun <name>(` in the Kotlin bridge.
 ///

--- a/packages/zig/test/android_conformance_test.zig
+++ b/packages/zig/test/android_conformance_test.zig
@@ -50,6 +50,7 @@ const zig_sources = [_][]const u8{
     @embedFile("src/bridge_android_calendar.zig"),
     @embedFile("src/bridge_android_db.zig"),
     @embedFile("src/bridge_android_shareditem.zig"),
+    @embedFile("src/bridge_android_contacts.zig"),
 };
 
 /// How many spec actions Zig does not serve yet.
@@ -69,8 +70,8 @@ const zig_sources = [_][]const u8{
 /// getCalendarEvents, the first to send the page a payload it built rather
 /// than a constant; 84 with createCalendarEvent, the first to read one; 82
 /// with the database pair, the first to borrow a connection the Kotlin owns;
-/// 79 with the shared-item trio.
-const max_not_yet_migrated: usize = 79;
+/// 79 with the shared-item trio; 78 with getContacts.
+const max_not_yet_migrated: usize = 78;
 
 /// Every `@JavascriptInterface fun <name>(` in the Kotlin bridge.
 ///


### PR DESCRIPTION
`getContacts` and `addContact` — the last large `ContentResolver` surface, and three different answers to the same missing value.

## getContacts: the same null, answered three different ways

Within four lines of the shim:

```kotlin
put("id", id)                              // null REMOVES the key
put("displayName", name ?: "")             // null becomes ""
put("phoneNumbers", getContactPhones(id))  // a null element is KEPT as JSON null
```

`JSONObject.put(name, null)` removes the mapping, so a contact without an `_id` arrives with no `id` key at all. The elvis on the next line turns the same null into an empty string. And `JSONArray.put(Object)` *stores* a null, which `JSONStringer` writes as `null` — so the array keeps its length and the page sees a hole rather than a shorter list.

All three are ported, and one test asserts all three at once, because the interesting property is that they differ.

## Two columns that really are the same column

`Phone.NUMBER` and `Email.ADDRESS` are both `DATA1`; `Phone.TYPE` and `Email.TYPE` are both `DATA2`. A data row's meaning comes from its `MIMETYPE`, and the generic columns hold whichever value that row is. Writing `"data1"` twice is what the shim compiles to, and the test says so rather than leaving it looking like a copy-paste slip.

## The 2N+1 loop is reproduced on purpose

`getContacts` runs one query for the list and **two more per contact**. Two thousand contacts is 4,001 queries, each a Binder round trip, on the JavaBridge thread, with a `null` projection pulling every column of a wide denormalized view.

Three queries and an in-memory join would produce the same output — but a different mixture under a concurrent edit, and `ContentResolver` gives no snapshot across queries either way. Ported as-is so the port stays auditable against the Kotlin line by line, and filed as #165: it is the wrong algorithm in both languages now rather than in one.

The one departure: `getColumnIndexOrThrow` is resolved once per cursor rather than once per row. Not observable — the answer cannot change while a cursor is open.

## addContact: the MIME types are read, where the column names are written

Every other constant here is a literal, because a wrong column name **fails loudly** — the provider throws, or the cursor comes back empty. A wrong `MIMETYPE` does not: `applyBatch` accepts it, the row is written, and it simply never appears as a name or a phone number anywhere. No error, nothing to notice until someone opens the address book.

So `CONTENT_ITEM_TYPE` is read through JNI. The value is identical to what javac folded into the shim; reading it is one static field access that cannot be misremembered. The asymmetry is the whole argument, and it is in the module comment rather than left looking like an inconsistency.

## An explicit null becomes a contact named "null"

`optString` on JSON null returns the four characters `"null"`, which passes `isNotEmpty()` and is written to the address book. `JSON.stringify({displayName: null})` produces exactly that, so it is a live path — reproduced, with a test that fails when the quirk is removed.

Otherwise the same rule `createCalendarEvent` set: serve the declared shape, hand back anything only `org.json`'s coercions would read, and decline **before** any JNI call has touched the provider.

The batch itself is a raw contact with a null account — local-only, which is what the shim creates — then up to three data rows referencing it by `withValueBackReference(RAW_CONTACT_ID, 0)`, since the row it points at does not exist until the batch runs. An empty field writes no row rather than an empty one. The id resolves as a JSON *string*, because the shim interpolated its `Long` into a quoted JavaScript string and the page has always received text.

## Where getContacts declines to serve

If the query throws, the native returns false and the shim runs. `getContacts` has no `try`/`catch`, so the exception escapes the `@JavascriptInterface` method and the promise hangs — the same shape as #157, which covers `getCalendarEvents` for the same reason.

## Testing

`zig build test:android` passes with the ratchet at 77. Three mutations fired before these were committed: emitting `"id":""` for a null id, dropping null array elements, and removing the `"null"` coercion each fail a named test. Both `libcraft.so` targets still build with no NDK.