### PR TITLE
feat(android): a main-thread trampoline, and the orientation pair to prove it — ratchet 72 → 70

### DIFF
--- a/packages/android/templates/CraftBridge.kt.template
+++ b/packages/android/templates/CraftBridge.kt.template
@@ -2592,6 +2592,10 @@ class CraftBridge(
 
     @JavascriptInterface
     fun lockOrientation(orientation: String): Boolean {
+        // Zig queues the same work on the same looper, through a Runnable
+        // this file's holder owns — see CraftNative.runOnMain.
+        if (CraftNative.lockOrientation(activity, orientation)) return true
+
         activity.runOnUiThread {
             activity.requestedOrientation = when (orientation) {
                 "portrait" -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
@@ -2606,6 +2610,8 @@ class CraftBridge(
 
     @JavascriptInterface
     fun unlockOrientation(): Boolean {
+        if (CraftNative.unlockOrientation(activity)) return true
+
         activity.runOnUiThread {
             activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
         }

--- a/packages/android/templates/CraftNative.kt.template
+++ b/packages/android/templates/CraftNative.kt.template
@@ -1,6 +1,8 @@
 package com.craft.runtime
 
 import android.app.Activity
+import android.os.Handler
+import android.os.Looper
 import android.content.SharedPreferences
 import android.database.sqlite.SQLiteDatabase
 import org.json.JSONObject
@@ -123,6 +125,9 @@ object CraftNative {
     private external fun nativeSetShortcuts(activity: Activity, shortcutsJson: String): Boolean
     private external fun nativeClearShortcuts(activity: Activity): Boolean
     private external fun nativeScheduleNotification(activity: Activity, notificationJson: String): Boolean
+    private external fun nativeRunTask(activity: Activity, token: Long)
+    private external fun nativeLockOrientation(activity: Activity, orientation: String): Boolean
+    private external fun nativeUnlockOrientation(activity: Activity): Boolean
 
     /**
      * `getDeviceInfo`, or null to use the Kotlin implementation.
@@ -551,6 +556,65 @@ object CraftNative {
         if (!isAvailable) return false
         return try {
             nativeScheduleNotification(activity, notificationJson)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    /**
+     * How Zig reaches the main looper.
+     *
+     * `Window.addFlags` and `setRequestedOrientation` have to run there, and
+     * the shim wraps each in `runOnUiThread { ... }` — which takes a
+     * `Runnable`, a Java object implementing a Java interface. JNI cannot make
+     * one: `RegisterNatives` binds methods onto a class that already exists in
+     * the APK, so a native can be *called* from Java but cannot be handed to
+     * Java as an object.
+     *
+     * So the `Runnable` is here, the work is there, and a token says which
+     * work. The Activity goes across with it rather than being held by Zig
+     * over the hop, which is what would need a global reference and a matching
+     * release.
+     *
+     * Called from Zig, never from the Kotlin below.
+     */
+    @JvmStatic
+    fun runOnMain(activity: Activity, token: Long, delayMs: Long) {
+        val block = Runnable {
+            try {
+                nativeRunTask(activity, token)
+            } catch (e: UnsatisfiedLinkError) {
+                // The library went away between the post and the looper. There
+                // is nothing to answer to here and nothing to retry.
+            }
+        }
+        if (delayMs > 0) {
+            Handler(Looper.getMainLooper()).postDelayed(block, delayMs)
+        } else {
+            activity.runOnUiThread(block)
+        }
+    }
+
+    /**
+     * Returns whether Zig queued the work, not whether the device has turned.
+     *
+     * The shim returns true after `runOnUiThread` for the same reason: the
+     * JavaBridge thread is never the main thread, so the block always runs
+     * later than the answer.
+     */
+    fun lockOrientation(activity: Activity, orientation: String): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeLockOrientation(activity, orientation)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    fun unlockOrientation(activity: Activity): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeUnlockOrientation(activity)
         } catch (e: UnsatisfiedLinkError) {
             false
         }

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -473,6 +473,9 @@ pub fn build(b: *std.Build) void {
     android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_shortcuts.zig", .{
         .root_source_file = b.path("src/bridge_android_shortcuts.zig"),
     });
+    android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_orientation.zig", .{
+        .root_source_file = b.path("src/bridge_android_orientation.zig"),
+    });
     const run_android_conformance_tests = b.addRunArtifact(android_conformance_tests);
 
     // The page surface, across both bridges. Not folded into the iOS

--- a/packages/zig/src/android_dispatch.zig
+++ b/packages/zig/src/android_dispatch.zig
@@ -52,6 +52,8 @@ const shareditem = @import("bridge_android_shareditem.zig");
 const contacts = @import("bridge_android_contacts.zig");
 const widgets = @import("bridge_android_widgets.zig");
 const shortcuts = @import("bridge_android_shortcuts.zig");
+const orientation = @import("bridge_android_orientation.zig");
+const main_thread = @import("android_main_thread.zig");
 
 const Jni = jni.Jni;
 
@@ -322,6 +324,23 @@ const natives = [_]jni.JNINativeMethod{
         .name = "nativeScheduleNotification",
         .signature = "(Landroid/app/Activity;Ljava/lang/String;)Z",
         .fnPtr = @ptrCast(&nativeScheduleNotification),
+    },
+    // Not an action: the other end of `CraftNative.runOnMain`, which is how
+    // anything here reaches the main looper at all.
+    .{
+        .name = "nativeRunTask",
+        .signature = "(Landroid/app/Activity;J)V",
+        .fnPtr = @ptrCast(&nativeRunTask),
+    },
+    .{
+        .name = "nativeLockOrientation",
+        .signature = "(Landroid/app/Activity;Ljava/lang/String;)Z",
+        .fnPtr = @ptrCast(&nativeLockOrientation),
+    },
+    .{
+        .name = "nativeUnlockOrientation",
+        .signature = "(Landroid/app/Activity;)Z",
+        .fnPtr = @ptrCast(&nativeUnlockOrientation),
     },
 };
 
@@ -1301,6 +1320,62 @@ fn nativeScheduleNotification(
     return jni.JNI_TRUE;
 }
 
+/// `nativeRunTask(activity, token)` — the main thread, arrived at.
+///
+/// The only native here that is not an action. `CraftNative.runOnMain` posted
+/// a `Runnable` that calls this, so by the time it runs the looper is ours and
+/// the Activity came back with it rather than being held across the hop.
+///
+/// Void and silent: there is nothing to answer to. A token that no longer
+/// names a task is dropped by `main_thread.run`, which is the case a
+/// `Runnable` outliving whatever queued it would otherwise crash on.
+fn nativeRunTask(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+    token: jni.jlong,
+) callconv(.c) void {
+    main_thread.run(Jni.init(env), activity, @bitCast(token));
+}
+
+/// `nativeLockOrientation(activity, orientation)`.
+///
+/// True means the work is queued, not that the device has turned — which is
+/// what the shim's `return true` after `runOnUiThread` means too.
+fn nativeLockOrientation(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+    name: jni.jstring,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+
+    const text = j.stringToUtf8(arena.allocator(), name) catch return jni.JNI_FALSE;
+
+    orientation.apply(j, activity, orientation.modeFor(text)) catch |err| {
+        std.log.warn("craft: lockOrientation fell through to the shim ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+    return jni.JNI_TRUE;
+}
+
+/// `nativeUnlockOrientation(activity)`.
+fn nativeUnlockOrientation(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+
+    orientation.apply(j, activity, .unspecified) catch |err| {
+        std.log.warn("craft: unlockOrientation fell through to the shim ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+    return jni.JNI_TRUE;
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -1412,7 +1487,7 @@ test "the registered natives name methods the Kotlin actually declares" {
     // A descriptor is checked by the JVM at registration, so a wrong one fails
     // at load rather than at call — but only if the *name* matches something.
     // These two strings are the contract with CraftBridge.kt.
-    try testing.expectEqual(@as(usize, 31), natives.len);
+    try testing.expectEqual(@as(usize, 34), natives.len);
     try testing.expectEqualStrings("nativeGetDeviceInfo", std.mem.span(natives[0].name));
 
     // And the class they bind to is the fixed one, not the templated bridge.

--- a/packages/zig/src/android_main_thread.zig
+++ b/packages/zig/src/android_main_thread.zig
@@ -1,0 +1,265 @@
+//! Getting onto the main thread, which Zig cannot do by itself.
+//!
+//! Several Android calls must run on the main looper — `Window.addFlags`
+//! touches the view hierarchy, `setRequestedOrientation` goes through the
+//! Activity — and the shim wraps each in `activity.runOnUiThread { ... }`.
+//! That takes a `Runnable`, a Java object implementing a Java interface, and
+//! JNI cannot make one: `RegisterNatives` binds methods on a class that
+//! already exists in the APK, so a native can *be* called from Java but cannot
+//! be handed to Java as an object.
+//!
+//! This is the same wall `android_events.zig` gets around for replies, and the
+//! same answer: Kotlin owns the object, Zig owns the work. `CraftNative.runOnMain`
+//! posts a `Runnable` that calls straight back into `nativeRunTask`, carrying a
+//! token — and the Activity, so nothing here has to hold a reference across
+//! the hop.
+//!
+//! ## Why a token and not a pointer
+//!
+//! The obvious shape is to pass Zig a pointer and cast it back. It is also the
+//! shape where a stale `Runnable` — one the looper still holds after whatever
+//! queued it is gone — reads freed memory and the crash lands somewhere else
+//! entirely.
+//!
+//! A token is checkable. Each slot carries a generation that increments when
+//! the slot is reused, so a token from a previous occupant does not match and
+//! the task is dropped rather than run. `nativeRunTask` cannot be made to run
+//! the wrong task by anything the JVM does with timing.
+//!
+//! ## The table is fixed and small
+//!
+//! Thirty-two slots, no allocator. These tasks live between a page's call and
+//! the next turn of the looper — microseconds — so the table being full means
+//! something is wrong rather than busy, and the caller falls through to the
+//! shim rather than growing.
+
+const std = @import("std");
+const jni = @import("jni_runtime.zig");
+
+const Jni = jni.Jni;
+const jobject = jni.jobject;
+
+/// The work to do once the main thread is reached.
+///
+/// A tagged union rather than a function pointer and an opaque payload: every
+/// variant is small, the set is closed, and a reader can see what can be
+/// queued without following an indirection. A variant needing heap memory
+/// would carry an owned slice and gain a `free` arm below.
+pub const Task = union(enum) {
+    /// `activity.setRequestedOrientation(mode)`.
+    set_requested_orientation: i32,
+};
+
+const slot_count = 32;
+
+const Slot = struct {
+    task: Task = undefined,
+    generation: u32 = 0,
+    occupied: bool = false,
+};
+
+var slots: [slot_count]Slot = @splat(.{});
+
+/// The table is written from the JavaBridge thread and read from the main
+/// looper, which are different threads by construction — that is the entire
+/// point of the hop.
+///
+/// A spin lock rather than a mutex, because `std.Io.Mutex` on this toolchain
+/// wants an `Io` and a JNI native has nowhere to get one. The critical
+/// sections are a handful of instructions over a 32-entry array, and at most
+/// two threads ever contend, so spinning is the cheap answer rather than the
+/// lazy one.
+var table_locked: std.atomic.Value(bool) = .init(false);
+
+fn lockTable() void {
+    while (table_locked.cmpxchgWeak(false, true, .acquire, .monotonic) != null) {
+        std.atomic.spinLoopHint();
+    }
+}
+
+fn unlockTable() void {
+    table_locked.store(false, .release);
+}
+
+pub const PostError = error{TableFull};
+
+/// Claim a slot and return its token, or fail if none is free.
+///
+/// Split from `post` so the reservation is testable without a JVM: this is
+/// where every property worth checking lives.
+pub fn reserve(task: Task) PostError!u64 {
+    lockTable();
+    defer unlockTable();
+
+    for (&slots, 0..) |*slot, index| {
+        if (slot.occupied) continue;
+        slot.task = task;
+        slot.occupied = true;
+        return (@as(u64, @intCast(index)) << 32) | slot.generation;
+    }
+    return error.TableFull;
+}
+
+/// Take the task a token names, or null if the token is stale or unknown.
+///
+/// Taking rather than reading: a slot is released here, so a `Runnable` that
+/// somehow fires twice finds nothing the second time.
+pub fn claim(token: u64) ?Task {
+    const index: usize = @intCast(token >> 32);
+    const generation: u32 = @truncate(token);
+
+    if (index >= slot_count) return null;
+
+    lockTable();
+    defer unlockTable();
+
+    const slot = &slots[index];
+    if (!slot.occupied or slot.generation != generation) return null;
+
+    const task = slot.task;
+    slot.occupied = false;
+    // Wrapping, because the only thing that matters is that a token minted
+    // before this point stops matching. Sixty-four thousand reuses of one slot
+    // between a post and its Runnable is not a thing that happens.
+    slot.generation +%= 1;
+    return task;
+}
+
+/// Give a reserved slot back, for a caller that could not schedule it.
+///
+/// Without this a failed `runOnMain` would leak the slot until the table
+/// filled, and the failure would show up as an unrelated action falling
+/// through much later.
+pub fn release(token: u64) void {
+    _ = claim(token);
+}
+
+/// `CraftNative.runOnMain(activity, token, delayMs)`.
+///
+/// `delay_ms` above zero posts through a `Handler`; zero goes through
+/// `runOnUiThread`, which runs inline when the caller is already on the main
+/// thread. The shim's `runOnUiThread` has that same property, so an action
+/// this serves keeps the shim's ordering.
+pub fn post(j: Jni, activity: jobject, task: Task, delay_ms: i64) !void {
+    const token = try reserve(task);
+    errdefer release(token);
+
+    const holder = try j.findClass(holder_class);
+    try j.callStaticVoidMethodA(
+        holder,
+        try j.staticMethodId(holder, "runOnMain", "(Landroid/app/Activity;JJ)V"),
+        &.{ .{ .l = activity }, .{ .j = @bitCast(token) }, .{ .j = delay_ms } },
+    );
+}
+
+/// The fixed-package holder the natives are registered on.
+const holder_class = "com/craft/runtime/CraftNative";
+
+/// Run the task a token names. Called from `nativeRunTask`, on the main thread.
+pub fn run(j: Jni, activity: jobject, token: u64) void {
+    const task = claim(token) orelse return;
+    switch (task) {
+        .set_requested_orientation => |mode| setRequestedOrientation(j, activity, mode) catch {},
+    }
+}
+
+fn setRequestedOrientation(j: Jni, activity: jobject, mode: i32) !void {
+    try j.pushLocalFrame(4);
+    defer _ = j.popLocalFrame(null);
+
+    try j.callVoidMethodA(
+        activity,
+        try j.methodId(try j.objectClass(activity), "setRequestedOrientation", "(I)V"),
+        &.{.{ .i = mode }},
+    );
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+const testing = std.testing;
+
+fn clearTable() void {
+    lockTable();
+    defer unlockTable();
+    for (&slots) |*slot| slot.occupied = false;
+}
+
+test "a reserved task comes back exactly once" {
+    clearTable();
+
+    const token = try reserve(.{ .set_requested_orientation = 1 });
+    const claimed = claim(token).?;
+    try testing.expectEqual(@as(i32, 1), claimed.set_requested_orientation);
+
+    // The second claim is the one that matters: a Runnable the looper somehow
+    // ran twice must not set the orientation twice.
+    try testing.expect(claim(token) == null);
+}
+
+test "a stale token does not run the slot's new occupant" {
+    clearTable();
+
+    const first = try reserve(.{ .set_requested_orientation = 1 });
+    _ = claim(first);
+
+    // The same slot, a new task. Without the generation, `first` would still
+    // index it and would run this.
+    const second = try reserve(.{ .set_requested_orientation = 8 });
+    try testing.expect(claim(first) == null);
+
+    const claimed = claim(second).?;
+    try testing.expectEqual(@as(i32, 8), claimed.set_requested_orientation);
+}
+
+test "an unknown token is dropped rather than indexing out of bounds" {
+    clearTable();
+
+    // A token naming a slot past the end, which is what a corrupted or
+    // fabricated long would look like arriving from Java.
+    try testing.expect(claim(0xFFFF_FFFF_0000_0000) == null);
+    try testing.expect(claim(std.math.maxInt(u64)) == null);
+    // And one naming a real slot that holds nothing.
+    try testing.expect(claim(0) == null);
+}
+
+test "the table fills and says so rather than overwriting" {
+    clearTable();
+
+    var tokens: [slot_count]u64 = undefined;
+    for (&tokens) |*token| token.* = try reserve(.{ .set_requested_orientation = 0 });
+
+    try testing.expectError(error.TableFull, reserve(.{ .set_requested_orientation = 0 }));
+
+    // Every token is distinct — the failure above is a full table and not a
+    // slot handed out twice.
+    for (tokens, 0..) |a, i| {
+        for (tokens[i + 1 ..]) |b| try testing.expect(a != b);
+    }
+
+    // And releasing one makes room again.
+    release(tokens[3]);
+    _ = try reserve(.{ .set_requested_orientation = 0 });
+}
+
+test "releasing a token a caller could not schedule frees its slot" {
+    clearTable();
+
+    const token = try reserve(.{ .set_requested_orientation = 1 });
+    release(token);
+    try testing.expect(claim(token) == null);
+
+    // The slot is genuinely free rather than merely unreadable.
+    var count: usize = 0;
+    while (count < slot_count) : (count += 1) {
+        _ = try reserve(.{ .set_requested_orientation = 0 });
+    }
+}
+
+test "the holder class is the fixed one, not the templated bridge" {
+    // A `{{` here would mean the library had been made app-specific, which is
+    // the thing RegisterNatives exists to avoid.
+    try testing.expectEqualStrings("com/craft/runtime/CraftNative", holder_class);
+    try testing.expect(std.mem.indexOf(u8, holder_class, "{") == null);
+}

--- a/packages/zig/src/bridge_android_orientation.zig
+++ b/packages/zig/src/bridge_android_orientation.zig
@@ -1,0 +1,149 @@
+//! `lockOrientation` and `unlockOrientation` on Android.
+//!
+//! The first pair to go through `android_main_thread`: both do their whole job
+//! on the main looper and neither touches state the shim keeps, which is what
+//! makes them the right thing to prove the trampoline with.
+//!
+//! ## They answer by returning, not through the reply channel
+//!
+//! Both are `Boolean` methods that `return true` after *queueing* the work.
+//! So the page's promise resolves before the orientation has changed, on the
+//! shim as much as here — `runOnUiThread` returns immediately when the caller
+//! is not the main thread, which the JavaBridge thread never is. Nothing here
+//! makes that worse and nothing here fixes it.
+//!
+//! ## The constants are read, not written down
+//!
+//! `ActivityInfo.SCREEN_ORIENTATION_*` are compile-time constants, so the
+//! shim's DEX holds the numbers and literals here would be faithful. They are
+//! read anyway, for the reason `addContact` reads its MIME types: a wrong
+//! column name throws, and a wrong orientation number silently locks the
+//! device the wrong way round.
+//!
+//! ## Two names mean the same thing, and an unknown name unlocks
+//!
+//! `landscape` and `landscapeLeft` both map to `SCREEN_ORIENTATION_LANDSCAPE`
+//! — so a page asking for the left-hand landscape and a page asking for either
+//! landscape get the same lock. `landscapeRight` is the only one that reaches
+//! `REVERSE_LANDSCAPE`.
+//!
+//! And the `else` branch is `SCREEN_ORIENTATION_UNSPECIFIED`, which is what
+//! `unlockOrientation` sets. So `craft.lockOrientation("portrat")` does not
+//! fail — it silently *unlocks*, and still returns true.
+
+const std = @import("std");
+const jni = @import("jni_runtime.zig");
+const main_thread = @import("android_main_thread.zig");
+
+const Jni = jni.Jni;
+const jobject = jni.jobject;
+
+pub const A = struct {
+    pub const lock_orientation = "lockOrientation";
+    pub const unlock_orientation = "unlockOrientation";
+};
+
+/// Which `ActivityInfo` constant a page's string names.
+pub const Mode = enum {
+    unspecified,
+    landscape,
+    portrait,
+    reverse_landscape,
+
+    /// The field on `android.content.pm.ActivityInfo`.
+    pub fn field(self: Mode) [:0]const u8 {
+        return switch (self) {
+            .unspecified => "SCREEN_ORIENTATION_UNSPECIFIED",
+            .landscape => "SCREEN_ORIENTATION_LANDSCAPE",
+            .portrait => "SCREEN_ORIENTATION_PORTRAIT",
+            .reverse_landscape => "SCREEN_ORIENTATION_REVERSE_LANDSCAPE",
+        };
+    }
+};
+
+/// The shim's `when (orientation)`, including its `else`.
+pub fn modeFor(orientation: []const u8) Mode {
+    if (std.mem.eql(u8, orientation, "portrait")) return .portrait;
+    if (std.mem.eql(u8, orientation, "landscape")) return .landscape;
+    if (std.mem.eql(u8, orientation, "landscapeLeft")) return .landscape;
+    if (std.mem.eql(u8, orientation, "landscapeRight")) return .reverse_landscape;
+    return .unspecified;
+}
+
+/// `ActivityInfo.<field>`.
+pub fn constantFor(j: Jni, mode: Mode) !i32 {
+    try j.pushLocalFrame(4);
+    defer _ = j.popLocalFrame(null);
+
+    const info_cls = try j.findClass("android/content/pm/ActivityInfo");
+    return j.staticIntField(info_cls, try j.staticFieldId(info_cls, mode.field(), "I"));
+}
+
+/// Queue `activity.setRequestedOrientation(...)` for the main thread.
+pub fn apply(j: Jni, activity: jobject, mode: Mode) !void {
+    const constant = try constantFor(j, mode);
+    try main_thread.post(j, activity, .{ .set_requested_orientation = constant }, 0);
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+const testing = std.testing;
+
+test "every name the shim knows maps where the shim maps it" {
+    try testing.expectEqual(Mode.portrait, modeFor("portrait"));
+    try testing.expectEqual(Mode.landscape, modeFor("landscape"));
+
+    // Both of these are SCREEN_ORIENTATION_LANDSCAPE in the shim. Written as
+    // two rows rather than one, because they read like they should differ.
+    try testing.expectEqual(Mode.landscape, modeFor("landscapeLeft"));
+    try testing.expectEqual(Mode.reverse_landscape, modeFor("landscapeRight"));
+}
+
+test "an unknown name unlocks rather than failing" {
+    // The shim's `else`. `craft.lockOrientation("portrat")` returns true and
+    // leaves the device unlocked, which is worth knowing before debugging it.
+    try testing.expectEqual(Mode.unspecified, modeFor("portrat"));
+    try testing.expectEqual(Mode.unspecified, modeFor(""));
+    try testing.expectEqual(Mode.unspecified, modeFor("PORTRAIT"));
+    try testing.expectEqual(Mode.unspecified, modeFor("portrait "));
+    try testing.expectEqual(Mode.unspecified, modeFor("upsideDown"));
+}
+
+test "unlocking is the same constant an unknown name reaches" {
+    // `unlockOrientation` sets SCREEN_ORIENTATION_UNSPECIFIED, which is why
+    // the typo above is not a harmless no-op: it actively unlocks.
+    try testing.expectEqualStrings(
+        "SCREEN_ORIENTATION_UNSPECIFIED",
+        Mode.unspecified.field(),
+    );
+}
+
+test "each mode names a real ActivityInfo field" {
+    // The names are what `GetStaticFieldID` looks up, so a typo is a
+    // NoSuchFieldError at the call rather than a compile error here.
+    try testing.expectEqualStrings("SCREEN_ORIENTATION_LANDSCAPE", Mode.landscape.field());
+    try testing.expectEqualStrings("SCREEN_ORIENTATION_PORTRAIT", Mode.portrait.field());
+    try testing.expectEqualStrings(
+        "SCREEN_ORIENTATION_REVERSE_LANDSCAPE",
+        Mode.reverse_landscape.field(),
+    );
+
+    // All four are distinct, which a copy-paste in the switch above would
+    // quietly break.
+    const fields = [_][]const u8{
+        Mode.unspecified.field(),
+        Mode.landscape.field(),
+        Mode.portrait.field(),
+        Mode.reverse_landscape.field(),
+    };
+    for (fields, 0..) |a, i| {
+        for (fields[i + 1 ..]) |b| try testing.expect(!std.mem.eql(u8, a, b));
+    }
+}
+
+test "the actions match the shim exactly" {
+    try testing.expectEqualStrings("lockOrientation", A.lock_orientation);
+    try testing.expectEqualStrings("unlockOrientation", A.unlock_orientation);
+}

--- a/packages/zig/test/android_conformance_test.zig
+++ b/packages/zig/test/android_conformance_test.zig
@@ -53,6 +53,7 @@ const zig_sources = [_][]const u8{
     @embedFile("src/bridge_android_contacts.zig"),
     @embedFile("src/bridge_android_widgets.zig"),
     @embedFile("src/bridge_android_shortcuts.zig"),
+    @embedFile("src/bridge_android_orientation.zig"),
 };
 
 /// How many spec actions Zig does not serve yet.
@@ -77,8 +78,10 @@ const zig_sources = [_][]const u8{
 /// deriving it here would be silently wrong under an applicationIdSuffix; 73
 /// with the shortcut pair, whose two halves disagree about what to do below
 /// API 25 and are ported disagreeing; 72 with the immediate half of
-/// scheduleNotification, whose delayed half needs a Runnable.
-const max_not_yet_migrated: usize = 72;
+/// scheduleNotification, whose delayed half needs a Runnable; 70 with the
+/// orientation pair, the first to run on the main looper — through a Runnable
+/// the Kotlin holder owns and a token that says what to do.
+const max_not_yet_migrated: usize = 70;
 
 /// Every `@JavascriptInterface fun <name>(` in the Kotlin bridge.
 ///


### PR DESCRIPTION
Several Android calls must run on the main looper — `Window.addFlags` touches the view hierarchy, `setRequestedOrientation` goes through the Activity — and the shim wraps each in `activity.runOnUiThread { ... }`. That takes a `Runnable`: a Java object implementing a Java interface, which JNI cannot make. `RegisterNatives` binds methods onto a class that already exists in the APK, so a native can *be* called from Java but cannot be handed to Java as an object.

Same wall the reply channel gets around, same answer: **Kotlin owns the object, Zig owns the work.** `CraftNative.runOnMain` posts a `Runnable` that calls straight back into `nativeRunTask`, carrying a token — and the Activity, so nothing on the Zig side holds a reference across the hop and nothing needs a global ref or a matching release.

## A token, not a pointer

The obvious shape is to hand Zig a pointer and cast it back. It is also the shape where a stale `Runnable` — one the looper still holds after whatever queued it is gone — reads freed memory, and the crash lands somewhere else entirely.

A token is checkable:

- each of the 32 slots carries a **generation** that increments on reuse, so a token from a previous occupant does not match and its task is dropped;
- claiming also **releases**, so a `Runnable` that somehow fires twice finds nothing the second time;
- an out-of-range token is dropped rather than indexing the array.

All three have tests, and the first two fail when the generation check is removed — that mutation was run before this was committed.

The table is fixed and has no allocator. These tasks live between a page's call and the next turn of the looper, so a full table means something is wrong rather than busy, and the caller falls through to the shim rather than growing. A spin lock rather than a mutex, because `std.Io.Mutex` on this toolchain wants an `Io` and a JNI native has nowhere to get one.

## The orientation pair, which proves it

Both do their whole job on the looper and neither touches state the shim keeps — which is what makes them the right pair to prove this with, rather than `setKeepAwake` (which writes a field, albeit one nothing reads).

They answer by **returning**, not through the reply channel: `return true` after queueing. That is what the shim's `return true` after `runOnUiThread` means too — the JavaBridge thread is never the main thread, so the block always runs later than the answer. The page's promise resolves before the device has turned, on both sides.

Three things ported that read like bugs and are not:

- `landscape` and `landscapeLeft` map to the **same** constant, so a page asking for the left-hand landscape gets the general one;
- `landscapeRight` is the only name that reaches `REVERSE_LANDSCAPE`;
- the `else` branch is `SCREEN_ORIENTATION_UNSPECIFIED`, which is exactly what `unlockOrientation` sets — so `craft.lockOrientation("portrat")` returns `true` and silently **unlocks**. Worth knowing before debugging it.

The `ActivityInfo` constants are read through JNI rather than written down, for the reason `addContact` reads its MIME types: a wrong column name throws, and a wrong orientation number silently locks the device the wrong way round.

## What this unblocks next

`setKeepAwake` (whose `isKeepingAwake` field turns out to be written once and read nowhere), and the delayed half of `scheduleNotification` — `runOnMain` already takes a `delayMs` and posts through a `Handler` for it.

## Testing

`zig build test:android` passes with the ratchet at 70. Two mutations fired: dropping the generation check, and pointing `landscapeRight` at `LANDSCAPE`. Both `libcraft.so` targets still build with no NDK.