### PR TITLE
feat(android): the location-recording controls in Zig — ratchet 65 → 61

### DIFF
--- a/packages/android/templates/CraftBridge.kt.template
+++ b/packages/android/templates/CraftBridge.kt.template
@@ -1772,6 +1772,10 @@ class CraftBridge(
 
     @JavascriptInterface
     fun startLocationRecording(optionsJson: String): String {
+        // Null is "Zig declined". A permission-denied answer is not null — it
+        // is a state object saying so, and returning it here is the answer.
+        CraftNative.startLocationRecording(activity)?.let { return it }
+
         if (ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
             return JSONObject().apply {
                 put("id", JSONObject.NULL)
@@ -1792,12 +1796,16 @@ class CraftBridge(
 
     @JavascriptInterface
     fun pauseLocationRecording(): String {
+        CraftNative.pauseLocationRecording(activity)?.let { return it }
+
         CraftLocationRecordingStore.setPaused(activity, true)
         return CraftLocationRecordingStore.state(activity).toString()
     }
 
     @JavascriptInterface
     fun resumeLocationRecording(): String {
+        CraftNative.resumeLocationRecording(activity)?.let { return it }
+
         CraftLocationRecordingStore.setPaused(activity, false)
         if (CraftLocationRecordingStore.isActive(activity)) {
             ContextCompat.startForegroundService(
@@ -1810,6 +1818,8 @@ class CraftBridge(
 
     @JavascriptInterface
     fun stopLocationRecording(): String {
+        CraftNative.stopLocationRecording(activity)?.let { return it }
+
         CraftLocationRecordingStore.stop(activity)
         val result = CraftLocationRecordingStore.state(activity, includeLocations = true).toString()
         activity.stopService(Intent(activity, LocationRecordingService::class.java).setAction(LocationRecordingService.ACTION_STOP))

--- a/packages/android/templates/CraftNative.kt.template
+++ b/packages/android/templates/CraftNative.kt.template
@@ -1,6 +1,8 @@
 package com.craft.runtime
 
 import android.app.Activity
+import androidx.core.content.ContextCompat
+import android.content.Intent
 import android.os.Handler
 import android.os.Looper
 import android.content.SharedPreferences
@@ -133,6 +135,10 @@ object CraftNative {
     private external fun nativeSaveFile(activity: Activity, data: String, filename: String): Boolean
     private external fun nativeGetLocationRecordingState(activity: Activity): String?
     private external fun nativeReadLocationRecording(activity: Activity): String?
+    private external fun nativeStartLocationRecording(activity: Activity): String?
+    private external fun nativeStopLocationRecording(activity: Activity): String?
+    private external fun nativePauseLocationRecording(activity: Activity): String?
+    private external fun nativeResumeLocationRecording(activity: Activity): String?
 
     /**
      * `getDeviceInfo`, or null to use the Kotlin implementation.
@@ -673,5 +679,72 @@ object CraftNative {
         } catch (e: UnsatisfiedLinkError) {
             null
         }
+    }
+
+    /**
+     * The four controls. Each returns the store's state as JSON, or null when
+     * Zig declined and the Kotlin below should answer instead.
+     */
+    fun startLocationRecording(activity: Activity): String? {
+        if (!isAvailable) return null
+        return try {
+            nativeStartLocationRecording(activity)
+        } catch (e: UnsatisfiedLinkError) {
+            null
+        }
+    }
+
+    fun stopLocationRecording(activity: Activity): String? {
+        if (!isAvailable) return null
+        return try {
+            nativeStopLocationRecording(activity)
+        } catch (e: UnsatisfiedLinkError) {
+            null
+        }
+    }
+
+    fun pauseLocationRecording(activity: Activity): String? {
+        if (!isAvailable) return null
+        return try {
+            nativePauseLocationRecording(activity)
+        } catch (e: UnsatisfiedLinkError) {
+            null
+        }
+    }
+
+    fun resumeLocationRecording(activity: Activity): String? {
+        if (!isAvailable) return null
+        return try {
+            nativeResumeLocationRecording(activity)
+        } catch (e: UnsatisfiedLinkError) {
+            null
+        }
+    }
+
+    /**
+     * Start and stop the recording service.
+     *
+     * Called from Zig, and here rather than there because
+     * `LocationRecordingService::class.java` names a class whose package is
+     * templated per app — `FindClass` on the native side has no name to look
+     * up, and assembling one from `getPackageName()` is the trap the widget
+     * broadcast action already documents: an `applicationIdSuffix` moves the
+     * runtime package and leaves the class where it was.
+     */
+    @JvmStatic
+    fun startRecordingService(activity: Activity) {
+        ContextCompat.startForegroundService(
+            activity,
+            Intent(activity, LocationRecordingService::class.java)
+                .setAction(LocationRecordingService.ACTION_START)
+        )
+    }
+
+    @JvmStatic
+    fun stopRecordingService(activity: Activity) {
+        activity.stopService(
+            Intent(activity, LocationRecordingService::class.java)
+                .setAction(LocationRecordingService.ACTION_STOP)
+        )
     }
 }

--- a/packages/zig/src/android_dispatch.zig
+++ b/packages/zig/src/android_dispatch.zig
@@ -371,6 +371,26 @@ const natives = [_]jni.JNINativeMethod{
         .signature = "(Landroid/app/Activity;)Ljava/lang/String;",
         .fnPtr = @ptrCast(&nativeReadLocationRecording),
     },
+    .{
+        .name = "nativeStartLocationRecording",
+        .signature = "(Landroid/app/Activity;)Ljava/lang/String;",
+        .fnPtr = @ptrCast(&nativeStartLocationRecording),
+    },
+    .{
+        .name = "nativeStopLocationRecording",
+        .signature = "(Landroid/app/Activity;)Ljava/lang/String;",
+        .fnPtr = @ptrCast(&nativeStopLocationRecording),
+    },
+    .{
+        .name = "nativePauseLocationRecording",
+        .signature = "(Landroid/app/Activity;)Ljava/lang/String;",
+        .fnPtr = @ptrCast(&nativePauseLocationRecording),
+    },
+    .{
+        .name = "nativeResumeLocationRecording",
+        .signature = "(Landroid/app/Activity;)Ljava/lang/String;",
+        .fnPtr = @ptrCast(&nativeResumeLocationRecording),
+    },
 };
 
 /// How binding went. A value rather than a log line, so every path is
@@ -1539,6 +1559,146 @@ fn nativeReadLocationRecording(
     return j.newStringUtf8(allocator, locations.json) catch null;
 }
 
+/// The current state as a Java String, or null if any part of the read
+/// declines. Shared by every control, since all four answer with one.
+fn recordingStateString(
+    j: Jni,
+    allocator: std.mem.Allocator,
+    activity: jni.jobject,
+    include_locations: bool,
+) jni.jstring {
+    const contents = locationstore.readFile(j, allocator, activity) catch return null;
+    const locations = (locationstore.renderLocations(allocator, contents) catch return null) orelse
+        return null;
+    const state = locationstore.readState(j, allocator, activity, locations.count) catch return null;
+
+    const json = locationstore.renderStateWith(
+        allocator,
+        state,
+        if (include_locations) locations.json else null,
+    ) catch return null;
+    return j.newStringUtf8(allocator, json) catch null;
+}
+
+/// `nativeStartLocationRecording(activity)`.
+fn nativeStartLocationRecording(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+) callconv(.c) jni.jstring {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const granted = permissions.isGranted(j, activity, permissions.access_fine_location) catch
+        return null;
+
+    if (!granted) {
+        // A different object from "never recorded": this path builds a fresh
+        // JSONObject with an explicit JSONObject.NULL id, so the key is
+        // present and null rather than absent.
+        const json = locationstore.renderDenied(allocator) catch return null;
+        return j.newStringUtf8(allocator, json) catch null;
+    }
+
+    const id = locationstore.newRecordingId(j, allocator) catch return null;
+    const started_at = locationstore.nowMillis(j) catch return null;
+    locationstore.startStore(j, allocator, activity, id, started_at) catch return null;
+
+    // Kotlin names the service class, because its package is templated.
+    startRecordingService(j, activity) catch return null;
+
+    return recordingStateString(j, allocator, activity, false);
+}
+
+/// `nativeStopLocationRecording(activity)`.
+///
+/// The state is read *before* the service is stopped, as the shim reads it —
+/// so the array it returns is the recording as it stood at the call.
+fn nativeStopLocationRecording(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+) callconv(.c) jni.jstring {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    locationstore.stopStore(j, allocator, activity) catch return null;
+
+    // Declining after the store write is safe: `stop` is idempotent, so the
+    // shim runs the whole method again and reaches `stopService` itself.
+    const result = recordingStateString(j, allocator, activity, true);
+    if (result == null) return null;
+
+    stopRecordingService(j, activity) catch return null;
+    return result;
+}
+
+/// `nativePauseLocationRecording(activity)`.
+fn nativePauseLocationRecording(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+) callconv(.c) jni.jstring {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    locationstore.setPaused(j, allocator, activity, true) catch return null;
+    return recordingStateString(j, allocator, activity, false);
+}
+
+/// `nativeResumeLocationRecording(activity)`.
+///
+/// Restarts the service only when a recording is active, as the shim does — a
+/// page resuming something it never started should not raise a foreground
+/// notification.
+fn nativeResumeLocationRecording(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+) callconv(.c) jni.jstring {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    locationstore.setPaused(j, allocator, activity, false) catch return null;
+
+    const active = locationstore.isActive(j, allocator, activity) catch return null;
+    if (active) startRecordingService(j, activity) catch return null;
+
+    return recordingStateString(j, allocator, activity, false);
+}
+
+fn startRecordingService(j: Jni, activity: jni.jobject) !void {
+    try j.pushLocalFrame(8);
+    defer _ = j.popLocalFrame(null);
+
+    const holder = try j.findClass(holder_class);
+    try j.callStaticVoidMethodA(
+        holder,
+        try j.staticMethodId(holder, "startRecordingService", "(Landroid/app/Activity;)V"),
+        &.{.{ .l = activity }},
+    );
+}
+
+fn stopRecordingService(j: Jni, activity: jni.jobject) !void {
+    try j.pushLocalFrame(8);
+    defer _ = j.popLocalFrame(null);
+
+    const holder = try j.findClass(holder_class);
+    try j.callStaticVoidMethodA(
+        holder,
+        try j.staticMethodId(holder, "stopRecordingService", "(Landroid/app/Activity;)V"),
+        &.{.{ .l = activity }},
+    );
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -1650,7 +1810,7 @@ test "the registered natives name methods the Kotlin actually declares" {
     // A descriptor is checked by the JVM at registration, so a wrong one fails
     // at load rather than at call — but only if the *name* matches something.
     // These two strings are the contract with CraftBridge.kt.
-    try testing.expectEqual(@as(usize, 39), natives.len);
+    try testing.expectEqual(@as(usize, 43), natives.len);
     try testing.expectEqualStrings("nativeGetDeviceInfo", std.mem.span(natives[0].name));
 
     // And the class they bind to is the fixed one, not the templated bridge.

--- a/packages/zig/src/android_permissions.zig
+++ b/packages/zig/src/android_permissions.zig
@@ -40,6 +40,7 @@ pub const read_calendar = "android.permission.READ_CALENDAR";
 pub const write_calendar = "android.permission.WRITE_CALENDAR";
 pub const read_contacts = "android.permission.READ_CONTACTS";
 pub const write_contacts = "android.permission.WRITE_CONTACTS";
+pub const access_fine_location = "android.permission.ACCESS_FINE_LOCATION";
 
 /// `activity.checkSelfPermission(permission) == PERMISSION_GRANTED`.
 pub fn isGranted(j: Jni, activity: jobject, permission: [*:0]const u8) !bool {
@@ -92,6 +93,7 @@ test "the permission names match Manifest.permission exactly" {
     try testing.expectEqualStrings("android.permission.WRITE_CALENDAR", write_calendar);
     try testing.expectEqualStrings("android.permission.READ_CONTACTS", read_contacts);
     try testing.expectEqualStrings("android.permission.WRITE_CONTACTS", write_contacts);
+    try testing.expectEqualStrings("android.permission.ACCESS_FINE_LOCATION", access_fine_location);
 }
 
 test "PERMISSION_GRANTED is zero, and PERMISSION_DENIED is not" {

--- a/packages/zig/src/android_prefs.zig
+++ b/packages/zig/src/android_prefs.zig
@@ -84,6 +84,53 @@ pub fn putString(
     );
 }
 
+/// `editor.putBoolean(key, value)`.
+pub fn putBoolean(
+    j: Jni,
+    allocator: std.mem.Allocator,
+    editor: jobject,
+    key: []const u8,
+    value: bool,
+) !void {
+    try j.pushLocalFrame(4);
+    defer _ = j.popLocalFrame(null);
+
+    _ = try j.callObjectMethodA(
+        editor,
+        try j.methodId(
+            try j.objectClass(editor),
+            "putBoolean",
+            "(Ljava/lang/String;Z)Landroid/content/SharedPreferences$Editor;",
+        ),
+        &.{
+            .{ .l = try j.newStringUtf8(allocator, key) },
+            .{ .z = if (value) jni.JNI_TRUE else jni.JNI_FALSE },
+        },
+    );
+}
+
+/// `editor.putLong(key, value)`.
+pub fn putLong(
+    j: Jni,
+    allocator: std.mem.Allocator,
+    editor: jobject,
+    key: []const u8,
+    value: i64,
+) !void {
+    try j.pushLocalFrame(4);
+    defer _ = j.popLocalFrame(null);
+
+    _ = try j.callObjectMethodA(
+        editor,
+        try j.methodId(
+            try j.objectClass(editor),
+            "putLong",
+            "(Ljava/lang/String;J)Landroid/content/SharedPreferences$Editor;",
+        ),
+        &.{ .{ .l = try j.newStringUtf8(allocator, key) }, .{ .j = value } },
+    );
+}
+
 /// `editor.remove(key)`.
 pub fn remove(j: Jni, allocator: std.mem.Allocator, editor: jobject, key: []const u8) !void {
     try j.pushLocalFrame(4);

--- a/packages/zig/src/bridge_android_locationstore.zig
+++ b/packages/zig/src/bridge_android_locationstore.zig
@@ -1,12 +1,26 @@
-//! `getLocationRecordingState` and `readLocationRecording` on Android.
+//! The location-recording actions on Android: the two reads and the four
+//! controls.
 //!
-//! Both are the *read* side of `CraftLocationRecordingStore`, which a
-//! foreground service writes while a recording runs. Neither starts, stops or
-//! samples anything — those need the service, and the service needs a
-//! `LocationCallback`, which is a Java interface Zig cannot implement.
+//! `CraftLocationRecordingStore` is a preferences file and a JSONL file, and
+//! everything here is one or both of those — plus, for two of the controls, a
+//! foreground service that has to be started or stopped.
 //!
-//! So this migrates the half that is a file and a preferences read, and leaves
-//! the half that is a service alone.
+//! What stays with the shim is the *sampling*: the service holds a
+//! `LocationCallback`, a Java interface Zig cannot implement. So Zig owns the
+//! record of a recording and Kotlin owns the thing that fills it.
+//!
+//! ## The service Intent is built by Kotlin
+//!
+//! `Intent(activity, LocationRecordingService::class.java)` names a class
+//! whose package is `{{PACKAGE_NAME}}` — templated per app, so `FindClass`
+//! here has no name to look up. Zig could assemble one from
+//! `getPackageName()`, and that is the same trap the widget broadcast action
+//! sits in: an `applicationIdSuffix` moves the runtime package and leaves the
+//! class where it was.
+//!
+//! So `CraftNative` starts and stops the service with its own class
+//! reference, the way it passes its own broadcast constant across. One side
+//! decides.
 //!
 //! ## Both return a String rather than answering through the channel
 //!
@@ -45,6 +59,10 @@ const jobject = jni.jobject;
 pub const A = struct {
     pub const get_location_recording_state = "getLocationRecordingState";
     pub const read_location_recording = "readLocationRecording";
+    pub const start_location_recording = "startLocationRecording";
+    pub const stop_location_recording = "stopLocationRecording";
+    pub const pause_location_recording = "pauseLocationRecording";
+    pub const resume_location_recording = "resumeLocationRecording";
 };
 
 /// `CraftLocationRecordingStore.PREFS` and `FILE`.
@@ -71,6 +89,19 @@ pub const State = struct {
 /// function with a test rather than a format string: a missing `id` has no
 /// key at all, and a missing `startedAt` is present and null.
 pub fn renderState(allocator: std.mem.Allocator, state: State) ![]u8 {
+    return renderStateWith(allocator, state, null);
+}
+
+/// The same, with `includeLocations = true`.
+///
+/// `stopLocationRecording` is the only caller that asks for it, and it asks
+/// *before* stopping the service — so the array it returns is the recording
+/// as it stood at the moment of the call.
+pub fn renderStateWith(
+    allocator: std.mem.Allocator,
+    state: State,
+    locations_json: ?[]const u8,
+) ![]u8 {
     var out: std.ArrayListUnmanaged(u8) = .empty;
     errdefer out.deinit(allocator);
 
@@ -92,8 +123,28 @@ pub fn renderState(allocator: std.mem.Allocator, state: State) ![]u8 {
         try out.appendSlice(allocator, "null");
     }
 
-    try out.print(allocator, ",\"sampleCount\":{d}}}", .{state.sample_count});
+    try out.print(allocator, ",\"sampleCount\":{d}", .{state.sample_count});
+    if (locations_json) |locations| {
+        try out.appendSlice(allocator, ",\"locations\":");
+        try out.appendSlice(allocator, locations);
+    }
+    try out.append(allocator, '}');
     return out.toOwnedSlice(allocator);
+}
+
+/// What `startLocationRecording` returns when the permission is not granted.
+///
+/// Not `renderState` with everything empty, and the difference is the point:
+/// this path builds a fresh `JSONObject` with `put("id", JSONObject.NULL)`, an
+/// **explicit** null whose key stays — while `state()` uses
+/// `put("id", getString("id", null))`, a Kotlin null that *removes* the key.
+///
+/// So "permission denied" and "never recorded" are two different objects, and
+/// a page can tell them apart only by whether `id` is present at all.
+pub fn renderDenied(allocator: std.mem.Allocator) ![]u8 {
+    return allocator.dupe(u8,
+        \\{"id":null,"active":false,"paused":false,"startedAt":null,"sampleCount":0}
+    );
 }
 
 /// The array and how many samples are in it.
@@ -145,17 +196,8 @@ pub fn readFile(j: Jni, allocator: std.mem.Allocator, activity: jobject) ![]u8 {
     try j.pushLocalFrame(16);
     defer _ = j.popLocalFrame(null);
 
-    const files_dir = try j.callObjectMethod(
-        activity,
-        try j.methodId(try j.objectClass(activity), "getFilesDir", "()Ljava/io/File;"),
-    );
-
-    const file_cls = try j.findClass("java/io/File");
-    const file = try j.newObjectA(
-        file_cls,
-        try j.methodId(file_cls, "<init>", "(Ljava/io/File;Ljava/lang/String;)V"),
-        &.{ .{ .l = files_dir }, .{ .l = try j.newStringUtf(file_name) } },
-    );
+    const file = try recordingFile(j, activity);
+    const file_cls = try j.objectClass(file);
 
     // `if (!source.exists()) return result` — an empty array rather than an
     // error, because a recording that never started has no file.
@@ -213,6 +255,132 @@ pub fn readState(
         .started_at = if (started_at > 0) started_at else null,
         .sample_count = sample_count,
     };
+}
+
+/// `CraftLocationRecordingStore.start(context, id, startedAt)`.
+///
+/// Truncates the sample file first, as the store does — a new recording does
+/// not inherit the last one's points. Opening a `FileOutputStream` without the
+/// append flag is `writeText("")`: it creates or truncates and writes nothing.
+pub fn startStore(
+    j: Jni,
+    allocator: std.mem.Allocator,
+    activity: jobject,
+    id: []const u8,
+    started_at: i64,
+) !void {
+    try j.pushLocalFrame(24);
+    defer _ = j.popLocalFrame(null);
+
+    try truncateFile(j, activity);
+
+    const prefs = try prefs_api.open(j, allocator, activity, prefs_name);
+    const editor = try prefs_api.edit(j, prefs);
+    try prefs_api.putString(j, allocator, editor, "id", id);
+    try prefs_api.putBoolean(j, allocator, editor, "active", true);
+    try prefs_api.putBoolean(j, allocator, editor, "paused", false);
+    try prefs_api.putLong(j, allocator, editor, "startedAt", started_at);
+    try prefs_api.apply(j, editor);
+}
+
+/// `CraftLocationRecordingStore.setPaused(context, paused)`.
+pub fn setPaused(j: Jni, allocator: std.mem.Allocator, activity: jobject, paused: bool) !void {
+    try j.pushLocalFrame(16);
+    defer _ = j.popLocalFrame(null);
+
+    const prefs = try prefs_api.open(j, allocator, activity, prefs_name);
+    const editor = try prefs_api.edit(j, prefs);
+    try prefs_api.putBoolean(j, allocator, editor, "paused", paused);
+    try prefs_api.apply(j, editor);
+}
+
+/// `CraftLocationRecordingStore.stop(context)`.
+///
+/// Clears `paused` as well as `active`, so a recording stopped while paused
+/// does not come back paused. The sample file is left alone — `stop` is what
+/// makes the points readable, not what discards them.
+pub fn stopStore(j: Jni, allocator: std.mem.Allocator, activity: jobject) !void {
+    try j.pushLocalFrame(16);
+    defer _ = j.popLocalFrame(null);
+
+    const prefs = try prefs_api.open(j, allocator, activity, prefs_name);
+    const editor = try prefs_api.edit(j, prefs);
+    try prefs_api.putBoolean(j, allocator, editor, "active", false);
+    try prefs_api.putBoolean(j, allocator, editor, "paused", false);
+    try prefs_api.apply(j, editor);
+}
+
+/// `UUID.randomUUID().toString()`.
+///
+/// Through Java rather than from a Zig random source: the id is the shim's to
+/// define, and `UUID.toString` is a specific hyphenated format a page may well
+/// be matching on.
+pub fn newRecordingId(j: Jni, allocator: std.mem.Allocator) ![]u8 {
+    try j.pushLocalFrame(8);
+    defer _ = j.popLocalFrame(null);
+
+    const uuid_cls = try j.findClass("java/util/UUID");
+    const uuid = try j.callStaticObjectMethodA(
+        uuid_cls,
+        try j.staticMethodId(uuid_cls, "randomUUID", "()Ljava/util/UUID;"),
+        &.{},
+    );
+    const text = try j.callObjectMethod(
+        uuid,
+        try j.methodId(uuid_cls, "toString", "()Ljava/lang/String;"),
+    );
+    return j.stringToUtf8(allocator, text);
+}
+
+/// `System.currentTimeMillis()`.
+pub fn nowMillis(j: Jni) !i64 {
+    try j.pushLocalFrame(4);
+    defer _ = j.popLocalFrame(null);
+
+    const system_cls = try j.findClass("java/lang/System");
+    return j.callStaticLongMethodA(
+        system_cls,
+        try j.staticMethodId(system_cls, "currentTimeMillis", "()J"),
+        &.{},
+    );
+}
+
+/// `prefs.getBoolean("active", false)` — what `resumeLocationRecording` asks
+/// before restarting the service.
+pub fn isActive(j: Jni, allocator: std.mem.Allocator, activity: jobject) !bool {
+    try j.pushLocalFrame(8);
+    defer _ = j.popLocalFrame(null);
+
+    const prefs = try prefs_api.open(j, allocator, activity, prefs_name);
+    return prefs_api.getBoolean(j, allocator, prefs, "active", false);
+}
+
+fn recordingFile(j: Jni, activity: jobject) !jobject {
+    const files_dir = try j.callObjectMethod(
+        activity,
+        try j.methodId(try j.objectClass(activity), "getFilesDir", "()Ljava/io/File;"),
+    );
+
+    const file_cls = try j.findClass("java/io/File");
+    return j.newObjectA(
+        file_cls,
+        try j.methodId(file_cls, "<init>", "(Ljava/io/File;Ljava/lang/String;)V"),
+        &.{ .{ .l = files_dir }, .{ .l = try j.newStringUtf(file_name) } },
+    );
+}
+
+fn truncateFile(j: Jni, activity: jobject) !void {
+    try j.pushLocalFrame(8);
+    defer _ = j.popLocalFrame(null);
+
+    const file = try recordingFile(j, activity);
+    const stream_cls = try j.findClass("java/io/FileOutputStream");
+    const stream = try j.newObjectA(
+        stream_cls,
+        try j.methodId(stream_cls, "<init>", "(Ljava/io/File;)V"),
+        &.{.{ .l = file }},
+    );
+    try j.callVoidMethodA(stream, try j.methodId(stream_cls, "close", "()V"), &.{});
 }
 
 // =============================================================================
@@ -352,4 +520,89 @@ test "the store's names are the ones the service writes" {
 test "the actions match the shim exactly" {
     try testing.expectEqualStrings("getLocationRecordingState", A.get_location_recording_state);
     try testing.expectEqualStrings("readLocationRecording", A.read_location_recording);
+}
+
+// --- the controls ----------------------------------------------------------
+
+test "permission denied is a different object from never having recorded" {
+    // The one place these two shapes differ, and the reason `renderDenied` is
+    // its own function: the denied path builds a fresh JSONObject with
+    // `put("id", JSONObject.NULL)` — an explicit null whose key stays — while
+    // `state()` uses `put("id", getString("id", null))`, a Kotlin null that
+    // removes the key. A page can only tell them apart by whether `id` is
+    // there at all.
+    const denied = try renderDenied(testing.allocator);
+    defer testing.allocator.free(denied);
+
+    const never = try renderState(testing.allocator, .{
+        .id = null,
+        .active = false,
+        .paused = false,
+        .started_at = null,
+        .sample_count = 0,
+    });
+    defer testing.allocator.free(never);
+
+    try testing.expectEqualStrings(
+        \\{"id":null,"active":false,"paused":false,"startedAt":null,"sampleCount":0}
+    , denied);
+    try testing.expectEqualStrings(
+        \\{"active":false,"paused":false,"startedAt":null,"sampleCount":0}
+    , never);
+
+    // Everything else about them agrees, which is what makes the one
+    // difference easy to lose.
+    try testing.expect(!std.mem.eql(u8, denied, never));
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, denied, .{});
+    defer parsed.deinit();
+    try testing.expect(parsed.value.object.get("id").? == .null);
+}
+
+test "only stopLocationRecording asks for the locations" {
+    // `state(context, includeLocations = false)` everywhere else, so the key
+    // is absent rather than empty — a page reading `locations` on a pause
+    // reply gets undefined, not [].
+    const without = try renderStateWith(testing.allocator, .{
+        .id = "run-7",
+        .active = true,
+        .paused = false,
+        .started_at = 1,
+        .sample_count = 2,
+    }, null);
+    defer testing.allocator.free(without);
+    try testing.expect(std.mem.indexOf(u8, without, "locations") == null);
+
+    const with = try renderStateWith(testing.allocator, .{
+        .id = "run-7",
+        .active = false,
+        .paused = false,
+        .started_at = 1,
+        .sample_count = 2,
+    }, "[{\"a\":1},{\"b\":2}]");
+    defer testing.allocator.free(with);
+
+    try testing.expectEqualStrings(
+        \\{"id":"run-7","active":false,"paused":false,"startedAt":1,"sampleCount":2,"locations":[{"a":1},{"b":2}]}
+    , with);
+
+    // `locations` comes last, after `sampleCount`, because the store's
+    // `if (includeLocations) put(...)` runs after every other put.
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, with, .{});
+    defer parsed.deinit();
+    try testing.expectEqual(
+        @as(i64, 2),
+        parsed.value.object.get("sampleCount").?.integer,
+    );
+    try testing.expectEqual(
+        @as(usize, 2),
+        parsed.value.object.get("locations").?.array.items.len,
+    );
+}
+
+test "the four controls name themselves as the shim does" {
+    try testing.expectEqualStrings("startLocationRecording", A.start_location_recording);
+    try testing.expectEqualStrings("stopLocationRecording", A.stop_location_recording);
+    try testing.expectEqualStrings("pauseLocationRecording", A.pause_location_recording);
+    try testing.expectEqualStrings("resumeLocationRecording", A.resume_location_recording);
 }

--- a/packages/zig/test/android_conformance_test.zig
+++ b/packages/zig/test/android_conformance_test.zig
@@ -86,8 +86,9 @@ const zig_sources = [_][]const u8{
 /// setKeepAwake, whose Kotlin field turns out to be written and never read;
 /// 67 with downloadFile and saveFile, neither of which needed the main thread
 /// at all; 65 with the recording store's two reads, whose writers stay with
-/// the service that owns them.
-const max_not_yet_migrated: usize = 65;
+/// the service that owns them; 61 with the four controls, once Kotlin agreed
+/// to name its own service class.
+const max_not_yet_migrated: usize = 61;
 
 /// Every `@JavascriptInterface fun <name>(` in the Kotlin bridge.
 ///


### PR DESCRIPTION
The other half of the store. #177 took the two reads; these four are the writes — a preferences edit, sometimes a file truncation, and for two of them a foreground service to start or stop.

What stays with the shim is the **sampling**: the service holds a `LocationCallback`, a Java interface Zig cannot implement. So Zig owns the record of a recording and Kotlin owns the thing that fills it.

## Permission denied is a different object from never having recorded

`startLocationRecording`'s denied path builds a fresh `JSONObject`:

```kotlin
put("id", JSONObject.NULL)   // explicit null — the key STAYS
```

Every other reply goes through `state()`:

```kotlin
put("id", values.getString("id", null))   // Kotlin null — the key is REMOVED
```

So the two objects differ in exactly one way, and a page can only tell *"you did not grant location"* from *"nothing has ever been recorded"* by whether `id` is present at all.

Reproduced, with both shapes asserted side by side in one test — everything else about them agrees, which is what makes the one difference easy to lose. The mutation that collapses `renderDenied` into the `state()` shape fails that test.

## The service Intent is built by Kotlin

`LocationRecordingService::class.java` names a class whose package is `{{PACKAGE_NAME}}` — templated per app, so `FindClass` on the native side has no name to look up.

Zig could assemble one from `getPackageName()`. That is the trap the widget broadcast action already documents (#167): an `applicationIdSuffix` moves the runtime package and leaves the class where it was. So `CraftNative.startRecordingService` / `stopRecordingService` do it with their own class reference, and one side decides.

## Declining after a write is safe here

`stopLocationRecording` writes the store, reads the state, then stops the service. If the read declines, Zig returns null and the shim runs the whole method — which is correct precisely because `stop` is idempotent, so the service still gets stopped by the half that took over. Worth stating, because "declined after a side effect" is normally the dangerous case.

## Also

`UUID.randomUUID().toString()` goes through Java: the id is the shim's to define, and `UUID.toString` is a specific hyphenated format a page may be matching on. `locations` is emitted last and only for `stopLocationRecording`, because the store's `if (includeLocations) put(...)` runs after every other put — so a pause reply has no `locations` key rather than an empty one.

## Testing

`zig build test:android` passes with the ratchet at 61. Both `libcraft.so` targets still build with no NDK.