### PR TITLE
feat(android): the widget pair in Zig — ratchet 77 → 75

### DIFF
--- a/packages/android/templates/CraftBridge.kt.template
+++ b/packages/android/templates/CraftBridge.kt.template
@@ -3740,6 +3740,11 @@ class CraftBridge(
 
     @JavascriptInterface
     fun updateWidget(dataJson: String) {
+        // Zig answers through the reply channel, so returning here is what
+        // stops the promise being settled twice. The action is passed across
+        // rather than rebuilt there — see CraftNative.updateWidget.
+        if (CraftNative.updateWidget(activity, "{{PACKAGE_NAME}}.WIDGET_UPDATE", dataJson)) return
+
         try {
             val data = JSONObject(dataJson)
             val editor = widgetPrefs.edit()
@@ -3782,6 +3787,8 @@ class CraftBridge(
 
     @JavascriptInterface
     fun reloadWidgets() {
+        if (CraftNative.reloadWidgets(activity, "{{PACKAGE_NAME}}.WIDGET_UPDATE")) return
+
         val intent = Intent("{{PACKAGE_NAME}}.WIDGET_UPDATE")
         intent.setPackage(activity.packageName)
         activity.sendBroadcast(intent)

--- a/packages/android/templates/CraftNative.kt.template
+++ b/packages/android/templates/CraftNative.kt.template
@@ -118,6 +118,8 @@ object CraftNative {
     private external fun nativeRemoveSharedItem(activity: Activity, key: String, group: String): Boolean
     private external fun nativeGetContacts(activity: Activity): Boolean
     private external fun nativeAddContact(activity: Activity, contactJson: String): Boolean
+    private external fun nativeUpdateWidget(activity: Activity, action: String, dataJson: String): Boolean
+    private external fun nativeReloadWidgets(activity: Activity, action: String): Boolean
 
     /**
      * `getDeviceInfo`, or null to use the Kotlin implementation.
@@ -479,6 +481,32 @@ object CraftNative {
         if (!isAvailable) return false
         return try {
             nativeAddContact(activity, contactJson)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    /**
+     * The widget pair. `action` is the caller's own broadcast constant.
+     *
+     * Zig could build it from `activity.packageName`, and today that is the
+     * same string — but an `applicationIdSuffix` on a build type would move
+     * the package name and leave the constant where it was, and the widget
+     * would silently stop updating. Only one side gets to decide.
+     */
+    fun updateWidget(activity: Activity, action: String, dataJson: String): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeUpdateWidget(activity, action, dataJson)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    fun reloadWidgets(activity: Activity, action: String): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeReloadWidgets(activity, action)
         } catch (e: UnsatisfiedLinkError) {
             false
         }

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -467,6 +467,9 @@ pub fn build(b: *std.Build) void {
     android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_contacts.zig", .{
         .root_source_file = b.path("src/bridge_android_contacts.zig"),
     });
+    android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_widgets.zig", .{
+        .root_source_file = b.path("src/bridge_android_widgets.zig"),
+    });
     const run_android_conformance_tests = b.addRunArtifact(android_conformance_tests);
 
     // The page surface, across both bridges. Not folded into the iOS

--- a/packages/zig/src/android_dispatch.zig
+++ b/packages/zig/src/android_dispatch.zig
@@ -50,6 +50,7 @@ const calendar = @import("bridge_android_calendar.zig");
 const db = @import("bridge_android_db.zig");
 const shareditem = @import("bridge_android_shareditem.zig");
 const contacts = @import("bridge_android_contacts.zig");
+const widgets = @import("bridge_android_widgets.zig");
 
 const Jni = jni.Jni;
 
@@ -291,6 +292,20 @@ const natives = [_]jni.JNINativeMethod{
         .name = "nativeAddContact",
         .signature = "(Landroid/app/Activity;Ljava/lang/String;)Z",
         .fnPtr = @ptrCast(&nativeAddContact),
+    },
+    // The broadcast action is passed across rather than built here: it is a
+    // compile-time constant in the generated app, and deriving it from the
+    // runtime package name would silently stop matching under an
+    // `applicationIdSuffix`.
+    .{
+        .name = "nativeUpdateWidget",
+        .signature = "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)Z",
+        .fnPtr = @ptrCast(&nativeUpdateWidget),
+    },
+    .{
+        .name = "nativeReloadWidgets",
+        .signature = "(Landroid/app/Activity;Ljava/lang/String;)Z",
+        .fnPtr = @ptrCast(&nativeReloadWidgets),
     },
 };
 
@@ -1087,6 +1102,71 @@ fn nativeAddContact(
     return jni.JNI_TRUE;
 }
 
+/// `nativeUpdateWidget(activity, action, dataJson)`.
+fn nativeUpdateWidget(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+    action: jni.jstring,
+    data_json: jni.jstring,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const text = j.stringToUtf8(allocator, data_json) catch return jni.JNI_FALSE;
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, text, .{}) catch
+        return jni.JNI_FALSE;
+    defer parsed.deinit();
+
+    const update = widgets.parseUpdate(parsed.value) orelse return jni.JNI_FALSE;
+    const action_text = j.stringToUtf8(allocator, action) catch return jni.JNI_FALSE;
+
+    widgets.writeUpdate(j, allocator, activity, update) catch |err| {
+        calendar.rejectOn(allocator, widgets.reject_global, @errorName(err)) catch {};
+        return jni.JNI_TRUE;
+    };
+    widgets.broadcast(j, allocator, activity, action_text) catch |err| {
+        calendar.rejectOn(allocator, widgets.reject_global, @errorName(err)) catch {};
+        return jni.JNI_TRUE;
+    };
+
+    events.settle(allocator, widgets.resolve_global, widgets.updated_result) catch
+        return jni.JNI_FALSE;
+    return jni.JNI_TRUE;
+}
+
+/// `nativeReloadWidgets(activity, action)`.
+///
+/// The shim wraps none of `reloadWidgets` in a try/catch, so a `sendBroadcast`
+/// that throws escapes the `@JavascriptInterface` method and the promise
+/// hangs. Rejecting here diverges in the page's favour, and unlike
+/// `getCalendarEvents` there is nothing to fall through *to* — the shim would
+/// hang. So this one rejects, and says so rather than reproducing a hang.
+fn nativeReloadWidgets(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+    action: jni.jstring,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const action_text = j.stringToUtf8(allocator, action) catch return jni.JNI_FALSE;
+
+    widgets.broadcast(j, allocator, activity, action_text) catch |err| {
+        calendar.rejectOn(allocator, widgets.reject_global, @errorName(err)) catch {};
+        return jni.JNI_TRUE;
+    };
+
+    events.settle(allocator, widgets.resolve_global, widgets.reloaded_result) catch
+        return jni.JNI_FALSE;
+    return jni.JNI_TRUE;
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -1198,7 +1278,7 @@ test "the registered natives name methods the Kotlin actually declares" {
     // A descriptor is checked by the JVM at registration, so a wrong one fails
     // at load rather than at call — but only if the *name* matches something.
     // These two strings are the contract with CraftBridge.kt.
-    try testing.expectEqual(@as(usize, 26), natives.len);
+    try testing.expectEqual(@as(usize, 28), natives.len);
     try testing.expectEqualStrings("nativeGetDeviceInfo", std.mem.span(natives[0].name));
 
     // And the class they bind to is the fixed one, not the templated bridge.

--- a/packages/zig/src/bridge_android_widgets.zig
+++ b/packages/zig/src/bridge_android_widgets.zig
@@ -1,0 +1,332 @@
+//! `updateWidget` and `reloadWidgets` on Android.
+//!
+//! A widget cannot be drawn from here — that is `CraftWidgetProvider`'s job,
+//! in the app's own process, when the system asks. These two actions are the
+//! page's side of that: write what the widget should say into a preferences
+//! file the provider reads, then broadcast so it reads it now rather than at
+//! the next scheduled update.
+//!
+//! ## The broadcast action is passed in rather than built
+//!
+//! The shim broadcasts `"{{PACKAGE_NAME}}.WIDGET_UPDATE"`, and
+//! `CraftWidgetProvider` filters on the same templated constant — both are
+//! compile-time strings in the generated app.
+//!
+//! Zig could build it from `activity.getPackageName()`, and today that is the
+//! same string: the generated `build.gradle.kts` sets
+//! `applicationId = "{{PACKAGE_NAME}}"` with no suffix. But an app author who
+//! adds `applicationIdSuffix = ".debug"` to a build type moves the runtime
+//! package name and leaves the constant where it was — and then Zig would
+//! broadcast an action no filter matches. Nothing throws, nothing logs, and
+//! the widget silently stops updating in debug builds only.
+//!
+//! So the Kotlin passes its own constant across, the way it passes the
+//! database connection. The two cannot disagree if only one of them decides.
+//!
+//! ## `has` and `getString` are not the same question
+//!
+//! `updateWidget` writes a key only when `data.has(name)`, so a field the page
+//! left out keeps whatever the widget last showed rather than being cleared.
+//! `has` is true for an explicit null, and `getString` then returns the four
+//! characters "null" — so `{"title": null}` sets the widget's title to the
+//! word null rather than clearing it. That is the shim's behaviour and it is
+//! reproduced.
+
+const std = @import("std");
+const jni = @import("jni_runtime.zig");
+
+const Jni = jni.Jni;
+const jobject = jni.jobject;
+
+pub const A = struct {
+    pub const update_widget = "updateWidget";
+    pub const reload_widgets = "reloadWidgets";
+};
+
+pub const resolve_global = "_craftWidgetResolve";
+pub const reject_global = "_craftWidgetReject";
+
+/// What each action resolves with, exactly as the shim writes it.
+pub const updated_result = "{\"updated\":true}";
+pub const reloaded_result = "{\"reloaded\":true}";
+
+/// `activity.getSharedPreferences("craft_widget_prefs", MODE_PRIVATE)`.
+const prefs_name = "craft_widget_prefs";
+const mode_private: i32 = 0;
+
+/// The four fields, and the preference key each is written to.
+///
+/// The names differ on the two sides — `title` in, `widget_title` out — which
+/// is the sort of mapping that goes wrong silently, so it lives in one table
+/// rather than in four `if` blocks.
+pub const fields = [_]Field{
+    .{ .name = "title", .key = "widget_title" },
+    .{ .name = "subtitle", .key = "widget_subtitle" },
+    .{ .name = "value", .key = "widget_value" },
+    .{ .name = "icon", .key = "widget_icon" },
+};
+
+pub const Field = struct {
+    name: []const u8,
+    key: [:0]const u8,
+};
+
+/// What to write, one slot per `fields` entry; null means the page did not
+/// mention that field and the widget keeps what it had.
+pub const Update = [fields.len]?[]const u8;
+
+/// Read the declared shape, or null where only `org.json` would.
+///
+/// `getString` coerces a number or a nested object into its string form, and
+/// `Double.toString` and `JSONObject.toString` are not things to reproduce
+/// from memory — those payloads go back to the shim. An explicit null is the
+/// one coercion carried over: `has` says the key is there, and `getString`
+/// returns the four characters "null".
+pub fn parseUpdate(value: std.json.Value) ?Update {
+    const object = switch (value) {
+        .object => |o| o,
+        else => return null,
+    };
+
+    var update: Update = @splat(null);
+    inline for (fields, 0..) |field, i| {
+        if (object.get(field.name)) |found| {
+            update[i] = switch (found) {
+                .string => |text| text,
+                .null => "null",
+                else => return null,
+            };
+        }
+    }
+    return update;
+}
+
+/// Write the mentioned fields and apply.
+pub fn writeUpdate(j: Jni, allocator: std.mem.Allocator, activity: jobject, update: Update) !void {
+    try j.pushLocalFrame(16);
+    defer _ = j.popLocalFrame(null);
+
+    const prefs = try j.callObjectMethodA(
+        activity,
+        try j.methodId(
+            try j.objectClass(activity),
+            "getSharedPreferences",
+            "(Ljava/lang/String;I)Landroid/content/SharedPreferences;",
+        ),
+        &.{ .{ .l = try j.newStringUtf(prefs_name) }, .{ .i = mode_private } },
+    );
+
+    const editor = try j.callObjectMethod(
+        prefs,
+        try j.methodId(
+            try j.objectClass(prefs),
+            "edit",
+            "()Landroid/content/SharedPreferences$Editor;",
+        ),
+    );
+    const editor_cls = try j.objectClass(editor);
+    const put_string = try j.methodId(
+        editor_cls,
+        "putString",
+        "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;",
+    );
+
+    inline for (fields, 0..) |field, i| {
+        if (update[i]) |text| {
+            try j.pushLocalFrame(4);
+            defer _ = j.popLocalFrame(null);
+            _ = try j.callObjectMethodA(editor, put_string, &.{
+                .{ .l = try j.newStringUtf(field.key) },
+                .{ .l = try javaString(j, allocator, text) },
+            });
+        }
+    }
+
+    // `apply`, as the shim does — the write lands on a background thread and
+    // the resolve is a promise about having asked.
+    try j.callVoidMethodA(editor, try j.methodId(editor_cls, "apply", "()V"), &.{});
+}
+
+/// `Intent(action).setPackage(activity.packageName)`, then `sendBroadcast`.
+pub fn broadcast(j: Jni, allocator: std.mem.Allocator, activity: jobject, action: []const u8) !void {
+    try j.pushLocalFrame(16);
+    defer _ = j.popLocalFrame(null);
+
+    const intent_cls = try j.findClass("android/content/Intent");
+    const intent = try j.newObjectA(
+        intent_cls,
+        try j.methodId(intent_cls, "<init>", "(Ljava/lang/String;)V"),
+        &.{.{ .l = try javaString(j, allocator, action) }},
+    );
+
+    const activity_cls = try j.objectClass(activity);
+    const package_name = try j.callObjectMethod(
+        activity,
+        try j.methodId(activity_cls, "getPackageName", "()Ljava/lang/String;"),
+    );
+
+    // `setPackage` keeps the broadcast inside this app. It is a delivery
+    // restriction and not the action, which is why the runtime package name is
+    // safe here and would not be safe as the action itself.
+    _ = try j.callObjectMethodA(
+        intent,
+        try j.methodId(intent_cls, "setPackage", "(Ljava/lang/String;)Landroid/content/Intent;"),
+        &.{.{ .l = package_name }},
+    );
+
+    try j.callVoidMethodA(
+        activity,
+        try j.methodId(activity_cls, "sendBroadcast", "(Landroid/content/Intent;)V"),
+        &.{.{ .l = intent }},
+    );
+}
+
+fn javaString(j: Jni, allocator: std.mem.Allocator, text: []const u8) !jni.jstring {
+    const terminated = try allocator.allocSentinel(u8, text.len, 0);
+    defer allocator.free(terminated);
+    @memcpy(terminated, text);
+    return j.newStringUtf(terminated.ptr);
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+const testing = std.testing;
+
+fn parsed(json: []const u8) !?Update {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+
+    var doc = try std.json.parseFromSlice(std.json.Value, arena.allocator(), json, .{});
+    defer doc.deinit();
+
+    const update = parseUpdate(doc.value) orelse return null;
+
+    // Copied out, because the slices borrow from the arena.
+    var copy: Update = @splat(null);
+    for (update, 0..) |slot, i| {
+        if (slot) |text| copy[i] = try testing.allocator.dupe(u8, text);
+    }
+    return copy;
+}
+
+fn freeUpdate(update: Update) void {
+    for (update) |slot| {
+        if (slot) |text| testing.allocator.free(text);
+    }
+}
+
+test "every field maps to its widget_ key" {
+    const update = (try parsed(
+        \\{"title":"Sales","subtitle":"today","value":"42","icon":"chart"}
+    )).?;
+    defer freeUpdate(update);
+
+    try testing.expectEqualStrings("Sales", update[0].?);
+    try testing.expectEqualStrings("today", update[1].?);
+    try testing.expectEqualStrings("42", update[2].?);
+    try testing.expectEqualStrings("chart", update[3].?);
+
+    // The mapping itself, which is what a rewrite would get subtly wrong.
+    try testing.expectEqualStrings("title", fields[0].name);
+    try testing.expectEqualStrings("widget_title", fields[0].key);
+    try testing.expectEqualStrings("subtitle", fields[1].name);
+    try testing.expectEqualStrings("widget_subtitle", fields[1].key);
+    try testing.expectEqualStrings("value", fields[2].name);
+    try testing.expectEqualStrings("widget_value", fields[2].key);
+    try testing.expectEqualStrings("icon", fields[3].name);
+    try testing.expectEqualStrings("widget_icon", fields[3].key);
+}
+
+test "an unmentioned field is left alone rather than cleared" {
+    // `if (data.has("title"))` — a page updating only the value keeps the
+    // title the widget is already showing.
+    const update = (try parsed(
+        \\{"value":"42"}
+    )).?;
+    defer freeUpdate(update);
+
+    try testing.expect(update[0] == null);
+    try testing.expect(update[1] == null);
+    try testing.expectEqualStrings("42", update[2].?);
+    try testing.expect(update[3] == null);
+}
+
+test "an empty string clears the field, where an absent one does not" {
+    // The distinction the null above exists to preserve: "" is a value the
+    // page chose, and it is written.
+    const update = (try parsed(
+        \\{"title":""}
+    )).?;
+    defer freeUpdate(update);
+
+    try testing.expect(update[0] != null);
+    try testing.expectEqualStrings("", update[0].?);
+}
+
+test "an explicit null sets the field to the word null" {
+    // `has` is true for a JSON null and `getString` returns "null", so this
+    // does not clear the title — it sets it to four characters. Reproduced
+    // because `JSON.stringify({title: null})` is an ordinary thing to send.
+    const update = (try parsed(
+        \\{"title":null}
+    )).?;
+    defer freeUpdate(update);
+
+    try testing.expectEqualStrings("null", update[0].?);
+}
+
+test "a shape only org.json would stringify is handed back" {
+    for ([_][]const u8{
+        \\{"title":1.5}
+        ,
+        \\{"value":42}
+        ,
+        \\{"icon":true}
+        ,
+        \\{"title":{"a":1}}
+        ,
+        \\{"title":["a"]}
+        ,
+        \\[]
+        ,
+        \\"Sales"
+        ,
+    }) |payload| {
+        if (try parsed(payload)) |update| {
+            freeUpdate(update);
+            std.debug.print("payload was served rather than handed back: {s}\n", .{payload});
+            return error.CoercedShapeAccepted;
+        }
+    }
+}
+
+test "an empty object writes nothing and still resolves" {
+    const update = (try parsed("{}")).?;
+    defer freeUpdate(update);
+    for (update) |slot| try testing.expect(slot == null);
+}
+
+test "the results are the shim's constants" {
+    try testing.expectEqualStrings("{\"updated\":true}", updated_result);
+    try testing.expectEqualStrings("{\"reloaded\":true}", reloaded_result);
+
+    inline for (.{ updated_result, reloaded_result }) |result| {
+        var doc = try std.json.parseFromSlice(std.json.Value, testing.allocator, result, .{});
+        defer doc.deinit();
+        try testing.expectEqual(@as(usize, 1), doc.value.object.count());
+    }
+}
+
+test "the preferences file is the one CraftWidgetProvider reads" {
+    try testing.expectEqualStrings("craft_widget_prefs", prefs_name);
+    try testing.expectEqual(@as(i32, 0), mode_private);
+}
+
+test "the actions and globals match the shim exactly" {
+    try testing.expectEqualStrings("updateWidget", A.update_widget);
+    try testing.expectEqualStrings("reloadWidgets", A.reload_widgets);
+    try testing.expectEqualStrings("_craftWidgetResolve", resolve_global);
+    try testing.expectEqualStrings("_craftWidgetReject", reject_global);
+}

--- a/packages/zig/test/android_conformance_test.zig
+++ b/packages/zig/test/android_conformance_test.zig
@@ -51,6 +51,7 @@ const zig_sources = [_][]const u8{
     @embedFile("src/bridge_android_db.zig"),
     @embedFile("src/bridge_android_shareditem.zig"),
     @embedFile("src/bridge_android_contacts.zig"),
+    @embedFile("src/bridge_android_widgets.zig"),
 };
 
 /// How many spec actions Zig does not serve yet.
@@ -70,8 +71,10 @@ const zig_sources = [_][]const u8{
 /// getCalendarEvents, the first to send the page a payload it built rather
 /// than a constant; 84 with createCalendarEvent, the first to read one; 82
 /// with the database pair, the first to borrow a connection the Kotlin owns;
-/// 79 with the shared-item trio; 77 with the contacts pair.
-const max_not_yet_migrated: usize = 77;
+/// 79 with the shared-item trio; 77 with the contacts pair; 75 with the
+/// widget pair, the first to take a constant across from the Kotlin because
+/// deriving it here would be silently wrong under an applicationIdSuffix.
+const max_not_yet_migrated: usize = 75;
 
 /// Every `@JavascriptInterface fun <name>(` in the Kotlin bridge.
 ///


### PR DESCRIPTION
`updateWidget` and `reloadWidgets`. A widget cannot be drawn from here — that is `CraftWidgetProvider`'s job, in the app's own process, when the system asks. These two are the page's side of it: write what the widget should say into a preferences file the provider reads, then broadcast so it reads it now.

## The broadcast action is passed across, not rebuilt

The shim broadcasts `"{{PACKAGE_NAME}}.WIDGET_UPDATE"`, and `CraftWidgetProvider` filters on the same templated constant. Zig could build it from `activity.getPackageName()`, and **today that produces the same string** — the generated `build.gradle.kts` sets `applicationId = "{{PACKAGE_NAME}}"` with no suffix.

But an app author adding `applicationIdSuffix = ".debug"` to a build type moves the runtime package name and leaves the constant where it was. Zig would then broadcast an action no filter matches: nothing throws, nothing logs, and the widget silently stops updating **in debug builds only** — which is where someone would be watching it.

So the Kotlin hands its own constant across, the way it hands the database connection across. Two sides cannot disagree when only one of them decides.

`setPackage` still uses the runtime package name, because that is a delivery restriction rather than the action — exactly why it is safe there and would not be safe as the action itself.

## `has` and `getString` are not the same question

`updateWidget` writes a key only when `data.has(name)`, so a field the page left out keeps whatever the widget last showed rather than being cleared. An empty string is *not* that case — it is a value the page chose, and it is written. Both have tests, because collapsing them is the natural rewrite.

`has` is also true for an explicit null, and `getString` then returns the four characters `"null"` — so `{"title": null}` sets the widget's title to the word *null* rather than clearing it. `JSON.stringify` produces that shape every day, so it is reproduced.

The field-to-key mapping (`title` in, `widget_title` out) is a table rather than four `if` blocks, and the test asserts all four pairs: a mismatch there writes a preference `CraftWidgetProvider` never reads, with nothing at all to notice.

## reloadWidgets rejects where the shim hangs

The shim wraps none of `reloadWidgets` in a `try`/`catch`, so a `sendBroadcast` that throws escapes the `@JavascriptInterface` method and the promise never settles. Unlike `getCalendarEvents` (#157) there is nothing to fall through *to* — the shim would hang — so this one rejects, and the code says why rather than reproducing a hang for symmetry.

## Testing

`zig build test:android` passes with the ratchet at 75. Both mutations fired before this was committed: removing the `"null"` coercion, and changing one preference key, each fail a named test. Both `libcraft.so` targets still build with no NDK.