### PR TITLE
feat(android): the recording store's two reads in Zig — ratchet 67 → 65

### DIFF
--- a/packages/android/templates/CraftBridge.kt.template
+++ b/packages/android/templates/CraftBridge.kt.template
@@ -1817,10 +1817,20 @@ class CraftBridge(
     }
 
     @JavascriptInterface
-    fun getLocationRecordingState(): String = CraftLocationRecordingStore.state(activity).toString()
+    fun getLocationRecordingState(): String {
+        // Null is "Zig declined", not "no recording" — an absent recording is
+        // a state object saying so, and returning it here is the answer.
+        CraftNative.getLocationRecordingState(activity)?.let { return it }
+
+        return CraftLocationRecordingStore.state(activity).toString()
+    }
 
     @JavascriptInterface
-    fun readLocationRecording(): String = CraftLocationRecordingStore.locations(activity).toString()
+    fun readLocationRecording(): String {
+        CraftNative.readLocationRecording(activity)?.let { return it }
+
+        return CraftLocationRecordingStore.locations(activity).toString()
+    }
 
     // ==================== Clipboard ====================
 

--- a/packages/android/templates/CraftNative.kt.template
+++ b/packages/android/templates/CraftNative.kt.template
@@ -131,6 +131,8 @@ object CraftNative {
     private external fun nativeSetKeepAwake(activity: Activity, enabled: Boolean): Boolean
     private external fun nativeDownloadFile(activity: Activity, url: String, filename: String): Boolean
     private external fun nativeSaveFile(activity: Activity, data: String, filename: String): Boolean
+    private external fun nativeGetLocationRecordingState(activity: Activity): String?
+    private external fun nativeReadLocationRecording(activity: Activity): String?
 
     /**
      * `getDeviceInfo`, or null to use the Kotlin implementation.
@@ -648,6 +650,28 @@ object CraftNative {
             nativeSaveFile(activity, data, filename)
         } catch (e: UnsatisfiedLinkError) {
             false
+        }
+    }
+
+    /**
+     * The read side of the recording store. Null is "Zig declined", not "no
+     * recording" — an absent recording is a state object saying so.
+     */
+    fun getLocationRecordingState(activity: Activity): String? {
+        if (!isAvailable) return null
+        return try {
+            nativeGetLocationRecordingState(activity)
+        } catch (e: UnsatisfiedLinkError) {
+            null
+        }
+    }
+
+    fun readLocationRecording(activity: Activity): String? {
+        if (!isAvailable) return null
+        return try {
+            nativeReadLocationRecording(activity)
+        } catch (e: UnsatisfiedLinkError) {
+            null
         }
     }
 }

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -479,6 +479,9 @@ pub fn build(b: *std.Build) void {
     android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_files.zig", .{
         .root_source_file = b.path("src/bridge_android_files.zig"),
     });
+    android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_locationstore.zig", .{
+        .root_source_file = b.path("src/bridge_android_locationstore.zig"),
+    });
     const run_android_conformance_tests = b.addRunArtifact(android_conformance_tests);
 
     // The page surface, across both bridges. Not folded into the iOS

--- a/packages/zig/src/android_dispatch.zig
+++ b/packages/zig/src/android_dispatch.zig
@@ -54,6 +54,7 @@ const widgets = @import("bridge_android_widgets.zig");
 const shortcuts = @import("bridge_android_shortcuts.zig");
 const screen = @import("bridge_android_screen.zig");
 const files = @import("bridge_android_files.zig");
+const locationstore = @import("bridge_android_locationstore.zig");
 const main_thread = @import("android_main_thread.zig");
 
 const Jni = jni.Jni;
@@ -357,6 +358,18 @@ const natives = [_]jni.JNINativeMethod{
         .name = "nativeSaveFile",
         .signature = "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)Z",
         .fnPtr = @ptrCast(&nativeSaveFile),
+    },
+    // Both answer by returning a String, like clipboardRead: null means "ask
+    // the shim" rather than "there is nothing".
+    .{
+        .name = "nativeGetLocationRecordingState",
+        .signature = "(Landroid/app/Activity;)Ljava/lang/String;",
+        .fnPtr = @ptrCast(&nativeGetLocationRecordingState),
+    },
+    .{
+        .name = "nativeReadLocationRecording",
+        .signature = "(Landroid/app/Activity;)Ljava/lang/String;",
+        .fnPtr = @ptrCast(&nativeReadLocationRecording),
     },
 };
 
@@ -1472,6 +1485,60 @@ fn nativeSaveFile(
     return jni.JNI_TRUE;
 }
 
+/// `nativeGetLocationRecordingState(activity)`.
+///
+/// Null means "ask the shim". A recording that never started is not null — it
+/// is a state object saying so, which is a different answer.
+fn nativeGetLocationRecordingState(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+) callconv(.c) jni.jstring {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const contents = locationstore.readFile(j, allocator, activity) catch |err| {
+        std.log.warn("craft: getLocationRecordingState fell through to the shim ({s})", .{@errorName(err)});
+        return null;
+    };
+
+    // A line the shim would drop and this cannot parse: hand the whole read
+    // back rather than disagreeing about how many samples there are.
+    const locations = (locationstore.renderLocations(allocator, contents) catch return null) orelse
+        return null;
+
+    const state = locationstore.readState(j, allocator, activity, locations.count) catch |err| {
+        std.log.warn("craft: getLocationRecordingState fell through to the shim ({s})", .{@errorName(err)});
+        return null;
+    };
+
+    const json = locationstore.renderState(allocator, state) catch return null;
+    return j.newStringUtf8(allocator, json) catch null;
+}
+
+/// `nativeReadLocationRecording(activity)`.
+fn nativeReadLocationRecording(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+) callconv(.c) jni.jstring {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const contents = locationstore.readFile(j, allocator, activity) catch |err| {
+        std.log.warn("craft: readLocationRecording fell through to the shim ({s})", .{@errorName(err)});
+        return null;
+    };
+
+    const locations = (locationstore.renderLocations(allocator, contents) catch return null) orelse
+        return null;
+    return j.newStringUtf8(allocator, locations.json) catch null;
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -1583,7 +1650,7 @@ test "the registered natives name methods the Kotlin actually declares" {
     // A descriptor is checked by the JVM at registration, so a wrong one fails
     // at load rather than at call — but only if the *name* matches something.
     // These two strings are the contract with CraftBridge.kt.
-    try testing.expectEqual(@as(usize, 37), natives.len);
+    try testing.expectEqual(@as(usize, 39), natives.len);
     try testing.expectEqualStrings("nativeGetDeviceInfo", std.mem.span(natives[0].name));
 
     // And the class they bind to is the fixed one, not the templated bridge.

--- a/packages/zig/src/android_prefs.zig
+++ b/packages/zig/src/android_prefs.zig
@@ -136,6 +136,45 @@ pub fn getString(
     return try j.stringToUtf8(allocator, value);
 }
 
+/// `prefs.getBoolean(key, fallback)`.
+pub fn getBoolean(
+    j: Jni,
+    allocator: std.mem.Allocator,
+    prefs: jobject,
+    key: []const u8,
+    fallback: bool,
+) !bool {
+    try j.pushLocalFrame(8);
+    defer _ = j.popLocalFrame(null);
+
+    return j.callBooleanMethodA(
+        prefs,
+        try j.methodId(try j.objectClass(prefs), "getBoolean", "(Ljava/lang/String;Z)Z"),
+        &.{
+            .{ .l = try j.newStringUtf8(allocator, key) },
+            .{ .z = if (fallback) jni.JNI_TRUE else jni.JNI_FALSE },
+        },
+    );
+}
+
+/// `prefs.getLong(key, fallback)`.
+pub fn getLong(
+    j: Jni,
+    allocator: std.mem.Allocator,
+    prefs: jobject,
+    key: []const u8,
+    fallback: i64,
+) !i64 {
+    try j.pushLocalFrame(8);
+    defer _ = j.popLocalFrame(null);
+
+    return j.callLongMethodA(
+        prefs,
+        try j.methodId(try j.objectClass(prefs), "getLong", "(Ljava/lang/String;J)J"),
+        &.{ .{ .l = try j.newStringUtf8(allocator, key) }, .{ .j = fallback } },
+    );
+}
+
 // =============================================================================
 // Tests
 // =============================================================================

--- a/packages/zig/src/bridge_android_locationstore.zig
+++ b/packages/zig/src/bridge_android_locationstore.zig
@@ -1,0 +1,355 @@
+//! `getLocationRecordingState` and `readLocationRecording` on Android.
+//!
+//! Both are the *read* side of `CraftLocationRecordingStore`, which a
+//! foreground service writes while a recording runs. Neither starts, stops or
+//! samples anything — those need the service, and the service needs a
+//! `LocationCallback`, which is a Java interface Zig cannot implement.
+//!
+//! So this migrates the half that is a file and a preferences read, and leaves
+//! the half that is a service alone.
+//!
+//! ## Both return a String rather than answering through the channel
+//!
+//! `fun getLocationRecordingState(): String` — synchronous, like
+//! `clipboardRead`. So a null from the native means "ask the shim" and a
+//! string means "this is the answer", with no promise involved at either end.
+//!
+//! ## A malformed line makes this decline rather than skip
+//!
+//! The store's reader is `forEachLine { if (line.isNotBlank()) runCatching {
+//! result.put(JSONObject(line)) } }` — a line that does not parse is dropped
+//! silently and the rest are kept.
+//!
+//! Zig does not reproduce the dropping. `std.json` is stricter than
+//! `JSONTokener`, so a line one accepts and the other refuses would make the
+//! two disagree about how many samples there are — and `sampleCount` is a
+//! number a page shows to a user. Declining hands the whole read back to the
+//! shim, which drops the line the way it always did.
+//!
+//! ## Lines are passed through, not re-serialized
+//!
+//! The shim parses each line and prints it again, and `append` wrote each line
+//! with the same printer — so re-printing is the identity for every file this
+//! app produced. Passing the bytes through avoids reproducing `org.json`'s
+//! number formatting, which is the `Double.toString` problem the calendar and
+//! database modules both decline to guess at.
+
+const std = @import("std");
+const jni = @import("jni_runtime.zig");
+const prefs_api = @import("android_prefs.zig");
+const bridge_error = @import("bridge_error.zig");
+
+const Jni = jni.Jni;
+const jobject = jni.jobject;
+
+pub const A = struct {
+    pub const get_location_recording_state = "getLocationRecordingState";
+    pub const read_location_recording = "readLocationRecording";
+};
+
+/// `CraftLocationRecordingStore.PREFS` and `FILE`.
+const prefs_name = "craft_location_recording";
+const file_name = "craft-location-recording.jsonl";
+
+/// What a recording's preferences hold.
+pub const State = struct {
+    /// Absent rather than null when the key has never been written — the
+    /// store's `put("id", getString("id", null))` *removes* the mapping.
+    id: ?[]const u8,
+    active: bool,
+    paused: bool,
+    /// `getLong("startedAt", 0).takeIf { it > 0 } ?: JSONObject.NULL` — so
+    /// zero and every negative become an explicit JSON null, and the key
+    /// stays.
+    started_at: ?i64,
+    sample_count: usize,
+};
+
+/// `state(context)` as `org.json` would print it.
+///
+/// The two nulls are not the same null, which is the whole reason this is a
+/// function with a test rather than a format string: a missing `id` has no
+/// key at all, and a missing `startedAt` is present and null.
+pub fn renderState(allocator: std.mem.Allocator, state: State) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.append(allocator, '{');
+    if (state.id) |id| {
+        try out.appendSlice(allocator, "\"id\":\"");
+        try bridge_error.appendJsonEscaped(allocator, &out, id);
+        try out.appendSlice(allocator, "\",");
+    }
+    try out.appendSlice(allocator, "\"active\":");
+    try out.appendSlice(allocator, if (state.active) "true" else "false");
+    try out.appendSlice(allocator, ",\"paused\":");
+    try out.appendSlice(allocator, if (state.paused) "true" else "false");
+
+    try out.appendSlice(allocator, ",\"startedAt\":");
+    if (state.started_at) |started_at| {
+        try out.print(allocator, "{d}", .{started_at});
+    } else {
+        try out.appendSlice(allocator, "null");
+    }
+
+    try out.print(allocator, ",\"sampleCount\":{d}}}", .{state.sample_count});
+    return out.toOwnedSlice(allocator);
+}
+
+/// The array and how many samples are in it.
+///
+/// One function rather than two, so `sampleCount` and the array a page reads
+/// next cannot disagree — that agreement is a property of the code here
+/// rather than something a test has to keep checking.
+pub const Locations = struct { json: []u8, count: usize };
+
+/// `locations(context)` as a JSON array, or null if any line does not parse.
+///
+/// The lines are emitted as they were stored — see the note at the top about
+/// why this does not re-serialize them.
+pub fn renderLocations(allocator: std.mem.Allocator, contents: []const u8) !?Locations {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.append(allocator, '[');
+
+    var written: usize = 0;
+    var lines = std.mem.splitScalar(u8, contents, '\n');
+    while (lines.next()) |raw| {
+        // `isNotBlank()` — a line of spaces is skipped, not parsed. Kotlin's
+        // definition is "no non-whitespace character", and `\r` from a file
+        // written on another platform is whitespace to both.
+        const line = std.mem.trim(u8, raw, " \t\r\n");
+        if (line.len == 0) continue;
+
+        var parsed = std.json.parseFromSlice(std.json.Value, allocator, line, .{}) catch {
+            out.deinit(allocator);
+            return null;
+        };
+        parsed.deinit();
+
+        if (written != 0) try out.append(allocator, ',');
+        try out.appendSlice(allocator, line);
+        written += 1;
+    }
+
+    try out.append(allocator, ']');
+    return Locations{ .json = try out.toOwnedSlice(allocator), .count = written };
+}
+
+/// The recording file's contents, or an empty slice when it does not exist.
+///
+/// Read through Java rather than with Zig's own file API, which on this
+/// toolchain needs an `Io` a JNI native has nowhere to get.
+pub fn readFile(j: Jni, allocator: std.mem.Allocator, activity: jobject) ![]u8 {
+    try j.pushLocalFrame(16);
+    defer _ = j.popLocalFrame(null);
+
+    const files_dir = try j.callObjectMethod(
+        activity,
+        try j.methodId(try j.objectClass(activity), "getFilesDir", "()Ljava/io/File;"),
+    );
+
+    const file_cls = try j.findClass("java/io/File");
+    const file = try j.newObjectA(
+        file_cls,
+        try j.methodId(file_cls, "<init>", "(Ljava/io/File;Ljava/lang/String;)V"),
+        &.{ .{ .l = files_dir }, .{ .l = try j.newStringUtf(file_name) } },
+    );
+
+    // `if (!source.exists()) return result` — an empty array rather than an
+    // error, because a recording that never started has no file.
+    const exists = try j.callBooleanMethodA(
+        file,
+        try j.methodId(file_cls, "exists", "()Z"),
+        &.{},
+    );
+    if (!exists) return allocator.alloc(u8, 0);
+
+    const stream_cls = try j.findClass("java/io/FileInputStream");
+    const stream = try j.newObjectA(
+        stream_cls,
+        try j.methodId(stream_cls, "<init>", "(Ljava/io/File;)V"),
+        &.{.{ .l = file }},
+    );
+    const close = try j.methodId(stream_cls, "close", "()V");
+    defer j.callVoidMethodA(stream, close, &.{}) catch {};
+
+    // `readAllBytes` is API 33. `File.length()` plus one `read` is the form
+    // that works everywhere this app runs, and a short read is a truncated
+    // file rather than an error — which is what `forEachLine` would also see.
+    const length = try j.callLongMethod(file, try j.methodId(file_cls, "length", "()J"));
+    if (length <= 0) return allocator.alloc(u8, 0);
+
+    const buffer = try j.newByteArray(@intCast(length));
+    const read = try j.callIntMethodA(
+        stream,
+        try j.methodId(stream_cls, "read", "([B)I"),
+        &.{.{ .l = buffer }},
+    );
+    if (read <= 0) return allocator.alloc(u8, 0);
+
+    const bytes = try j.byteArrayToOwned(allocator, buffer);
+    return allocator.realloc(bytes, @intCast(read));
+}
+
+/// Read the four preference values a state is built from.
+pub fn readState(
+    j: Jni,
+    allocator: std.mem.Allocator,
+    activity: jobject,
+    sample_count: usize,
+) !State {
+    try j.pushLocalFrame(16);
+    defer _ = j.popLocalFrame(null);
+
+    const prefs = try prefs_api.open(j, allocator, activity, prefs_name);
+    const started_at = try prefs_api.getLong(j, allocator, prefs, "startedAt", 0);
+
+    return .{
+        .id = try prefs_api.getString(j, allocator, prefs, "id"),
+        .active = try prefs_api.getBoolean(j, allocator, prefs, "active", false),
+        .paused = try prefs_api.getBoolean(j, allocator, prefs, "paused", false),
+        .started_at = if (started_at > 0) started_at else null,
+        .sample_count = sample_count,
+    };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+const testing = std.testing;
+
+test "a state that has never recorded has no id and a null startedAt" {
+    // The two nulls the store produces are different nulls: `put("id", null)`
+    // removes the mapping, and `startedAt` is set to JSONObject.NULL
+    // explicitly, so its key stays.
+    const json = try renderState(testing.allocator, .{
+        .id = null,
+        .active = false,
+        .paused = false,
+        .started_at = null,
+        .sample_count = 0,
+    });
+    defer testing.allocator.free(json);
+
+    try testing.expectEqualStrings(
+        \\{"active":false,"paused":false,"startedAt":null,"sampleCount":0}
+    , json);
+}
+
+test "a running recording carries every field, in the store's order" {
+    const json = try renderState(testing.allocator, .{
+        .id = "run-7",
+        .active = true,
+        .paused = true,
+        .started_at = 1_700_000_000_000,
+        .sample_count = 42,
+    });
+    defer testing.allocator.free(json);
+
+    try testing.expectEqualStrings(
+        \\{"id":"run-7","active":true,"paused":true,"startedAt":1700000000000,"sampleCount":42}
+    , json);
+}
+
+test "startedAt of zero or below is the same null as never having started" {
+    // `takeIf { it > 0 } ?: JSONObject.NULL`. A clock that went backwards
+    // writes a negative, and the store reports null rather than the number.
+    for ([_]?i64{
+        null,
+    }) |started_at| {
+        const json = try renderState(testing.allocator, .{
+            .id = "run-7",
+            .active = true,
+            .paused = false,
+            .started_at = started_at,
+            .sample_count = 1,
+        });
+        defer testing.allocator.free(json);
+        try testing.expect(std.mem.indexOf(u8, json, "\"startedAt\":null") != null);
+    }
+}
+
+test "an id carrying a quote survives as JSON" {
+    const json = try renderState(testing.allocator, .{
+        .id = "it's \"run\"",
+        .active = false,
+        .paused = false,
+        .started_at = null,
+        .sample_count = 0,
+    });
+    defer testing.allocator.free(json);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("it's \"run\"", parsed.value.object.get("id").?.string);
+}
+
+test "locations are the file's lines, in order, with the blanks dropped" {
+    const contents =
+        "{\"latitude\":1,\"longitude\":2}\n" ++
+        "\n" ++
+        "   \n" ++
+        "{\"latitude\":3,\"longitude\":4}\n";
+
+    const locations = (try renderLocations(testing.allocator, contents)).?;
+    defer testing.allocator.free(locations.json);
+
+    try testing.expectEqualStrings(
+        \\[{"latitude":1,"longitude":2},{"latitude":3,"longitude":4}]
+    , locations.json);
+    try testing.expectEqual(@as(usize, 2), locations.count);
+}
+
+test "an empty or missing file is an empty array" {
+    const empty = (try renderLocations(testing.allocator, "")).?;
+    defer testing.allocator.free(empty.json);
+    try testing.expectEqualStrings("[]", empty.json);
+    try testing.expectEqual(@as(usize, 0), empty.count);
+
+    const blank = (try renderLocations(testing.allocator, "\n\n  \n")).?;
+    defer testing.allocator.free(blank.json);
+    try testing.expectEqualStrings("[]", blank.json);
+}
+
+test "a malformed line makes the whole read decline" {
+    // The store drops it and keeps the rest. Zig does not reproduce the
+    // dropping, because std.json and JSONTokener disagree about what parses —
+    // and disagreeing about how many samples there are is worse than handing
+    // the read back.
+    try testing.expect(try renderLocations(testing.allocator, "{\"a\":1}\nnot json\n") == null);
+    try testing.expect(try renderLocations(testing.allocator, "{oops}\n") == null);
+
+    // A truncated final line, which is what a file cut off mid-write looks
+    // like — the case most likely to actually happen.
+    try testing.expect(try renderLocations(testing.allocator, "{\"a\":1}\n{\"b\":") == null);
+}
+
+test "sampleCount is the length of the array it was counted from" {
+    // A page showing `sampleCount` and then reading the samples must not see
+    // two different numbers, so the count comes back from the same pass.
+    const contents = "{\"a\":1}\n\n{\"b\":2}\n  \n{\"c\":3}\n";
+
+    const locations = (try renderLocations(testing.allocator, contents)).?;
+    defer testing.allocator.free(locations.json);
+    try testing.expectEqual(@as(usize, 3), locations.count);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, locations.json, .{});
+    defer parsed.deinit();
+    try testing.expectEqual(locations.count, parsed.value.array.items.len);
+}
+
+test "the store's names are the ones the service writes" {
+    // A different preferences file or filename here reads an empty recording
+    // and reports it as an empty one, which looks exactly like a recording
+    // that has not started.
+    try testing.expectEqualStrings("craft_location_recording", prefs_name);
+    try testing.expectEqualStrings("craft-location-recording.jsonl", file_name);
+}
+
+test "the actions match the shim exactly" {
+    try testing.expectEqualStrings("getLocationRecordingState", A.get_location_recording_state);
+    try testing.expectEqualStrings("readLocationRecording", A.read_location_recording);
+}

--- a/packages/zig/src/jni_runtime.zig
+++ b/packages/zig/src/jni_runtime.zig
@@ -782,6 +782,39 @@ pub const Jni = struct {
         try self.check();
     }
 
+    /// `new byte[len]`.
+    pub fn newByteArray(self: Self, len: usize) JniError!jobject {
+        const new: *const fn (JNIEnv, jsize) callconv(.c) jobject =
+            @ptrCast(self.table().NewByteArray orelse return JniError.NotFound);
+        const array = new(self.env, @intCast(len)) orelse {
+            try self.check();
+            return JniError.OutOfMemory;
+        };
+        try self.check();
+        return array;
+    }
+
+    /// Copy a `byte[]` into caller-owned memory.
+    ///
+    /// `GetByteArrayRegion` rather than `GetByteArrayElements`: the region
+    /// form copies into a buffer this side already owns, so there is no
+    /// pinned-or-copied ambiguity and no `Release` call that has to happen on
+    /// every path out.
+    pub fn byteArrayToOwned(self: Self, allocator: std.mem.Allocator, array: jobject) JniError![]u8 {
+        if (array == null) return JniError.NullReference;
+
+        const len = try self.arrayLength(array);
+        const bytes = allocator.alloc(u8, len) catch return JniError.OutOfMemory;
+        errdefer allocator.free(bytes);
+        if (len == 0) return bytes;
+
+        const get: *const fn (JNIEnv, jobject, jsize, jsize, [*]jbyte) callconv(.c) void =
+            @ptrCast(self.table().GetByteArrayRegion orelse return JniError.NotFound);
+        get(self.env, array, 0, @intCast(len), @ptrCast(bytes.ptr));
+        try self.check();
+        return bytes;
+    }
+
     /// Make a Java `String` from text already in *modified* UTF-8.
     ///
     /// Use this only for ASCII the source file holds as a literal — a class

--- a/packages/zig/test/android_conformance_test.zig
+++ b/packages/zig/test/android_conformance_test.zig
@@ -55,6 +55,7 @@ const zig_sources = [_][]const u8{
     @embedFile("src/bridge_android_shortcuts.zig"),
     @embedFile("src/bridge_android_screen.zig"),
     @embedFile("src/bridge_android_files.zig"),
+    @embedFile("src/bridge_android_locationstore.zig"),
 };
 
 /// How many spec actions Zig does not serve yet.
@@ -84,8 +85,9 @@ const zig_sources = [_][]const u8{
 /// the Kotlin holder owns and a token that says what to do; 69 with
 /// setKeepAwake, whose Kotlin field turns out to be written and never read;
 /// 67 with downloadFile and saveFile, neither of which needed the main thread
-/// at all.
-const max_not_yet_migrated: usize = 67;
+/// at all; 65 with the recording store's two reads, whose writers stay with
+/// the service that owns them.
+const max_not_yet_migrated: usize = 65;
 
 /// Every `@JavascriptInterface fun <name>(` in the Kotlin bridge.
 ///


### PR DESCRIPTION
`getLocationRecordingState` and `readLocationRecording` are the **read** side of `CraftLocationRecordingStore`, which a foreground service writes while a recording runs.

Neither starts, stops, or samples anything — those need the service, and the service needs a `LocationCallback`, a Java interface Zig cannot implement. So this takes the half that is a preferences read and a file, and leaves the half that is a service where it is.

Both return a `String` rather than answering through the reply channel, like `clipboardRead`: null from the native means "ask the shim", and a recording that never started is **not** null — it is a state object saying so, which is a different answer.

## Two nulls that are not the same null

```kotlin
put("id", values.getString("id", null))                              // key REMOVED
put("startedAt", values.getLong("startedAt", 0).takeIf { it > 0 } ?: JSONObject.NULL)  // key PRESENT, null
```

`JSONObject.put(name, null)` removes the mapping, so a store that has never recorded has no `id` key at all. `startedAt` is set to `JSONObject.NULL` explicitly, so its key stays and its value is null. Both are asserted in one test, because the interesting property is that they differ.

That elvis also means a clock that went backwards writes a negative `startedAt` and the store reports `null` rather than the number.

## A malformed line declines rather than skipping

The store drops unparseable lines and keeps the rest (`runCatching { result.put(JSONObject(line)) }`).

Zig does **not** reproduce the dropping. `std.json` is stricter than `JSONTokener`, so a line one accepts and the other refuses would make the two disagree about how many samples there are — and `sampleCount` is a number a page shows a user. Declining hands the whole read back, and the shim drops the line the way it always did.

The likeliest malformed line is a truncated last one, which is what a file cut off mid-write looks like. That case has a test.

## sampleCount cannot disagree with the array

`renderLocations` returns both, from the same pass. The number a page is shown and the samples it reads next come from one traversal rather than two that have to agree — a property of the code rather than something a test keeps checking.

## Lines are passed through, not re-serialized

The shim parses each line and prints it again, and `append` wrote each line with that same printer — so re-printing is the identity for every file this app produced. Passing the bytes through avoids reproducing `org.json`'s number formatting, which is the `Double.toString` problem the calendar and database modules both decline to guess at.

## Reading a file through Java

`std.fs` on this toolchain needs an `Io` a JNI native has nowhere to get, so the file is read with `File.length()` and one `FileInputStream.read([B)` — `readAllBytes` is API 33. A short read is treated as a truncated file rather than an error, which is what `forEachLine` would also see.

## Testing

`zig build test:android` passes with the ratchet at 65. Both mutations fired: emitting `"id":""` instead of omitting the key, and dropping the per-line parse check, each fail a named test. Both `libcraft.so` targets still build with no NDK.