### PR TITLE
feat(android): setKeepAwake through the trampoline — ratchet 70 → 69

### DIFF
--- a/packages/android/templates/CraftBridge.kt.template
+++ b/packages/android/templates/CraftBridge.kt.template
@@ -2577,6 +2577,11 @@ class CraftBridge(
 
     @JavascriptInterface
     fun setKeepAwake(enabled: Boolean): Boolean {
+        // Zig queues the same window call on the same looper. isKeepingAwake
+        // below is written here and read nowhere, so the Kotlin body not
+        // running leaves nothing stale — unlike the flashlight pair.
+        if (CraftNative.setKeepAwake(activity, enabled)) return true
+
         activity.runOnUiThread {
             if (enabled) {
                 activity.window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)

--- a/packages/android/templates/CraftNative.kt.template
+++ b/packages/android/templates/CraftNative.kt.template
@@ -128,6 +128,7 @@ object CraftNative {
     private external fun nativeRunTask(activity: Activity, token: Long)
     private external fun nativeLockOrientation(activity: Activity, orientation: String): Boolean
     private external fun nativeUnlockOrientation(activity: Activity): Boolean
+    private external fun nativeSetKeepAwake(activity: Activity, enabled: Boolean): Boolean
 
     /**
      * `getDeviceInfo`, or null to use the Kotlin implementation.
@@ -615,6 +616,15 @@ object CraftNative {
         if (!isAvailable) return false
         return try {
             nativeUnlockOrientation(activity)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    fun setKeepAwake(activity: Activity, enabled: Boolean): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeSetKeepAwake(activity, enabled)
         } catch (e: UnsatisfiedLinkError) {
             false
         }

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -473,8 +473,8 @@ pub fn build(b: *std.Build) void {
     android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_shortcuts.zig", .{
         .root_source_file = b.path("src/bridge_android_shortcuts.zig"),
     });
-    android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_orientation.zig", .{
-        .root_source_file = b.path("src/bridge_android_orientation.zig"),
+    android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_screen.zig", .{
+        .root_source_file = b.path("src/bridge_android_screen.zig"),
     });
     const run_android_conformance_tests = b.addRunArtifact(android_conformance_tests);
 

--- a/packages/zig/src/android_dispatch.zig
+++ b/packages/zig/src/android_dispatch.zig
@@ -52,7 +52,7 @@ const shareditem = @import("bridge_android_shareditem.zig");
 const contacts = @import("bridge_android_contacts.zig");
 const widgets = @import("bridge_android_widgets.zig");
 const shortcuts = @import("bridge_android_shortcuts.zig");
-const orientation = @import("bridge_android_orientation.zig");
+const screen = @import("bridge_android_screen.zig");
 const main_thread = @import("android_main_thread.zig");
 
 const Jni = jni.Jni;
@@ -341,6 +341,11 @@ const natives = [_]jni.JNINativeMethod{
         .name = "nativeUnlockOrientation",
         .signature = "(Landroid/app/Activity;)Z",
         .fnPtr = @ptrCast(&nativeUnlockOrientation),
+    },
+    .{
+        .name = "nativeSetKeepAwake",
+        .signature = "(Landroid/app/Activity;Z)Z",
+        .fnPtr = @ptrCast(&nativeSetKeepAwake),
     },
 };
 
@@ -1354,7 +1359,7 @@ fn nativeLockOrientation(
 
     const text = j.stringToUtf8(arena.allocator(), name) catch return jni.JNI_FALSE;
 
-    orientation.apply(j, activity, orientation.modeFor(text)) catch |err| {
+    screen.apply(j, activity, screen.modeFor(text)) catch |err| {
         std.log.warn("craft: lockOrientation fell through to the shim ({s})", .{@errorName(err)});
         return jni.JNI_FALSE;
     };
@@ -1369,8 +1374,28 @@ fn nativeUnlockOrientation(
 ) callconv(.c) jni.jboolean {
     const j = Jni.init(env);
 
-    orientation.apply(j, activity, .unspecified) catch |err| {
+    screen.apply(j, activity, .unspecified) catch |err| {
         std.log.warn("craft: unlockOrientation fell through to the shim ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+    return jni.JNI_TRUE;
+}
+
+/// `nativeSetKeepAwake(activity, enabled)`.
+///
+/// Safe to serve where the flashlight pair is not: the shim's block ends
+/// `isKeepingAwake = enabled`, and nothing in `CraftBridge.kt` ever reads that
+/// field — so the Kotlin body not running leaves nothing stale behind.
+fn nativeSetKeepAwake(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+    enabled: jni.jboolean,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+
+    screen.keepAwake(j, activity, enabled != jni.JNI_FALSE) catch |err| {
+        std.log.warn("craft: setKeepAwake fell through to the shim ({s})", .{@errorName(err)});
         return jni.JNI_FALSE;
     };
     return jni.JNI_TRUE;
@@ -1487,7 +1512,7 @@ test "the registered natives name methods the Kotlin actually declares" {
     // A descriptor is checked by the JVM at registration, so a wrong one fails
     // at load rather than at call — but only if the *name* matches something.
     // These two strings are the contract with CraftBridge.kt.
-    try testing.expectEqual(@as(usize, 34), natives.len);
+    try testing.expectEqual(@as(usize, 35), natives.len);
     try testing.expectEqualStrings("nativeGetDeviceInfo", std.mem.span(natives[0].name));
 
     // And the class they bind to is the fixed one, not the templated bridge.

--- a/packages/zig/src/android_main_thread.zig
+++ b/packages/zig/src/android_main_thread.zig
@@ -48,6 +48,8 @@ const jobject = jni.jobject;
 pub const Task = union(enum) {
     /// `activity.setRequestedOrientation(mode)`.
     set_requested_orientation: i32,
+    /// `activity.window.addFlags(flags)` or `clearFlags(flags)`.
+    set_window_flags: struct { flags: i32, add: bool },
 };
 
 const slot_count = 32;
@@ -160,7 +162,34 @@ pub fn run(j: Jni, activity: jobject, token: u64) void {
     const task = claim(token) orelse return;
     switch (task) {
         .set_requested_orientation => |mode| setRequestedOrientation(j, activity, mode) catch {},
+        .set_window_flags => |request| setWindowFlags(j, activity, request.flags, request.add) catch {},
     }
+}
+
+/// Which `Window` method a request names.
+///
+/// Split out because it is the one place the two directions can be swapped,
+/// and swapping them turns the screen timeout back on while reporting success.
+pub fn windowFlagMethod(add: bool) [:0]const u8 {
+    return if (add) "addFlags" else "clearFlags";
+}
+
+/// `activity.window.addFlags(flags)` / `clearFlags(flags)`.
+fn setWindowFlags(j: Jni, activity: jobject, flags: i32, add: bool) !void {
+    try j.pushLocalFrame(8);
+    defer _ = j.popLocalFrame(null);
+
+    const window = try j.callObjectMethod(
+        activity,
+        try j.methodId(try j.objectClass(activity), "getWindow", "()Landroid/view/Window;"),
+    );
+
+    const window_cls = try j.objectClass(window);
+    try j.callVoidMethodA(
+        window,
+        try j.methodId(window_cls, windowFlagMethod(add), "(I)V"),
+        &.{.{ .i = flags }},
+    );
 }
 
 fn setRequestedOrientation(j: Jni, activity: jobject, mode: i32) !void {
@@ -255,6 +284,22 @@ test "releasing a token a caller could not schedule frees its slot" {
     while (count < slot_count) : (count += 1) {
         _ = try reserve(.{ .set_requested_orientation = 0 });
     }
+}
+
+test "a window-flag task carries both halves of the request" {
+    clearTable();
+
+    const token = try reserve(.{ .set_window_flags = .{ .flags = 128, .add = true } });
+    const claimed = claim(token).?;
+    try testing.expectEqual(@as(i32, 128), claimed.set_window_flags.flags);
+    try testing.expect(claimed.set_window_flags.add);
+}
+
+test "adding and clearing name different Window methods" {
+    // The swap that would leave the screen timing out while every layer
+    // reported success.
+    try testing.expectEqualStrings("addFlags", windowFlagMethod(true));
+    try testing.expectEqualStrings("clearFlags", windowFlagMethod(false));
 }
 
 test "the holder class is the fixed one, not the templated bridge" {

--- a/packages/zig/src/bridge_android_screen.zig
+++ b/packages/zig/src/bridge_android_screen.zig
@@ -1,8 +1,8 @@
-//! `lockOrientation` and `unlockOrientation` on Android.
+//! The screen: `lockOrientation`, `unlockOrientation` and `setKeepAwake`.
 //!
-//! The first pair to go through `android_main_thread`: both do their whole job
-//! on the main looper and neither touches state the shim keeps, which is what
-//! makes them the right thing to prove the trampoline with.
+//! Everything here goes through `android_main_thread`, because everything here
+//! touches the Activity's window and the shim wraps each one in
+//! `runOnUiThread { ... }`.
 //!
 //! ## They answer by returning, not through the reply channel
 //!
@@ -41,6 +41,7 @@ const jobject = jni.jobject;
 pub const A = struct {
     pub const lock_orientation = "lockOrientation";
     pub const unlock_orientation = "unlockOrientation";
+    pub const set_keep_awake = "setKeepAwake";
 };
 
 /// Which `ActivityInfo` constant a page's string names.
@@ -83,6 +84,45 @@ pub fn constantFor(j: Jni, mode: Mode) !i32 {
 pub fn apply(j: Jni, activity: jobject, mode: Mode) !void {
     const constant = try constantFor(j, mode);
     try main_thread.post(j, activity, .{ .set_requested_orientation = constant }, 0);
+}
+
+// =============================================================================
+// setKeepAwake
+// =============================================================================
+//
+// ## The field it writes is read by nothing
+//
+// The shim's block ends `isKeepingAwake = enabled`, and that field is written
+// there and read nowhere else in `CraftBridge.kt`. So unlike the flashlight
+// pair — where `toggleFlashlight` reads what `setFlashlight` wrote, and Zig
+// serving one would leave the other inverting a stale value — there is no
+// state to keep in step here. Worth saying, because the two look identical
+// from the outside and only one of them is safe to take.
+
+/// `WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON`.
+///
+/// Read through JNI rather than written down. A wrong column name throws and a
+/// wrong flag does not: the window would quietly get `FLAG_DIM_BEHIND` or
+/// `FLAG_BLUR_BEHIND` instead, and the screen would keep timing out while
+/// everything reported success.
+pub fn keepScreenOnFlag(j: Jni) !i32 {
+    try j.pushLocalFrame(4);
+    defer _ = j.popLocalFrame(null);
+
+    const params_cls = try j.findClass("android/view/WindowManager$LayoutParams");
+    return j.staticIntField(
+        params_cls,
+        try j.staticFieldId(params_cls, "FLAG_KEEP_SCREEN_ON", "I"),
+    );
+}
+
+/// Queue `window.addFlags(...)` or `window.clearFlags(...)` for the main thread.
+pub fn keepAwake(j: Jni, activity: jobject, enabled: bool) !void {
+    const flag = try keepScreenOnFlag(j);
+    try main_thread.post(j, activity, .{ .set_window_flags = .{
+        .flags = flag,
+        .add = enabled,
+    } }, 0);
 }
 
 // =============================================================================
@@ -146,4 +186,5 @@ test "each mode names a real ActivityInfo field" {
 test "the actions match the shim exactly" {
     try testing.expectEqualStrings("lockOrientation", A.lock_orientation);
     try testing.expectEqualStrings("unlockOrientation", A.unlock_orientation);
+    try testing.expectEqualStrings("setKeepAwake", A.set_keep_awake);
 }

--- a/packages/zig/test/android_conformance_test.zig
+++ b/packages/zig/test/android_conformance_test.zig
@@ -53,7 +53,7 @@ const zig_sources = [_][]const u8{
     @embedFile("src/bridge_android_contacts.zig"),
     @embedFile("src/bridge_android_widgets.zig"),
     @embedFile("src/bridge_android_shortcuts.zig"),
-    @embedFile("src/bridge_android_orientation.zig"),
+    @embedFile("src/bridge_android_screen.zig"),
 };
 
 /// How many spec actions Zig does not serve yet.
@@ -80,8 +80,9 @@ const zig_sources = [_][]const u8{
 /// API 25 and are ported disagreeing; 72 with the immediate half of
 /// scheduleNotification, whose delayed half needs a Runnable; 70 with the
 /// orientation pair, the first to run on the main looper — through a Runnable
-/// the Kotlin holder owns and a token that says what to do.
-const max_not_yet_migrated: usize = 70;
+/// the Kotlin holder owns and a token that says what to do; 69 with
+/// setKeepAwake, whose Kotlin field turns out to be written and never read.
+const max_not_yet_migrated: usize = 69;
 
 /// Every `@JavascriptInterface fun <name>(` in the Kotlin bridge.
 ///


### PR DESCRIPTION
The first thing the main-thread hop paid for. `Window.addFlags` touches the view hierarchy, so this could not be served before #173 at all.

## Safe to take where the flashlight pair is not

The shim's block ends `isKeepingAwake = enabled`, and that field is written there and **read nowhere else** in `CraftBridge.kt`.

So unlike `setFlashlight` / `toggleFlashlight` — where the second reads what the first wrote, and serving one from Zig would leave the other inverting a stale value, turning the torch on when it is already on — there is no state to keep in step here.

The two look identical from the outside and only one is safe to take, which is why the reason is written at the seam rather than left implied by the fact that it works.

## The flag is read, and the direction is tested

`FLAG_KEEP_SCREEN_ON` goes through JNI rather than being written down. A wrong flag **does not throw** — the window would quietly get `FLAG_DIM_BEHIND` or `FLAG_BLUR_BEHIND` instead, and the screen would keep timing out while every layer reported success. Same asymmetry that made `addContact` read its MIME types.

`windowFlagMethod` is split out for the same reason: `addFlags` and `clearFlags` are one boolean apart, and swapping them fails a test rather than a device. That mutation was run.

## Also

`bridge_android_orientation.zig` is now `bridge_android_screen.zig`. A file named for orientation that also keeps the screen awake is the same misnaming `bridge_android_notifcancel` carried until #172.

## Testing

`zig build test:android` passes with the ratchet at 69. Both `libcraft.so` targets still build with no NDK.