### PR TITLE
fix(android): text going to the JVM is modified UTF-8, and was not being

### DIFF
--- a/packages/zig/src/android_dispatch.zig
+++ b/packages/zig/src/android_dispatch.zig
@@ -359,14 +359,10 @@ fn nativeGetDeviceInfo(env: jni.JNIEnv, _: jni.jobject, activity: jni.jobject) c
 
     const json = device.render(allocator, info) catch return null;
 
-    // `NewStringUTF` reads to a NUL, and `render` produces a plain slice.
-    // Copied rather than terminated in place because the reply is JSON built
-    // for the page, and giving `render` a sentinel to satisfy would put a
-    // JNI detail into the half of this action that has nothing to do with Java.
-    const owned = allocator.allocSentinel(u8, json.len, 0) catch return null;
-    @memcpy(owned, json);
-
-    return j.newStringUtf(owned.ptr) catch null;
+    // Re-encoded rather than handed over: this JSON carries device text — a
+    // model name, a carrier — and `NewStringUTF` reads modified UTF-8, where a
+    // NUL is two bytes and an astral character is a surrogate pair.
+    return j.newStringUtf8(allocator, json) catch null;
 }
 
 /// `nativeGetMemoryUsage()` — the JVM heap, as JSON.
@@ -383,10 +379,7 @@ fn nativeGetMemoryUsage(env: jni.JNIEnv, _: jni.jobject) callconv(.c) jni.jstrin
     };
 
     const json = system.renderMemory(allocator, usage) catch return null;
-    const owned = allocator.allocSentinel(u8, json.len, 0) catch return null;
-    @memcpy(owned, json);
-
-    return j.newStringUtf(owned.ptr) catch null;
+    return j.newStringUtf8(allocator, json) catch null;
 }
 
 /// `nativeLog(message)` — returns whether Zig wrote the line.
@@ -402,10 +395,8 @@ fn nativeLog(env: jni.JNIEnv, _: jni.jobject, message: jni.jstring) callconv(.c)
     const allocator = arena.allocator();
 
     const text = j.stringToUtf8(allocator, message) catch return jni.JNI_FALSE;
-    const owned = allocator.allocSentinel(u8, text.len, 0) catch return jni.JNI_FALSE;
-    @memcpy(owned, text);
 
-    system.writeLog(j, owned.ptr) catch |err| {
+    system.writeLog(j, allocator, text) catch |err| {
         std.log.warn("craft: log fell through to the shim ({s})", .{@errorName(err)});
         return jni.JNI_FALSE;
     };
@@ -429,9 +420,7 @@ fn nativeClipboardRead(env: jni.JNIEnv, _: jni.jobject, activity: jni.jobject) c
         return null;
     };
 
-    const owned = allocator.allocSentinel(u8, text.len, 0) catch return null;
-    @memcpy(owned, text);
-    return j.newStringUtf(owned.ptr) catch null;
+    return j.newStringUtf8(allocator, text) catch null;
 }
 
 /// `nativeClipboardWrite(activity, text)`.
@@ -448,25 +437,21 @@ fn nativeClipboardWrite(
     const allocator = arena.allocator();
 
     const value = j.stringToUtf8(allocator, text) catch return jni.JNI_FALSE;
-    const owned = allocator.allocSentinel(u8, value.len, 0) catch return jni.JNI_FALSE;
-    @memcpy(owned, value);
 
-    clipboard.write(j, activity, owned.ptr) catch |err| {
+    clipboard.write(j, allocator, activity, value) catch |err| {
         std.log.warn("craft: clipboardWrite fell through to the shim ({s})", .{@errorName(err)});
         return jni.JNI_FALSE;
     };
     return jni.JNI_TRUE;
 }
 
-/// Copy a `jstring` into NUL-terminated arena memory, or null.
+/// A `jstring` as arena-owned UTF-8, or null.
 ///
 /// Every native below needs this and none of them can share the result, since
-/// each arena dies with its call.
-fn ownedUtf8(j: Jni, allocator: std.mem.Allocator, str: jni.jstring) ?[:0]u8 {
-    const text = j.stringToUtf8(allocator, str) catch return null;
-    const owned = allocator.allocSentinel(u8, text.len, 0) catch return null;
-    @memcpy(owned, text);
-    return owned;
+/// each arena dies with its call. A plain slice: the JNI side re-encodes on
+/// the way back out, so nothing here has to carry a terminator.
+fn ownedUtf8(j: Jni, allocator: std.mem.Allocator, str: jni.jstring) ?[]u8 {
+    return j.stringToUtf8(allocator, str) catch null;
 }
 
 fn nativeOpenUrl(
@@ -479,8 +464,10 @@ fn nativeOpenUrl(
     var arena = std.heap.ArenaAllocator.init(backing);
     defer arena.deinit();
 
-    const value = ownedUtf8(j, arena.allocator(), url) orelse return jni.JNI_FALSE;
-    intents.openUrl(j, activity, value.ptr) catch |err| {
+    const allocator = arena.allocator();
+
+    const value = ownedUtf8(j, allocator, url) orelse return jni.JNI_FALSE;
+    intents.openUrl(j, allocator, activity, value) catch |err| {
         // Not a warning. `openURL` answering false is the documented outcome
         // when nothing on the device handles the scheme, and the Kotlin
         // catches exactly this — logging it at warn would put a line in
@@ -506,7 +493,7 @@ fn nativeShare(
     const body = ownedUtf8(j, allocator, text) orelse return jni.JNI_FALSE;
     const subject = ownedUtf8(j, allocator, title) orelse return jni.JNI_FALSE;
 
-    intents.share(j, activity, body.ptr, subject.ptr) catch |err| {
+    intents.share(j, allocator, activity, body, subject) catch |err| {
         std.log.warn("craft: share fell through to the shim ({s})", .{@errorName(err)});
         return jni.JNI_FALSE;
     };
@@ -525,9 +512,7 @@ fn nativeGetNetworkStatus(env: jni.JNIEnv, _: jni.jobject, activity: jni.jobject
     };
 
     const json = network.render(allocator, status) catch return null;
-    const owned = allocator.allocSentinel(u8, json.len, 0) catch return null;
-    @memcpy(owned, json);
-    return j.newStringUtf(owned.ptr) catch null;
+    return j.newStringUtf8(allocator, json) catch null;
 }
 
 fn nativeSecureSet(
@@ -545,7 +530,7 @@ fn nativeSecureSet(
     const k = ownedUtf8(j, allocator, key) orelse return jni.JNI_FALSE;
     const v = ownedUtf8(j, allocator, value) orelse return jni.JNI_FALSE;
 
-    securestore.set(j, prefs, k.ptr, v.ptr) catch |err| {
+    securestore.set(j, allocator, prefs, k, v) catch |err| {
         std.log.warn("craft: secureSet fell through to the shim ({s})", .{@errorName(err)});
         return jni.JNI_FALSE;
     };
@@ -569,15 +554,13 @@ fn nativeSecureGet(
     const allocator = arena.allocator();
 
     const k = ownedUtf8(j, allocator, key) orelse return null;
-    const value = securestore.get(allocator, j, prefs, k.ptr) catch |err| {
+    const value = securestore.get(allocator, j, prefs, k) catch |err| {
         std.log.warn("craft: secureGet fell through to the shim ({s})", .{@errorName(err)});
         return null;
     };
 
     const json = securestore.renderRead(allocator, value) catch return null;
-    const owned = allocator.allocSentinel(u8, json.len, 0) catch return null;
-    @memcpy(owned, json);
-    return j.newStringUtf(owned.ptr) catch null;
+    return j.newStringUtf8(allocator, json) catch null;
 }
 
 fn nativeSecureRemove(
@@ -590,8 +573,10 @@ fn nativeSecureRemove(
     var arena = std.heap.ArenaAllocator.init(backing);
     defer arena.deinit();
 
-    const k = ownedUtf8(j, arena.allocator(), key) orelse return jni.JNI_FALSE;
-    securestore.remove(j, prefs, k.ptr) catch |err| {
+    const allocator = arena.allocator();
+
+    const k = ownedUtf8(j, allocator, key) orelse return jni.JNI_FALSE;
+    securestore.remove(j, allocator, prefs, k) catch |err| {
         std.log.warn("craft: secureRemove fell through to the shim ({s})", .{@errorName(err)});
         return jni.JNI_FALSE;
     };

--- a/packages/zig/src/android_events.zig
+++ b/packages/zig/src/android_events.zig
@@ -99,7 +99,7 @@ fn detach(vm: jni.JavaVM) void {
 /// Silent on every failure, and deliberately: the caller is a device callback
 /// with nowhere to report to, and the alternatives are a log per location fix
 /// or an error nobody reads. `droppedCount` is what a diagnosis reads instead.
-pub fn evaluate(script: [*:0]const u8) void {
+pub fn evaluate(allocator: std.mem.Allocator, script: []const u8) void {
     const vm = java_vm orelse {
         dropped += 1;
         return;
@@ -111,12 +111,12 @@ pub fn evaluate(script: [*:0]const u8) void {
     };
     defer if (attachment.owned) detach(vm);
 
-    deliverThrough(attachment.env, script) catch {
+    deliverThrough(allocator, attachment.env, script) catch {
         dropped += 1;
     };
 }
 
-fn deliverThrough(env: jni.JNIEnv, script: [*:0]const u8) !void {
+fn deliverThrough(allocator: std.mem.Allocator, env: jni.JNIEnv, script: []const u8) !void {
     const j = jni.Jni.init(env);
 
     // A frame around the class, the string and any pending throwable. Without
@@ -127,7 +127,11 @@ fn deliverThrough(env: jni.JNIEnv, script: [*:0]const u8) !void {
     defer _ = j.popLocalFrame(null);
 
     const cls = try j.findClass(holder_class);
-    const text = try j.newStringUtf(script);
+    // Re-encoded rather than handed over: a reply carries page and device
+    // text — a contact's name, an event's title, an error message — and
+    // `NewStringUTF` reads modified UTF-8, in which an emoji is two three-byte
+    // halves rather than one four-byte sequence.
+    const text = try j.newStringUtf8(allocator, script);
 
     const deliver = try j.staticMethodId(cls, "deliver", "(Ljava/lang/String;)V");
     try j.callStaticVoidMethodA(cls, deliver, &.{.{ .l = text }});
@@ -152,9 +156,8 @@ pub fn emitEvent(
     try out.appendSlice(allocator, "', {detail: ");
     try out.appendSlice(allocator, detail_json);
     try out.appendSlice(allocator, "}));");
-    try out.append(allocator, 0);
 
-    evaluate(@ptrCast(out.items.ptr));
+    evaluate(allocator, out.items);
 }
 
 /// `window._craftXResolve && window._craftXResolve(payload)`.
@@ -180,9 +183,8 @@ pub fn settle(
     try out.append(allocator, '(');
     try out.appendSlice(allocator, payload_json);
     try out.appendSlice(allocator, ");");
-    try out.append(allocator, 0);
 
-    evaluate(@ptrCast(out.items.ptr));
+    evaluate(allocator, out.items);
 }
 
 // =============================================================================
@@ -287,7 +289,7 @@ test "a script reaches deliver on an already-attached thread, and nothing is det
     setVm(&ptr);
     defer clearVm();
 
-    evaluate("window.x = 1;");
+    evaluate(testing.allocator, "window.x = 1;");
     try testing.expectEqualStrings("window.x = 1;", delivered());
 
     // The UI thread and every binder thread are already attached, and
@@ -308,7 +310,7 @@ test "a detached thread is attached and then detached again" {
     defer clearVm();
 
     fake_already_attached = false;
-    evaluate("window.y = 2;");
+    evaluate(testing.allocator, "window.y = 2;");
 
     try testing.expectEqualStrings("window.y = 2;", delivered());
     try testing.expectEqual(@as(usize, 1), fake_attach_calls);
@@ -323,7 +325,7 @@ test "every way delivery can fail is counted, not logged and not crashed" {
     // No VM at all — before JNI_OnLoad, or in a build with no runtime linked.
     clearVm();
     resetDroppedForTest();
-    evaluate("window.z = 3;");
+    evaluate(testing.allocator, "window.z = 3;");
     try testing.expectEqual(@as(usize, 1), droppedCount());
 
     // A thread that cannot be attached.
@@ -332,7 +334,7 @@ test "every way delivery can fail is counted, not logged and not crashed" {
     fake_already_attached = false;
     fake_attach_succeeds = false;
     resetDroppedForTest();
-    evaluate("window.z = 3;");
+    evaluate(testing.allocator, "window.z = 3;");
     try testing.expectEqual(@as(usize, 1), droppedCount());
     // Nothing was attached, so nothing may be detached.
     try testing.expectEqual(@as(usize, 0), fake_detach_calls);
@@ -342,7 +344,7 @@ test "every way delivery can fail is counted, not logged and not crashed" {
     fake_attach_succeeds = true;
     fake_find_class_succeeds = false;
     resetDroppedForTest();
-    evaluate("window.z = 3;");
+    evaluate(testing.allocator, "window.z = 3;");
     try testing.expectEqual(@as(usize, 1), droppedCount());
 }
 
@@ -358,7 +360,7 @@ test "an attached thread is detached even when delivery fails" {
 
     fake_already_attached = false;
     fake_find_class_succeeds = false;
-    evaluate("window.z = 3;");
+    evaluate(testing.allocator, "window.z = 3;");
 
     try testing.expectEqual(@as(usize, 1), fake_attach_calls);
     try testing.expectEqual(@as(usize, 1), fake_detach_calls);
@@ -393,6 +395,50 @@ test "settling guards the global that the promise may not have assigned yet" {
     try settle(testing.allocator, "_craftLocationResolve", "{\"latitude\":1}");
     try testing.expectEqualStrings(
         "window._craftLocationResolve && window._craftLocationResolve({\"latitude\":1});",
+        delivered(),
+    );
+}
+
+test "a reply carrying an emoji reaches the JVM as a surrogate pair" {
+    // The end of the wire this whole change is about. A contact called a
+    // smiley arrives here as four UTF-8 bytes, and `NewStringUTF` reads
+    // *modified* UTF-8, where the same character is two three-byte halves.
+    // Handing over the standard form does not produce the string that was
+    // meant.
+    var invoke: jni.JNIInvokeInterface = undefined;
+    fakeVm(&invoke);
+    const ptr: *const jni.JNIInvokeInterface = &invoke;
+    setVm(&ptr);
+    defer clearVm();
+
+    try settle(testing.allocator, "_craftContactsResolve", "[{\"displayName\":\"\u{1F642}\"}]");
+
+    try testing.expectEqualStrings(
+        "window._craftContactsResolve && window._craftContactsResolve([{\"displayName\":\"" ++
+            "\xED\xA0\xBD\xED\xB9\x82" ++ "\"}]);",
+        delivered(),
+    );
+
+    // And the four-byte form is gone rather than merely accompanied.
+    try testing.expect(std.mem.indexOf(u8, delivered(), "\xF0\x9F\x99\x82") == null);
+}
+
+test "a NUL in a reply does not truncate it" {
+    // `NewStringUTF` reads to a terminator, so a payload carrying U+0000 would
+    // end the script early and `evaluateJavascript` would run the fragment
+    // before it. A database column holding a NUL byte is the everyday way to
+    // get one.
+    var invoke: jni.JNIInvokeInterface = undefined;
+    fakeVm(&invoke);
+    const ptr: *const jni.JNIInvokeInterface = &invoke;
+    setVm(&ptr);
+    defer clearVm();
+
+    try settle(testing.allocator, "_craftDbQueryResolve", "[\"a\x00b\"]");
+
+    try testing.expectEqualStrings(
+        "window._craftDbQueryResolve && window._craftDbQueryResolve([\"a" ++
+            "\xC0\x80" ++ "b\"]);",
         delivered(),
     );
 }

--- a/packages/zig/src/bridge_android_calendar.zig
+++ b/packages/zig/src/bridge_android_calendar.zig
@@ -612,15 +612,12 @@ fn putString(
     try j.pushLocalFrame(4);
     defer _ = j.popLocalFrame(null);
 
-    // `NewStringUTF` needs a NUL terminator, and a title is arbitrary page
-    // text — so it is copied rather than pointed at.
-    const terminated = try allocator.allocSentinel(u8, text.len, 0);
-    defer allocator.free(terminated);
-    @memcpy(terminated, text);
-
+    // A title is arbitrary page text, so it goes through the re-encoder: a
+    // NUL would end the string early and an emoji is a surrogate pair to the
+    // JVM.
     try j.callVoidMethodA(values, put, &.{
         .{ .l = try j.newStringUtf(column) },
-        .{ .l = try j.newStringUtf(terminated.ptr) },
+        .{ .l = try j.newStringUtf8(allocator, text) },
     });
 }
 

--- a/packages/zig/src/bridge_android_clipboard.zig
+++ b/packages/zig/src/bridge_android_clipboard.zig
@@ -120,7 +120,7 @@ pub fn read(allocator: std.mem.Allocator, j: Jni, activity: jobject) ![]u8 {
 /// The label is `"Craft"`, and it is user-visible: Android 13 and later show a
 /// preview toast naming it. Changing it because Zig now does the writing would
 /// change what the user sees.
-pub fn write(j: Jni, activity: jobject, text: [*:0]const u8) !void {
+pub fn write(j: Jni, allocator: std.mem.Allocator, activity: jobject, text: []const u8) !void {
     try j.pushLocalFrame(16);
     defer _ = j.popLocalFrame(null);
 
@@ -129,7 +129,7 @@ pub fn write(j: Jni, activity: jobject, text: [*:0]const u8) !void {
 
     const clip_cls = try j.findClass("android/content/ClipData");
     const label = try j.newStringUtf("Craft");
-    const value = try j.newStringUtf(text);
+    const value = try j.newStringUtf8(allocator, text);
 
     // `newPlainText` takes two CharSequences; a String is one, and the JVM
     // accepts the subtype without a cast.

--- a/packages/zig/src/bridge_android_contacts.zig
+++ b/packages/zig/src/bridge_android_contacts.zig
@@ -270,7 +270,7 @@ fn queryUri(
         for (args, 0..) |arg, i| {
             // A null argument is a null element, which is what
             // `arrayOf(contactId)` produces when the id was null.
-            const value: jni.jstring = if (arg) |text| try javaString(j, allocator, text) else null;
+            const value: jni.jstring = if (arg) |text| try j.newStringUtf8(allocator, text) else null;
             try j.setObjectArrayElement(array, i, value);
         }
         break :blk array;
@@ -286,9 +286,9 @@ fn queryUri(
         &.{
             .{ .l = uri },
             .{ .l = null },
-            .{ .l = if (selection) |text| try javaString(j, allocator, text) else null },
+            .{ .l = if (selection) |text| try j.newStringUtf8(allocator, text) else null },
             .{ .l = args_array },
-            .{ .l = if (sort_order) |text| try javaString(j, allocator, text) else null },
+            .{ .l = if (sort_order) |text| try j.newStringUtf8(allocator, text) else null },
         },
     );
 }
@@ -300,7 +300,7 @@ fn columnIndex(j: Jni, allocator: std.mem.Allocator, cursor: jobject, name: []co
     return j.callIntMethodA(
         cursor,
         try j.methodId(try j.objectClass(cursor), "getColumnIndexOrThrow", "(Ljava/lang/String;)I"),
-        &.{.{ .l = try javaString(j, allocator, name) }},
+        &.{.{ .l = try j.newStringUtf8(allocator, name) }},
     );
 }
 
@@ -314,13 +314,6 @@ fn columnText(
     const value = try j.callObjectMethodA(cursor, get_string, &.{.{ .i = index }});
     if (value == null) return null;
     return try j.stringToUtf8(allocator, value);
-}
-
-fn javaString(j: Jni, allocator: std.mem.Allocator, text: []const u8) !jni.jstring {
-    const terminated = try allocator.allocSentinel(u8, text.len, 0);
-    defer allocator.free(terminated);
-    @memcpy(terminated, text);
-    return j.newStringUtf(terminated.ptr);
 }
 
 // =============================================================================
@@ -471,7 +464,7 @@ pub fn addContact(j: Jni, allocator: std.mem.Allocator, activity: jobject, conta
             "(Ljava/lang/String;Ljava/util/ArrayList;)[Landroid/content/ContentProviderResult;",
         ),
         &.{
-            .{ .l = try javaString(j, allocator, contacts_authority) },
+            .{ .l = try j.newStringUtf8(allocator, contacts_authority) },
             .{ .l = ops },
         },
     );
@@ -535,11 +528,11 @@ fn appendDataRow(
             "withValueBackReference",
             "(Ljava/lang/String;I)Landroid/content/ContentProviderOperation$Builder;",
         ),
-        &.{ .{ .l = try javaString(j, allocator, col_raw_contact_id) }, .{ .i = 0 } },
+        &.{ .{ .l = try j.newStringUtf8(allocator, col_raw_contact_id) }, .{ .i = 0 } },
     );
 
     _ = try withValue(j, allocator, builder, col_mimetype, item_type);
-    _ = try withValue(j, allocator, builder, row.value_column, try javaString(j, allocator, row.value));
+    _ = try withValue(j, allocator, builder, row.value_column, try j.newStringUtf8(allocator, row.value));
 
     if (row.type_value) |type_value| {
         const integer_cls = try j.findClass("java/lang/Integer");
@@ -581,7 +574,7 @@ fn withValue(
             "withValue",
             "(Ljava/lang/String;Ljava/lang/Object;)Landroid/content/ContentProviderOperation$Builder;",
         ),
-        &.{ .{ .l = try javaString(j, allocator, column) }, .{ .l = value } },
+        &.{ .{ .l = try j.newStringUtf8(allocator, column) }, .{ .l = value } },
     );
 }
 

--- a/packages/zig/src/bridge_android_db.zig
+++ b/packages/zig/src/bridge_android_db.zig
@@ -136,7 +136,7 @@ pub fn execute(j: Jni, allocator: std.mem.Allocator, db: jobject, sql: []const u
     try j.callVoidMethodA(
         db,
         try j.methodId(db_cls, "execSQL", "(Ljava/lang/String;[Ljava/lang/Object;)V"),
-        &.{ .{ .l = try javaString(j, allocator, sql) }, .{ .l = bind } },
+        &.{ .{ .l = try j.newStringUtf8(allocator, sql) }, .{ .l = bind } },
     );
 }
 
@@ -161,7 +161,7 @@ pub fn query(
             "rawQuery",
             "(Ljava/lang/String;[Ljava/lang/String;)Landroid/database/Cursor;",
         ),
-        &.{ .{ .l = try javaString(j, allocator, sql) }, .{ .l = bind } },
+        &.{ .{ .l = try j.newStringUtf8(allocator, sql) }, .{ .l = bind } },
     );
 
     try out.append(allocator, '[');
@@ -212,20 +212,13 @@ pub fn query(
     }
 }
 
-fn javaString(j: Jni, allocator: std.mem.Allocator, text: []const u8) !jni.jstring {
-    const terminated = try allocator.allocSentinel(u8, text.len, 0);
-    defer allocator.free(terminated);
-    @memcpy(terminated, text);
-    return j.newStringUtf(terminated.ptr);
-}
-
 fn stringArray(j: Jni, allocator: std.mem.Allocator, values: []const []const u8) !jobject {
     const string_cls = try j.findClass("java/lang/String");
     const array = try j.newObjectArray(values.len, string_cls);
     for (values, 0..) |value, i| {
         try j.pushLocalFrame(4);
         defer _ = j.popLocalFrame(null);
-        try j.setObjectArrayElement(array, i, try javaString(j, allocator, value));
+        try j.setObjectArrayElement(array, i, try j.newStringUtf8(allocator, value));
     }
     return array;
 }

--- a/packages/zig/src/bridge_android_intents.zig
+++ b/packages/zig/src/bridge_android_intents.zig
@@ -66,12 +66,12 @@ fn startActivity(j: Jni, activity: jobject, intent: jobject) !void {
 /// produces a Uri with a null scheme for nonsense. The failure that matters
 /// comes later, from `startActivity` finding nothing to handle the result, and
 /// that arrives here as `JavaException` from the `check` after the call.
-pub fn openUrl(j: Jni, activity: jobject, url: [*:0]const u8) !void {
+pub fn openUrl(j: Jni, allocator: std.mem.Allocator, activity: jobject, url: []const u8) !void {
     try j.pushLocalFrame(16);
     defer _ = j.popLocalFrame(null);
 
     const uri_cls = try j.findClass("android/net/Uri");
-    const url_string = try j.newStringUtf(url);
+    const url_string = try j.newStringUtf8(allocator, url);
     const uri = try j.callStaticObjectMethodA(
         uri_cls,
         try j.staticMethodId(uri_cls, "parse", "(Ljava/lang/String;)Landroid/net/Uri;"),
@@ -93,7 +93,7 @@ pub fn openUrl(j: Jni, activity: jobject, url: [*:0]const u8) !void {
 ///
 /// An empty `title` skips `EXTRA_SUBJECT` entirely rather than setting it to
 /// the empty string — see the module comment.
-pub fn share(j: Jni, activity: jobject, text: [*:0]const u8, title: [*:0]const u8) !void {
+pub fn share(j: Jni, allocator: std.mem.Allocator, activity: jobject, text: []const u8, title: []const u8) !void {
     try j.pushLocalFrame(24);
     defer _ = j.popLocalFrame(null);
 
@@ -122,12 +122,12 @@ pub fn share(j: Jni, activity: jobject, text: [*:0]const u8, title: [*:0]const u
     );
 
     const extra_text = try intentConstant(j, intent_cls, "EXTRA_TEXT");
-    const body = try j.newStringUtf(text);
+    const body = try j.newStringUtf8(allocator, text);
     _ = try j.callObjectMethodA(intent, put_extra, &.{ .{ .l = extra_text }, .{ .l = body } });
 
-    if (title[0] != 0) {
+    if (title.len != 0) {
         const extra_subject = try intentConstant(j, intent_cls, "EXTRA_SUBJECT");
-        const subject = try j.newStringUtf(title);
+        const subject = try j.newStringUtf8(allocator, title);
         _ = try j.callObjectMethodA(intent, put_extra, &.{ .{ .l = extra_subject }, .{ .l = subject } });
     }
 
@@ -188,7 +188,12 @@ fn fStaticObjectField(_: jni.JNIEnv, _: jni.jclass, _: jni.jfieldID) callconv(.c
     return obj(2);
 }
 fn fNewStringUTF(_: jni.JNIEnv, text: [*:0]const u8) callconv(.c) jni.jstring {
-    fake_strings.append(testing.allocator, std.mem.span(text)) catch {};
+    // Copied, not borrowed. The caller re-encodes into a scratch buffer and
+    // frees it as soon as the JVM has the string — which is what a real
+    // `NewStringUTF` licenses, and what made this fake read freed memory when
+    // it held the pointer.
+    const copy = testing.allocator.dupe(u8, std.mem.span(text)) catch return obj(3);
+    fake_strings.append(testing.allocator, copy) catch testing.allocator.free(copy);
     return obj(3);
 }
 fn fCallStaticObjectMethodA(_: jni.JNIEnv, _: jni.jclass, id: jni.jmethodID, _: [*]const jni.jvalue) callconv(.c) jobject {
@@ -246,6 +251,7 @@ fn fakeEnv(table: *jni.JNINativeInterface) void {
 fn resetFakes() void {
     fake_calls.clearRetainingCapacity();
     fake_field_names.clearRetainingCapacity();
+    for (fake_strings.items) |text| testing.allocator.free(text);
     fake_strings.clearRetainingCapacity();
     fake_throw_on_start = false;
     fake_pending = null;
@@ -254,6 +260,7 @@ fn resetFakes() void {
 fn freeFakes() void {
     fake_calls.deinit(testing.allocator);
     fake_field_names.deinit(testing.allocator);
+    for (fake_strings.items) |text| testing.allocator.free(text);
     fake_strings.deinit(testing.allocator);
     fake_calls = .empty;
     fake_field_names = .empty;
@@ -280,7 +287,7 @@ test "openURL parses the url and hands the intent to the activity" {
     fakeEnv(&table);
     const ptr: *const jni.JNINativeInterface = &table;
 
-    try openUrl(Jni.init(&ptr), obj(8), "https://example.com/x?y=1");
+    try openUrl(Jni.init(&ptr), testing.allocator, obj(8), "https://example.com/x?y=1");
 
     try testing.expect(sawCall("parse"));
     try testing.expect(sawCall("<init>"));
@@ -303,7 +310,7 @@ test "a URL nothing can open reports the exception rather than success" {
     fake_throw_on_start = true;
     try testing.expectError(
         jni.JniError.JavaException,
-        openUrl(Jni.init(&ptr), obj(8), "definitely-not-a-scheme://x"),
+        openUrl(Jni.init(&ptr), testing.allocator, obj(8), "definitely-not-a-scheme://x"),
     );
 }
 
@@ -314,7 +321,7 @@ test "share sets the text extra and the chooser" {
     fakeEnv(&table);
     const ptr: *const jni.JNINativeInterface = &table;
 
-    try share(Jni.init(&ptr), obj(8), "hello", "Subject");
+    try share(Jni.init(&ptr), testing.allocator, obj(8), "hello", "Subject");
 
     try testing.expect(sawField("ACTION_SEND"));
     try testing.expect(sawField("EXTRA_TEXT"));
@@ -337,7 +344,7 @@ test "an empty title omits the subject rather than setting it empty" {
     fakeEnv(&table);
     const ptr: *const jni.JNINativeInterface = &table;
 
-    try share(Jni.init(&ptr), obj(8), "hello", "");
+    try share(Jni.init(&ptr), testing.allocator, obj(8), "hello", "");
 
     try testing.expect(sawField("EXTRA_TEXT"));
     try testing.expect(!sawField("EXTRA_SUBJECT"));

--- a/packages/zig/src/bridge_android_securestore.zig
+++ b/packages/zig/src/bridge_android_securestore.zig
@@ -78,7 +78,7 @@ fn apply(j: Jni, edit: jobject) !void {
     try j.callVoidMethodA(edit, try j.methodId(edit_cls, "apply", "()V"), &.{});
 }
 
-pub fn set(j: Jni, prefs: jobject, key: [*:0]const u8, value: [*:0]const u8) !void {
+pub fn set(j: Jni, allocator: std.mem.Allocator, prefs: jobject, key: []const u8, value: []const u8) !void {
     try j.pushLocalFrame(16);
     defer _ = j.popLocalFrame(null);
 
@@ -92,12 +92,12 @@ pub fn set(j: Jni, prefs: jobject, key: [*:0]const u8, value: [*:0]const u8) !vo
             "putString",
             "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;",
         ),
-        &.{ .{ .l = try j.newStringUtf(key) }, .{ .l = try j.newStringUtf(value) } },
+        &.{ .{ .l = try j.newStringUtf8(allocator, key) }, .{ .l = try j.newStringUtf8(allocator, value) } },
     );
     try apply(j, edit);
 }
 
-pub fn remove(j: Jni, prefs: jobject, key: [*:0]const u8) !void {
+pub fn remove(j: Jni, allocator: std.mem.Allocator, prefs: jobject, key: []const u8) !void {
     try j.pushLocalFrame(16);
     defer _ = j.popLocalFrame(null);
 
@@ -107,7 +107,7 @@ pub fn remove(j: Jni, prefs: jobject, key: [*:0]const u8) !void {
     _ = try j.callObjectMethodA(
         edit,
         try j.methodId(edit_cls, "remove", "(Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;"),
-        &.{.{ .l = try j.newStringUtf(key) }},
+        &.{.{ .l = try j.newStringUtf8(allocator, key) }},
     );
     try apply(j, edit);
 }
@@ -147,7 +147,7 @@ pub fn renderRead(allocator: std.mem.Allocator, value: ?[]const u8) ![]u8 {
 }
 
 /// `prefs.getString(key, null)`, as an owned optional. Caller frees.
-pub fn get(allocator: std.mem.Allocator, j: Jni, prefs: jobject, key: [*:0]const u8) !?[]u8 {
+pub fn get(allocator: std.mem.Allocator, j: Jni, prefs: jobject, key: []const u8) !?[]u8 {
     try j.pushLocalFrame(16);
     defer _ = j.popLocalFrame(null);
 
@@ -161,7 +161,7 @@ pub fn get(allocator: std.mem.Allocator, j: Jni, prefs: jobject, key: [*:0]const
         ),
         // The default is null, which is what makes "absent" distinguishable
         // from a stored empty string.
-        &.{ .{ .l = try j.newStringUtf(key) }, .{ .l = null } },
+        &.{ .{ .l = try j.newStringUtf8(allocator, key) }, .{ .l = null } },
     );
     if (value == null) return null;
     return try j.stringToUtf8(allocator, value);

--- a/packages/zig/src/bridge_android_shareditem.zig
+++ b/packages/zig/src/bridge_android_shareditem.zig
@@ -106,7 +106,7 @@ fn openPrefs(j: Jni, allocator: std.mem.Allocator, activity: jobject, group: []c
             "getSharedPreferences",
             "(Ljava/lang/String;I)Landroid/content/SharedPreferences;",
         ),
-        &.{ .{ .l = try j.newStringUtf(name.ptr) }, .{ .i = mode_private } },
+        &.{ .{ .l = try j.newStringUtf8(allocator, name) }, .{ .i = mode_private } },
     );
 }
 
@@ -134,8 +134,8 @@ pub fn set(
             "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;",
         ),
         &.{
-            .{ .l = try javaString(j, allocator, key) },
-            .{ .l = try javaString(j, allocator, value) },
+            .{ .l = try j.newStringUtf8(allocator, key) },
+            .{ .l = try j.newStringUtf8(allocator, value) },
         },
     );
 
@@ -167,7 +167,7 @@ pub fn remove(
             "remove",
             "(Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;",
         ),
-        &.{.{ .l = try javaString(j, allocator, key) }},
+        &.{.{ .l = try j.newStringUtf8(allocator, key) }},
     );
     try j.callVoidMethodA(editor, try j.methodId(editor_cls, "apply", "()V"), &.{});
 }
@@ -194,7 +194,7 @@ pub fn get(
             "getString",
             "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;",
         ),
-        &.{ .{ .l = try javaString(j, allocator, key) }, .{ .l = null } },
+        &.{ .{ .l = try j.newStringUtf8(allocator, key) }, .{ .l = null } },
     );
 
     if (value == null) return null;
@@ -210,13 +210,6 @@ fn editorFor(j: Jni, prefs: jobject) !jobject {
             "()Landroid/content/SharedPreferences$Editor;",
         ),
     );
-}
-
-fn javaString(j: Jni, allocator: std.mem.Allocator, text: []const u8) !jni.jstring {
-    const terminated = try allocator.allocSentinel(u8, text.len, 0);
-    defer allocator.free(terminated);
-    @memcpy(terminated, text);
-    return j.newStringUtf(terminated.ptr);
 }
 
 // =============================================================================

--- a/packages/zig/src/bridge_android_system.zig
+++ b/packages/zig/src/bridge_android_system.zig
@@ -135,13 +135,13 @@ pub fn readMemory(j: Jni) !MemoryUsage {
 /// `CraftBridge` is filtering on a string, and changing it because Zig now
 /// emits the line would break a filter that has nothing to do with this
 /// migration.
-pub fn writeLog(j: Jni, message: [*:0]const u8) !void {
+pub fn writeLog(j: Jni, allocator: std.mem.Allocator, message: []const u8) !void {
     try j.pushLocalFrame(8);
     defer _ = j.popLocalFrame(null);
 
     const cls = try j.findClass("android/util/Log");
     const tag = try j.newStringUtf("CraftBridge");
-    const text = try j.newStringUtf(message);
+    const text = try j.newStringUtf8(allocator, message);
 
     // `Log.d` returns the number of bytes written, which the Kotlin ignores
     // and so does this. Discarding it is not the same as calling a void

--- a/packages/zig/src/bridge_android_widgets.zig
+++ b/packages/zig/src/bridge_android_widgets.zig
@@ -137,7 +137,7 @@ pub fn writeUpdate(j: Jni, allocator: std.mem.Allocator, activity: jobject, upda
             defer _ = j.popLocalFrame(null);
             _ = try j.callObjectMethodA(editor, put_string, &.{
                 .{ .l = try j.newStringUtf(field.key) },
-                .{ .l = try javaString(j, allocator, text) },
+                .{ .l = try j.newStringUtf8(allocator, text) },
             });
         }
     }
@@ -156,7 +156,7 @@ pub fn broadcast(j: Jni, allocator: std.mem.Allocator, activity: jobject, action
     const intent = try j.newObjectA(
         intent_cls,
         try j.methodId(intent_cls, "<init>", "(Ljava/lang/String;)V"),
-        &.{.{ .l = try javaString(j, allocator, action) }},
+        &.{.{ .l = try j.newStringUtf8(allocator, action) }},
     );
 
     const activity_cls = try j.objectClass(activity);
@@ -179,13 +179,6 @@ pub fn broadcast(j: Jni, allocator: std.mem.Allocator, activity: jobject, action
         try j.methodId(activity_cls, "sendBroadcast", "(Landroid/content/Intent;)V"),
         &.{.{ .l = intent }},
     );
-}
-
-fn javaString(j: Jni, allocator: std.mem.Allocator, text: []const u8) !jni.jstring {
-    const terminated = try allocator.allocSentinel(u8, text.len, 0);
-    defer allocator.free(terminated);
-    @memcpy(terminated, text);
-    return j.newStringUtf(terminated.ptr);
 }
 
 // =============================================================================

--- a/packages/zig/src/jni_runtime.zig
+++ b/packages/zig/src/jni_runtime.zig
@@ -477,6 +477,9 @@ pub const JniError = error{
     StringUnavailable,
     /// The JVM handed back bytes that are not well-formed modified UTF-8.
     MalformedString,
+    /// Text on its way *to* the JVM that is not well-formed UTF-8. A bug in
+    /// whatever built it, rather than something a device did.
+    InvalidUtf8,
     OutOfMemory,
 };
 
@@ -779,20 +782,36 @@ pub const Jni = struct {
         try self.check();
     }
 
-    /// Make a Java `String` from UTF-8.
+    /// Make a Java `String` from text already in *modified* UTF-8.
     ///
-    /// The JVM wants *modified* UTF-8 here, the same encoding `stringToUtf8`
-    /// decodes on the way back — so a string carrying a NUL or an astral
-    /// character has to be re-encoded rather than handed over. Callers pass
-    /// NUL-terminated literals and ASCII package names today, which are
-    /// identical in both encodings; `encodeModifiedUtf8` is the function to
-    /// add when that stops being true, and this is where it goes.
+    /// Use this only for ASCII the source file holds as a literal — a class
+    /// name, a column name, a preference key. Anything that came from the page
+    /// or from the device goes through `newStringUtf8`, which re-encodes:
+    /// standard UTF-8 and modified UTF-8 agree on ASCII and disagree on a NUL
+    /// and on every character outside the BMP, and `NewStringUTF` given a
+    /// four-byte sequence does not produce the string that was meant.
     pub fn newStringUtf(self: Self, text: [*:0]const u8) JniError!jstring {
         const new: *const fn (JNIEnv, [*:0]const u8) callconv(.c) jstring =
             @ptrCast(self.table().NewStringUTF orelse return JniError.NotFound);
         const str = new(self.env, text);
         try self.check();
         return str orelse JniError.OutOfMemory;
+    }
+
+    /// Make a Java `String` from arbitrary UTF-8.
+    ///
+    /// This is the one to reach for whenever the text is not a literal in this
+    /// repository: a contact's name, a widget's title, a SQL statement, a
+    /// preference value. `NewStringUTF` reads *modified* UTF-8, so an emoji —
+    /// four bytes in the standard encoding, two three-byte halves in Java's —
+    /// has to be re-encoded rather than handed over, and a NUL has to become
+    /// `C0 80` or the string ends early.
+    ///
+    /// The allocation is freed before returning; the `jstring` is the JVM's.
+    pub fn newStringUtf8(self: Self, allocator: std.mem.Allocator, text: []const u8) JniError!jstring {
+        const encoded = try encodeModifiedUtf8(allocator, text);
+        defer allocator.free(encoded);
+        return self.newStringUtf(encoded.ptr);
     }
 
     pub fn callIntMethod(self: Self, obj: jobject, id: jmethodID) JniError!jint {
@@ -964,6 +983,81 @@ fn decodeThreeByte(bytes: *const [3]u8) u32 {
     return (@as(u32, bytes[0] & 0x0F) << 12) |
         (@as(u32, bytes[1] & 0x3F) << 6) |
         @as(u32, bytes[2] & 0x3F);
+}
+
+/// Convert standard UTF-8 to Java's modified UTF-8, NUL-terminated.
+///
+/// The inverse of `decodeModifiedUtf8`, and needed for the same two reasons in
+/// the other direction:
+///
+///  - **U+0000 becomes `C0 80`**, so the result can be NUL-terminated without
+///    the terminator being ambiguous. `NewStringUTF` takes a C string, so a
+///    text carrying a NUL would otherwise be truncated at it silently.
+///  - **A character outside the BMP becomes two three-byte sequences**, one
+///    per UTF-16 surrogate. Handing `NewStringUTF` the standard four-byte form
+///    does not produce the character that was meant — an emoji in a contact's
+///    name is the everyday case.
+///
+/// Invalid UTF-8 is an error rather than something to pass through. Every
+/// caller's text either came from `stringToUtf8`, which produces valid UTF-8,
+/// or was built here — so invalid input means a bug upstream, and quietly
+/// writing malformed bytes into the JVM would hide it.
+pub fn encodeModifiedUtf8(allocator: std.mem.Allocator, input: []const u8) JniError![:0]u8 {
+    // Validated once rather than per sequence, so the loop below can copy the
+    // two- and three-byte forms without re-deciding whether they are legal.
+    // This is also what refuses a lone surrogate: valid CESU-8, and not UTF-8,
+    // so it can only have come from something already confused about which
+    // encoding it holds.
+    if (!std.unicode.utf8ValidateSlice(input)) return JniError.InvalidUtf8;
+
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    var i: usize = 0;
+    while (i < input.len) {
+        const len = std.unicode.utf8ByteSequenceLength(input[i]) catch return JniError.InvalidUtf8;
+        const bytes = input[i .. i + len];
+        i += len;
+
+        switch (len) {
+            1 => {
+                if (bytes[0] == 0) {
+                    // The overlong form Java uses, and standard UTF-8 forbids.
+                    out.appendSlice(allocator, &.{ 0xC0, 0x80 }) catch return JniError.OutOfMemory;
+                } else {
+                    out.append(allocator, bytes[0]) catch return JniError.OutOfMemory;
+                }
+            },
+            2, 3 => out.appendSlice(allocator, bytes) catch return JniError.OutOfMemory,
+            4 => {
+                const codepoint = std.unicode.utf8Decode(bytes) catch return JniError.InvalidUtf8;
+                const offset = codepoint - 0x10000;
+                const high: u32 = 0xD800 + (offset >> 10);
+                const low: u32 = 0xDC00 + (offset & 0x3FF);
+                appendThreeByte(allocator, &out, high) catch return JniError.OutOfMemory;
+                appendThreeByte(allocator, &out, low) catch return JniError.OutOfMemory;
+            },
+            else => return JniError.InvalidUtf8,
+        }
+    }
+
+    return out.toOwnedSliceSentinel(allocator, 0) catch JniError.OutOfMemory;
+}
+
+/// One UTF-16 code unit as the three-byte form, surrogates included.
+///
+/// `std.unicode.utf8Encode` refuses a lone surrogate, which is precisely what
+/// each half of a CESU-8 pair is — so the bytes are written directly.
+fn appendThreeByte(
+    allocator: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+    unit: u32,
+) !void {
+    try out.appendSlice(allocator, &.{
+        @intCast(0xE0 | (unit >> 12)),
+        @intCast(0x80 | ((unit >> 6) & 0x3F)),
+        @intCast(0x80 | (unit & 0x3F)),
+    });
 }
 
 pub fn decodeModifiedUtf8(allocator: std.mem.Allocator, input: []const u8) JniError![]u8 {
@@ -1393,4 +1487,93 @@ test "a field read that throws reports the exception, not the value" {
     fake_pending_exception = @ptrCast(&throwable);
     var obj: u8 = 0;
     try testing.expectError(JniError.JavaException, jni.intField(@ptrCast(&obj), null));
+}
+
+test "encoding is the exact inverse of decoding" {
+    // The property that matters: whatever goes to the JVM comes back the same.
+    // Written as a round trip rather than as byte assertions, because the two
+    // functions are the pair that has to agree — and a shared misunderstanding
+    // of the format would survive either one being tested alone.
+    for ([_][]const u8{
+        "",
+        "plain ascii",
+        "café",
+        "日本語",
+        "🙂",
+        "a🙂b",
+        "🙂🙂",
+        // The astral range's ends.
+        "\u{10000}",
+        "\u{10FFFF}",
+        // BMP characters either side of the surrogate block, which must pass
+        // through as three bytes rather than being re-paired.
+        "\u{D7FF}\u{E000}",
+        "mixed café 🙂 日本語 x",
+    }) |original| {
+        const encoded = try encodeModifiedUtf8(testing.allocator, original);
+        defer testing.allocator.free(encoded);
+
+        const decoded = try decodeModifiedUtf8(testing.allocator, encoded);
+        defer testing.allocator.free(decoded);
+
+        try testing.expectEqualStrings(original, decoded);
+    }
+}
+
+test "a NUL becomes C0 80, so the terminator stays unambiguous" {
+    // `NewStringUTF` takes a C string. A text carrying a NUL encoded as one
+    // byte would be truncated there and nothing would say so.
+    const encoded = try encodeModifiedUtf8(testing.allocator, "a\x00b");
+    defer testing.allocator.free(encoded);
+
+    try testing.expectEqualSlices(u8, &.{ 'a', 0xC0, 0x80, 'b' }, encoded);
+    try testing.expectEqual(@as(usize, 4), encoded.len);
+    try testing.expectEqual(@as(u8, 0), encoded.ptr[encoded.len]);
+
+    // And the NUL survives the round trip rather than ending the string.
+    const decoded = try decodeModifiedUtf8(testing.allocator, encoded);
+    defer testing.allocator.free(decoded);
+    try testing.expectEqualSlices(u8, &.{ 'a', 0, 'b' }, decoded);
+}
+
+test "an astral character becomes two three-byte halves" {
+    // U+1F642, which JSON.stringify hands over as four bytes and Java holds as
+    // a surrogate pair. Asserted as bytes here because this is the case where
+    // handing NewStringUTF the standard form produces the wrong string, and a
+    // round trip through both of our own functions could not tell.
+    const encoded = try encodeModifiedUtf8(testing.allocator, "🙂");
+    defer testing.allocator.free(encoded);
+
+    // U+1F642 - 0x10000 = 0xF642; high = D800 + (F642 >> 10) = D83D,
+    // low = DC00 + (F642 & 3FF) = DE42.
+    try testing.expectEqualSlices(u8, &.{
+        0xED, 0xA0, 0xBD, // D83D
+        0xED, 0xB9, 0x82, // DE42
+    }, encoded);
+    try testing.expectEqual(@as(usize, 6), encoded.len);
+}
+
+test "ASCII and BMP text pass through unchanged" {
+    // The reason `newStringUtf` on a literal is still correct: the two
+    // encodings agree everywhere except a NUL and the astral planes.
+    for ([_][]const u8{ "SELECT 1", "craft_widget_prefs", "café", "日本語" }) |text| {
+        const encoded = try encodeModifiedUtf8(testing.allocator, text);
+        defer testing.allocator.free(encoded);
+        try testing.expectEqualStrings(text, encoded);
+    }
+}
+
+test "invalid UTF-8 is refused rather than written into the JVM" {
+    // Every caller's text either came from `stringToUtf8` or was built here,
+    // so this means a bug upstream — and malformed bytes reaching the JVM
+    // would hide it somewhere much harder to read.
+    for ([_][]const u8{
+        &.{0x80}, // a continuation byte with nothing to continue
+        &.{0xC3}, // a two-byte lead with no second byte
+        &.{ 0xE2, 0x82 }, // a three-byte sequence cut short
+        &.{0xF8}, // a five-byte lead, which UTF-8 does not have
+        &.{ 0xED, 0xA0, 0xBD }, // a lone surrogate, valid CESU-8 and not UTF-8
+    }) |bad| {
+        try testing.expectError(JniError.InvalidUtf8, encodeModifiedUtf8(testing.allocator, bad));
+    }
 }


### PR DESCRIPTION
`NewStringUTF` reads Java's **modified** UTF-8. Every migrated action has been handing it standard UTF-8, which is the same encoding only for ASCII and the BMP.

Two places it is not:

- **U+0000.** Java writes it as `C0 80` precisely so a string can be NUL-terminated. Passed through as a single `0x00` byte it *is* the terminator — the string ends there and nothing says so. A database column holding a NUL is the everyday way to hit this, and it truncates the reply script, so `evaluateJavascript` runs the fragment before it.
- **Anything outside the BMP.** Java holds an emoji as a UTF-16 surrogate pair — two three-byte sequences. Standard UTF-8 has one four-byte sequence. `NewStringUTF` given the four-byte form does not produce the character that was meant.

## The file already knew

`jni_runtime.zig` has had `decodeModifiedUtf8` since the JNI layer landed, and `newStringUtf` carried this comment:

> Callers pass NUL-terminated literals and ASCII package names today, which are identical in both encodings; `encodeModifiedUtf8` is the function to add when that stops being true, and this is where it goes.

That stopped being true several migrations ago. Nobody noticed because the affected text is never a literal in this repository — it is a contact's name, a widget's title, a calendar event, a SQL parameter, a database value.

## What changed

`encodeModifiedUtf8` and `newStringUtf8`, and every site carrying text that did not come from a literal now goes through them:

- **the whole reply channel** — `android_events.evaluate` takes a slice, so every resolve and reject on Android is re-encoded;
- the clipboard, the log, `share`, `openURL`, the secure store;
- the four modules added this week (calendar, database, shared items, contacts, widgets).

`newStringUtf` stays, for literals, and its doc now says that is what it is for.

## Two things found on the way

**`share` read out of bounds on an empty title.** It tested `title[0] != 0` — correct for a `[*:0]const u8`, an out-of-bounds read for a slice. The existing empty-title test caught it the moment the signature changed, which is the argument for that test existing.

**The intents fake stored the pointer `NewStringUTF` was given.** A real `NewStringUTF` copies into the JVM's heap and licenses the caller to free immediately — which is exactly what the re-encoder does. So the fake was reading freed memory as soon as its input stopped being a literal. It copies now.

## What the tests can and cannot show

The round trip through `encodeModifiedUtf8` / `decodeModifiedUtf8` is the property that matters, but **it cannot catch a shared misunderstanding of the format**: our decoder accepts the four-byte form our encoder should never emit, so a round trip would stay green with the surrogate branch removed.

So the surrogate and NUL cases are asserted as bytes as well, and `android_events` asserts them end to end through `settle` — a reply containing 🙂 must arrive as `ED A0 BD ED B9 82` with no four-byte form left in it. Deleting the surrogate branch fails all three tests; that mutation was run before this was committed.

## Testing

`zig build test:android` passes. Both `libcraft.so` targets still build with no NDK.