### PR TITLE
refactor(android): one SharedPreferences helper, after the third caller turned out to be dead

### DIFF
--- a/packages/zig/src/android_prefs.zig
+++ b/packages/zig/src/android_prefs.zig
@@ -1,0 +1,149 @@
+//! `SharedPreferences`, which three actions now reach for.
+//!
+//! The shim opens a preferences file by name in five places — the shared-item
+//! trio, the widget data, the voice actions — and each does the same four
+//! calls: `getSharedPreferences`, `edit`, `putString`/`remove`, `apply`. This
+//! is that sequence once.
+//!
+//! What it deliberately does *not* own is the file's name. Each caller decides
+//! that, because the names are the part that differs and the part that goes
+//! wrong: `craft_shared_<group>` is built from page text, `craft_widget_prefs`
+//! has to match what `CraftWidgetProvider` reads, and `craft_voice_actions` is
+//! read by nothing else at all. A helper that also chose the name would be
+//! four helpers wearing one signature.
+//!
+//! ## `apply`, not `commit`
+//!
+//! Every writer here uses `apply`: it hands the write to a background thread
+//! and returns void, so a failure is not observable at the call site. That is
+//! what the shim does, and it is why every one of these actions resolves with
+//! a promise about having *asked* rather than about having written.
+
+const std = @import("std");
+const jni = @import("jni_runtime.zig");
+
+const Jni = jni.Jni;
+const jobject = jni.jobject;
+
+/// `Context.MODE_PRIVATE`.
+///
+/// A compile-time constant in Java, so the shim's DEX holds the literal 0
+/// rather than a field read — which is why it is a literal here too.
+pub const mode_private: i32 = 0;
+
+/// `activity.getSharedPreferences(name, MODE_PRIVATE)`.
+///
+/// `name` is a slice rather than a literal because one caller builds it from
+/// page text, and it goes through `newStringUtf8` for the same reason.
+pub fn open(j: Jni, allocator: std.mem.Allocator, activity: jobject, name: []const u8) !jobject {
+    return j.callObjectMethodA(
+        activity,
+        try j.methodId(
+            try j.objectClass(activity),
+            "getSharedPreferences",
+            "(Ljava/lang/String;I)Landroid/content/SharedPreferences;",
+        ),
+        &.{ .{ .l = try j.newStringUtf8(allocator, name) }, .{ .i = mode_private } },
+    );
+}
+
+/// `prefs.edit()`.
+pub fn edit(j: Jni, prefs: jobject) !jobject {
+    return j.callObjectMethod(
+        prefs,
+        try j.methodId(
+            try j.objectClass(prefs),
+            "edit",
+            "()Landroid/content/SharedPreferences$Editor;",
+        ),
+    );
+}
+
+/// `editor.putString(key, value)`, whose return value is the editor again.
+pub fn putString(
+    j: Jni,
+    allocator: std.mem.Allocator,
+    editor: jobject,
+    key: []const u8,
+    value: []const u8,
+) !void {
+    try j.pushLocalFrame(4);
+    defer _ = j.popLocalFrame(null);
+
+    _ = try j.callObjectMethodA(
+        editor,
+        try j.methodId(
+            try j.objectClass(editor),
+            "putString",
+            "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;",
+        ),
+        &.{
+            .{ .l = try j.newStringUtf8(allocator, key) },
+            .{ .l = try j.newStringUtf8(allocator, value) },
+        },
+    );
+}
+
+/// `editor.remove(key)`.
+pub fn remove(j: Jni, allocator: std.mem.Allocator, editor: jobject, key: []const u8) !void {
+    try j.pushLocalFrame(4);
+    defer _ = j.popLocalFrame(null);
+
+    _ = try j.callObjectMethodA(
+        editor,
+        try j.methodId(
+            try j.objectClass(editor),
+            "remove",
+            "(Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;",
+        ),
+        &.{.{ .l = try j.newStringUtf8(allocator, key) }},
+    );
+}
+
+/// `editor.apply()`.
+pub fn apply(j: Jni, editor: jobject) !void {
+    try j.callVoidMethodA(
+        editor,
+        try j.methodId(try j.objectClass(editor), "apply", "()V"),
+        &.{},
+    );
+}
+
+/// `prefs.getString(key, null)`, null included.
+///
+/// The caller owns the returned bytes. Null means the key is absent, which is
+/// a different answer from an empty string and is kept as one.
+pub fn getString(
+    j: Jni,
+    allocator: std.mem.Allocator,
+    prefs: jobject,
+    key: []const u8,
+) !?[]u8 {
+    try j.pushLocalFrame(8);
+    defer _ = j.popLocalFrame(null);
+
+    const value = try j.callObjectMethodA(
+        prefs,
+        try j.methodId(
+            try j.objectClass(prefs),
+            "getString",
+            "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;",
+        ),
+        &.{ .{ .l = try j.newStringUtf8(allocator, key) }, .{ .l = null } },
+    );
+
+    if (value == null) return null;
+    return try j.stringToUtf8(allocator, value);
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+const testing = std.testing;
+
+test "MODE_PRIVATE is zero" {
+    // The shim's DEX holds this literal, so a field read here would be the
+    // slower way to get the same number and a chance to get a different one.
+    try testing.expectEqual(@as(i32, 0), mode_private);
+}

--- a/packages/zig/src/bridge_android_shareditem.zig
+++ b/packages/zig/src/bridge_android_shareditem.zig
@@ -25,6 +25,7 @@
 const std = @import("std");
 const jni = @import("jni_runtime.zig");
 const bridge_error = @import("bridge_error.zig");
+const prefs_api = @import("android_prefs.zig");
 
 const Jni = jni.Jni;
 const jobject = jni.jobject;
@@ -37,9 +38,6 @@ pub const A = struct {
 
 pub const resolve_global = "_craftSharedKeychainResolve";
 pub const reject_global = "_craftSharedKeychainReject";
-
-/// `Context.MODE_PRIVATE`, a compile-time constant the shim's DEX holds as 0.
-const mode_private: i32 = 0;
 
 const prefix = "craft_shared";
 
@@ -97,17 +95,7 @@ pub fn valuePayload(allocator: std.mem.Allocator, key: []const u8, value: ?[]con
 fn openPrefs(j: Jni, allocator: std.mem.Allocator, activity: jobject, group: []const u8) !jobject {
     const name = try prefsName(allocator, group);
     defer allocator.free(name);
-
-    const activity_cls = try j.objectClass(activity);
-    return j.callObjectMethodA(
-        activity,
-        try j.methodId(
-            activity_cls,
-            "getSharedPreferences",
-            "(Ljava/lang/String;I)Landroid/content/SharedPreferences;",
-        ),
-        &.{ .{ .l = try j.newStringUtf8(allocator, name) }, .{ .i = mode_private } },
-    );
+    return prefs_api.open(j, allocator, activity, name);
 }
 
 /// `prefs.edit().putString(key, value).apply()`.
@@ -122,27 +110,9 @@ pub fn set(
     try j.pushLocalFrame(16);
     defer _ = j.popLocalFrame(null);
 
-    const prefs = try openPrefs(j, allocator, activity, group);
-    const editor = try editorFor(j, prefs);
-    const editor_cls = try j.objectClass(editor);
-
-    _ = try j.callObjectMethodA(
-        editor,
-        try j.methodId(
-            editor_cls,
-            "putString",
-            "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;",
-        ),
-        &.{
-            .{ .l = try j.newStringUtf8(allocator, key) },
-            .{ .l = try j.newStringUtf8(allocator, value) },
-        },
-    );
-
-    // `apply` rather than `commit`: it writes on a background thread and
-    // returns void, so a failure is not observable here — which is exactly
-    // what the shim's resolve already promises regardless.
-    try j.callVoidMethodA(editor, try j.methodId(editor_cls, "apply", "()V"), &.{});
+    const editor = try prefs_api.edit(j, try openPrefs(j, allocator, activity, group));
+    try prefs_api.putString(j, allocator, editor, key, value);
+    try prefs_api.apply(j, editor);
 }
 
 /// `prefs.edit().remove(key).apply()`.
@@ -156,20 +126,9 @@ pub fn remove(
     try j.pushLocalFrame(16);
     defer _ = j.popLocalFrame(null);
 
-    const prefs = try openPrefs(j, allocator, activity, group);
-    const editor = try editorFor(j, prefs);
-    const editor_cls = try j.objectClass(editor);
-
-    _ = try j.callObjectMethodA(
-        editor,
-        try j.methodId(
-            editor_cls,
-            "remove",
-            "(Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;",
-        ),
-        &.{.{ .l = try j.newStringUtf8(allocator, key) }},
-    );
-    try j.callVoidMethodA(editor, try j.methodId(editor_cls, "apply", "()V"), &.{});
+    const editor = try prefs_api.edit(j, try openPrefs(j, allocator, activity, group));
+    try prefs_api.remove(j, allocator, editor, key);
+    try prefs_api.apply(j, editor);
 }
 
 /// `prefs.getString(key, null)`, null included.
@@ -187,29 +146,7 @@ pub fn get(
     defer _ = j.popLocalFrame(null);
 
     const prefs = try openPrefs(j, allocator, activity, group);
-    const value = try j.callObjectMethodA(
-        prefs,
-        try j.methodId(
-            try j.objectClass(prefs),
-            "getString",
-            "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;",
-        ),
-        &.{ .{ .l = try j.newStringUtf8(allocator, key) }, .{ .l = null } },
-    );
-
-    if (value == null) return null;
-    return try j.stringToUtf8(allocator, value);
-}
-
-fn editorFor(j: Jni, prefs: jobject) !jobject {
-    return j.callObjectMethod(
-        prefs,
-        try j.methodId(
-            try j.objectClass(prefs),
-            "edit",
-            "()Landroid/content/SharedPreferences$Editor;",
-        ),
-    );
+    return prefs_api.getString(j, allocator, prefs, key);
 }
 
 // =============================================================================
@@ -285,11 +222,6 @@ test "a key or value carrying a quote survives as JSON" {
     defer parsed_success.deinit();
     try testing.expectEqualStrings("it's", parsed_success.value.object.get("key").?.string);
     try testing.expect(parsed_success.value.object.get("success").?.bool);
-}
-
-test "MODE_PRIVATE is zero" {
-    // A compile-time constant in Java, so the shim's DEX holds the literal.
-    try testing.expectEqual(@as(i32, 0), mode_private);
 }
 
 test "the actions and globals match the shim exactly" {

--- a/packages/zig/src/bridge_android_widgets.zig
+++ b/packages/zig/src/bridge_android_widgets.zig
@@ -34,6 +34,7 @@
 
 const std = @import("std");
 const jni = @import("jni_runtime.zig");
+const prefs_api = @import("android_prefs.zig");
 
 const Jni = jni.Jni;
 const jobject = jni.jobject;
@@ -50,9 +51,9 @@ pub const reject_global = "_craftWidgetReject";
 pub const updated_result = "{\"updated\":true}";
 pub const reloaded_result = "{\"reloaded\":true}";
 
-/// `activity.getSharedPreferences("craft_widget_prefs", MODE_PRIVATE)`.
+/// `activity.getSharedPreferences("craft_widget_prefs", MODE_PRIVATE)` — the
+/// file `CraftWidgetProvider` reads back.
 const prefs_name = "craft_widget_prefs";
-const mode_private: i32 = 0;
 
 /// The four fields, and the preference key each is written to.
 ///
@@ -106,45 +107,16 @@ pub fn writeUpdate(j: Jni, allocator: std.mem.Allocator, activity: jobject, upda
     try j.pushLocalFrame(16);
     defer _ = j.popLocalFrame(null);
 
-    const prefs = try j.callObjectMethodA(
-        activity,
-        try j.methodId(
-            try j.objectClass(activity),
-            "getSharedPreferences",
-            "(Ljava/lang/String;I)Landroid/content/SharedPreferences;",
-        ),
-        &.{ .{ .l = try j.newStringUtf(prefs_name) }, .{ .i = mode_private } },
-    );
-
-    const editor = try j.callObjectMethod(
-        prefs,
-        try j.methodId(
-            try j.objectClass(prefs),
-            "edit",
-            "()Landroid/content/SharedPreferences$Editor;",
-        ),
-    );
-    const editor_cls = try j.objectClass(editor);
-    const put_string = try j.methodId(
-        editor_cls,
-        "putString",
-        "(Ljava/lang/String;Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;",
-    );
+    const prefs = try prefs_api.open(j, allocator, activity, prefs_name);
+    const editor = try prefs_api.edit(j, prefs);
 
     inline for (fields, 0..) |field, i| {
-        if (update[i]) |text| {
-            try j.pushLocalFrame(4);
-            defer _ = j.popLocalFrame(null);
-            _ = try j.callObjectMethodA(editor, put_string, &.{
-                .{ .l = try j.newStringUtf(field.key) },
-                .{ .l = try j.newStringUtf8(allocator, text) },
-            });
-        }
+        if (update[i]) |text| try prefs_api.putString(j, allocator, editor, field.key, text);
     }
 
     // `apply`, as the shim does — the write lands on a background thread and
     // the resolve is a promise about having asked.
-    try j.callVoidMethodA(editor, try j.methodId(editor_cls, "apply", "()V"), &.{});
+    try prefs_api.apply(j, editor);
 }
 
 /// `Intent(action).setPackage(activity.packageName)`, then `sendBroadcast`.
@@ -314,7 +286,6 @@ test "the results are the shim's constants" {
 
 test "the preferences file is the one CraftWidgetProvider reads" {
     try testing.expectEqualStrings("craft_widget_prefs", prefs_name);
-    try testing.expectEqual(@as(i32, 0), mode_private);
 }
 
 test "the actions and globals match the shim exactly" {


### PR DESCRIPTION
The shim opens a preferences file in five places, and each does the same four calls: `getSharedPreferences`, `edit`, `putString`/`remove`, `apply`. Two of those are ported and had a copy each. This is the sequence once.

## What the helper does not own

The file's **name**. That is the part that differs and the part that goes wrong:

- `craft_shared_<group>` is built from page text, so it needs its own tested naming function;
- `craft_widget_prefs` has to match what `CraftWidgetProvider` reads back;
- `craft_voice_actions` is read by nothing at all.

A helper that also chose the name would be four helpers wearing one signature.

## Why it lands with two callers instead of three

The third was going to be `registerVoiceAction`. Writing the port turned up three separate dead links:

1. the row it writes (`craft_voice_actions`) is written in two places and **read in zero** — `handleVoiceAction` reads the incoming intent's own action and data and never opens the file;
2. the reply goes to `window._craftVoiceResolve`, which appears three times in this repository and **all three are reads inside the `&&` guard** — the injected bridge has no `voice` namespace to assign it;
3. neither method is in `craft.d.ts`, in the injected JS, or on iOS.

Migrating that would have moved the silence rather than removed it — the same reason `setBadge` is not migrated (#148). Filed as #169 with the evidence; the port is deleted rather than shipped.

The `craftVoiceAction` **event** is real and untouched — it is dispatched from the intent, declared in `craft.d.ts`, and cross-platform. That is the type #135 restored after I deleted it on an iOS-only scan, which is why I checked the whole repository this time before concluding anything was dead.

## Testing

`zig build test:android` passes. No behaviour change: the shared-item and widget tests are the same tests, and the `MODE_PRIVATE` assertion moved to the helper rather than being duplicated in both.