### PR TITLE
feat(android): the first listener shim, and network monitoring on it — 61 → 59

### DIFF
--- a/packages/android/templates/CraftBridge.kt.template
+++ b/packages/android/templates/CraftBridge.kt.template
@@ -1962,6 +1962,12 @@ class CraftBridge(
 
     @JavascriptInterface
     fun startNetworkMonitoring() {
+        // The callback object is CraftNative's, because JNI cannot subclass
+        // an abstract Java class — what Zig owns is what happens when it
+        // fires. Returning here keeps this file's networkCallback null, which
+        // is why stopNetworkMonitoring has to reach the same way.
+        if (CraftNative.startNetworkMonitoring(activity)) return
+
         val connectivityManager = activity.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
 
         networkCallback = object : ConnectivityManager.NetworkCallback() {
@@ -1987,6 +1993,8 @@ class CraftBridge(
 
     @JavascriptInterface
     fun stopNetworkMonitoring() {
+        if (CraftNative.stopNetworkMonitoring(activity)) return
+
         val connectivityManager = activity.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
         networkCallback?.let {
             connectivityManager.unregisterNetworkCallback(it)

--- a/packages/android/templates/CraftNative.kt.template
+++ b/packages/android/templates/CraftNative.kt.template
@@ -1,6 +1,11 @@
 package com.craft.runtime
 
 import android.app.Activity
+import android.net.NetworkRequest
+import android.net.NetworkCapabilities
+import android.net.Network
+import android.net.ConnectivityManager
+import android.content.Context
 import androidx.core.content.ContextCompat
 import android.content.Intent
 import android.os.Handler
@@ -139,6 +144,9 @@ object CraftNative {
     private external fun nativeStopLocationRecording(activity: Activity): String?
     private external fun nativePauseLocationRecording(activity: Activity): String?
     private external fun nativeResumeLocationRecording(activity: Activity): String?
+    private external fun nativeNetworkChanged(activity: Activity)
+    private external fun nativeStartNetworkMonitoring(activity: Activity): Boolean
+    private external fun nativeStopNetworkMonitoring(activity: Activity): Boolean
 
     /**
      * `getDeviceInfo`, or null to use the Kotlin implementation.
@@ -746,5 +754,98 @@ object CraftNative {
             Intent(activity, LocationRecordingService::class.java)
                 .setAction(LocationRecordingService.ACTION_STOP)
         )
+    }
+
+    // ==================== Network monitoring ====================
+    //
+    // The first listener shim. `ConnectivityManager.NetworkCallback` is an
+    // abstract Java class, and JNI cannot subclass one — `RegisterNatives`
+    // binds methods onto a class that already exists in the APK, so a native
+    // can be *called* from Java but cannot be a Java object of a type the
+    // framework demands.
+    //
+    // The split is the one `runOnMain` uses: the object lives here, the work
+    // lives in Zig. This class holds the callback and the registration; every
+    // override forwards to `nativeNetworkChanged`, which reads the status and
+    // sends the event.
+    //
+    // Unlike `runOnMain` there is no token, because there is only ever one
+    // watch — which is also true of the CraftBridge field this replaces, and
+    // is the reason both of them leak a second one (see the note on start).
+
+    private var networkWatch: ConnectivityManager.NetworkCallback? = null
+
+    /**
+     * Register a network callback, exactly as `CraftBridge` would.
+     *
+     * Including the part that is wrong: a second call registers a second
+     * callback and overwrites the reference to the first, which then runs
+     * until the process dies and can never be unregistered. That is the
+     * shim's behaviour and is reproduced rather than guarded, because guarding
+     * would mean a page calling start twice gets one event per change here and
+     * two on the Kotlin path.
+     */
+    @JvmStatic
+    fun startNetworkWatch(activity: Activity) {
+        val manager =
+            activity.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+        val watch = object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) = changed(activity)
+            override fun onLost(network: Network) = changed(activity)
+            override fun onCapabilitiesChanged(
+                network: Network,
+                networkCapabilities: NetworkCapabilities
+            ) = changed(activity)
+        }
+
+        val request = NetworkRequest.Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .build()
+
+        manager.registerNetworkCallback(request, watch)
+        networkWatch = watch
+    }
+
+    @JvmStatic
+    fun stopNetworkWatch(activity: Activity) {
+        val manager =
+            activity.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        networkWatch?.let { manager.unregisterNetworkCallback(it) }
+        networkWatch = null
+    }
+
+    /**
+     * Every override lands here.
+     *
+     * This runs on a Binder thread, not the main one — which is fine, because
+     * the reply channel attaches the thread it is called on and hops to the
+     * main looper itself.
+     */
+    private fun changed(activity: Activity) {
+        try {
+            nativeNetworkChanged(activity)
+        } catch (e: UnsatisfiedLinkError) {
+            // The library went away. There is no promise waiting on this and
+            // nothing to retry.
+        }
+    }
+
+    fun startNetworkMonitoring(activity: Activity): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeStartNetworkMonitoring(activity)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    fun stopNetworkMonitoring(activity: Activity): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeStopNetworkMonitoring(activity)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
     }
 }

--- a/packages/zig/src/android_dispatch.zig
+++ b/packages/zig/src/android_dispatch.zig
@@ -391,6 +391,22 @@ const natives = [_]jni.JNINativeMethod{
         .signature = "(Landroid/app/Activity;)Ljava/lang/String;",
         .fnPtr = @ptrCast(&nativeResumeLocationRecording),
     },
+    // Not an action: the other end of the network callback the holder owns.
+    .{
+        .name = "nativeNetworkChanged",
+        .signature = "(Landroid/app/Activity;)V",
+        .fnPtr = @ptrCast(&nativeNetworkChanged),
+    },
+    .{
+        .name = "nativeStartNetworkMonitoring",
+        .signature = "(Landroid/app/Activity;)Z",
+        .fnPtr = @ptrCast(&nativeStartNetworkMonitoring),
+    },
+    .{
+        .name = "nativeStopNetworkMonitoring",
+        .signature = "(Landroid/app/Activity;)Z",
+        .fnPtr = @ptrCast(&nativeStopNetworkMonitoring),
+    },
 };
 
 /// How binding went. A value rather than a log line, so every path is
@@ -1676,25 +1692,86 @@ fn nativeResumeLocationRecording(
 }
 
 fn startRecordingService(j: Jni, activity: jni.jobject) !void {
-    try j.pushLocalFrame(8);
-    defer _ = j.popLocalFrame(null);
-
-    const holder = try j.findClass(holder_class);
-    try j.callStaticVoidMethodA(
-        holder,
-        try j.staticMethodId(holder, "startRecordingService", "(Landroid/app/Activity;)V"),
-        &.{.{ .l = activity }},
-    );
+    return callHolderVoid(j, "startRecordingService", activity);
 }
 
 fn stopRecordingService(j: Jni, activity: jni.jobject) !void {
+    return callHolderVoid(j, "stopRecordingService", activity);
+}
+
+/// `nativeNetworkChanged(activity)` — a network callback, arrived at.
+///
+/// Runs on a Binder thread. That is fine and is the reason the reply channel
+/// exists in the shape it does: `events.settle` attaches whatever thread it is
+/// called on and the Kotlin deliverer hops to the main looper.
+///
+/// Void and silent. There is no promise waiting on this — the page registered
+/// a callback with `onNetworkChange` and every change calls it — so a failure
+/// has nowhere to be reported and shows up in `droppedCount` instead.
+fn nativeNetworkChanged(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+) callconv(.c) void {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const status = network.read(j, activity) catch return;
+    const json = network.render(allocator, status) catch return;
+    events.settle(allocator, network.change_global, json) catch {};
+}
+
+/// `nativeStartNetworkMonitoring(activity)`.
+///
+/// The callback object is the holder's, because
+/// `ConnectivityManager.NetworkCallback` is an abstract Java class and JNI
+/// cannot subclass one. What Zig owns is what happens when it fires.
+fn nativeStartNetworkMonitoring(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+
+    callHolderVoid(j, "startNetworkWatch", activity) catch |err| {
+        std.log.warn("craft: startNetworkMonitoring fell through to the shim ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+    return jni.JNI_TRUE;
+}
+
+/// `nativeStopNetworkMonitoring(activity)`.
+///
+/// A false here after a successful start would leave the callback registered:
+/// the shim's own `networkCallback` field is null, so its stop finds nothing
+/// to unregister. The holder's stop is the only thing that can undo the
+/// holder's start, which is why this reports the JNI failure rather than
+/// pretending the shim can finish the job.
+fn nativeStopNetworkMonitoring(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+
+    callHolderVoid(j, "stopNetworkWatch", activity) catch |err| {
+        std.log.warn("craft: stopNetworkMonitoring failed ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+    return jni.JNI_TRUE;
+}
+
+/// Call a `(Activity) -> void` static on the holder.
+fn callHolderVoid(j: Jni, comptime name: [:0]const u8, activity: jni.jobject) !void {
     try j.pushLocalFrame(8);
     defer _ = j.popLocalFrame(null);
 
     const holder = try j.findClass(holder_class);
     try j.callStaticVoidMethodA(
         holder,
-        try j.staticMethodId(holder, "stopRecordingService", "(Landroid/app/Activity;)V"),
+        try j.staticMethodId(holder, name, "(Landroid/app/Activity;)V"),
         &.{.{ .l = activity }},
     );
 }
@@ -1810,7 +1887,7 @@ test "the registered natives name methods the Kotlin actually declares" {
     // A descriptor is checked by the JVM at registration, so a wrong one fails
     // at load rather than at call — but only if the *name* matches something.
     // These two strings are the contract with CraftBridge.kt.
-    try testing.expectEqual(@as(usize, 43), natives.len);
+    try testing.expectEqual(@as(usize, 46), natives.len);
     try testing.expectEqualStrings("nativeGetDeviceInfo", std.mem.span(natives[0].name));
 
     // And the class they bind to is the fixed one, not the templated bridge.

--- a/packages/zig/src/bridge_android_network.zig
+++ b/packages/zig/src/bridge_android_network.zig
@@ -38,7 +38,17 @@ const jobject = jni.jobject;
 
 pub const A = struct {
     pub const get_network_status = "getNetworkStatus";
+    pub const start_network_monitoring = "startNetworkMonitoring";
+    pub const stop_network_monitoring = "stopNetworkMonitoring";
 };
+
+/// The global the injected JS assigns for network changes.
+///
+/// Not a promise: `onNetworkChange(cb)` stores the callback once and every
+/// change calls it, so this global outlives any single reply — which is why
+/// the guard in front of it matters more here than elsewhere. A change
+/// arriving before the page has registered is dropped rather than throwing.
+pub const change_global = "_craftNetworkChangeCallback";
 
 /// The transports the Kotlin's `when` distinguishes, in its order.
 ///
@@ -151,6 +161,14 @@ pub fn read(j: Jni, activity: jobject) !NetworkStatus {
     // interface, an emulator. See the module comment: this is a real state.
     return .{ .connected = true, .transport = .none };
 }
+
+/// `NetworkCapabilities.NET_CAPABILITY_INTERNET`, the one capability the
+/// shim's `NetworkRequest` asks for.
+///
+/// Written down rather than read, because it is the Kotlin holder that builds
+/// the request — this constant is here only so the test can say what the
+/// holder is expected to have asked for.
+pub const net_capability_internet: i32 = 12;
 
 // =============================================================================
 // Tests
@@ -350,4 +368,31 @@ test "null capabilities is not connected, and an unknown transport still is" {
     const odd = try readWith(&.{}, false);
     try testing.expectEqual(true, odd.connected);
     try testing.expectEqual(Transport.none, odd.transport);
+}
+
+test "the monitoring pair names itself as the shim does" {
+    try testing.expectEqualStrings("startNetworkMonitoring", A.start_network_monitoring);
+    try testing.expectEqualStrings("stopNetworkMonitoring", A.stop_network_monitoring);
+}
+
+test "a change is delivered to the callback the page registered, not a promise" {
+    // `onNetworkChange(cb)` assigns this once and every change calls it. A
+    // promise global is assigned per call and consumed; this one is not, so a
+    // page that never called `onNetworkChange` leaves it undefined and the
+    // guard in `settle` is what stops a ReferenceError inside
+    // evaluateJavascript, where nothing would see it.
+    try testing.expectEqualStrings("_craftNetworkChangeCallback", change_global);
+    try testing.expect(!std.mem.eql(u8, change_global, "_craftNetworkResolve"));
+}
+
+test "a change carries the same object getNetworkStatus returns" {
+    // `sendNetworkChange` calls `getNetworkStatus()` and sends the result
+    // verbatim, so the event payload and the polled answer cannot drift —
+    // and here they are literally the same function.
+    const json = try render(testing.allocator, .{ .connected = true, .transport = .wifi });
+    defer testing.allocator.free(json);
+
+    try testing.expectEqualStrings(
+        \\{"isConnected":true,"type":"wifi","isWifi":true,"isCellular":false}
+    , json);
 }

--- a/packages/zig/test/android_conformance_test.zig
+++ b/packages/zig/test/android_conformance_test.zig
@@ -87,8 +87,10 @@ const zig_sources = [_][]const u8{
 /// 67 with downloadFile and saveFile, neither of which needed the main thread
 /// at all; 65 with the recording store's two reads, whose writers stay with
 /// the service that owns them; 61 with the four controls, once Kotlin agreed
-/// to name its own service class.
-const max_not_yet_migrated: usize = 61;
+/// to name its own service class; 59 with the network monitoring pair, the
+/// first listener shim — the callback object is the holder's, the work is
+/// Zig's.
+const max_not_yet_migrated: usize = 59;
 
 /// Every `@JavascriptInterface fun <name>(` in the Kotlin bridge.
 ///


### PR DESCRIPTION
`ConnectivityManager.NetworkCallback` is an abstract Java class, and JNI cannot subclass one — `RegisterNatives` binds methods onto a class that already exists in the APK, so a native can be *called* from Java but cannot be a Java object of a type the framework demands.

Same split as the reply channel and the main-thread trampoline: **the object lives in Kotlin, the work lives in Zig.** `CraftNative` holds the callback and the registration; every override forwards to `nativeNetworkChanged`, which reads the status and sends the event.

## What actually moves

Zig already served `getNetworkStatus`, and `sendNetworkChange` is `getNetworkStatus()` plus a delivery — so the event payload and the polled answer are now **literally the same function** rather than two implementations that have to agree.

The callback fires on a Binder thread, which needs nothing new: `events.settle` attaches whatever thread it is called on, and the Kotlin deliverer hops to the main looper. That is the reply channel earning its shape a second time.

## The leak is reproduced on purpose (#182)

A second `startNetworkMonitoring` registers a second callback and overwrites the reference to the first. The orphan keeps waking the app on every network change, can never be unregistered, and makes every change fire twice — and `stopNetworkMonitoring` only ever unregisters the most recent one.

`CraftNative.startNetworkWatch` does exactly the same. Guarding on the Zig path alone would mean a page calling start twice gets **one** event per change through Zig and **two** through Kotlin — a divergence visible only as a differing event count, which is worse than the bug being consistent. The comment at the seam says so, and #182 has the suggested fix.

This is the same shape as #179 (`watchPosition` orphaning its predecessor), which suggests the pattern rather than the instance is what wants fixing.

## And stop cannot decline

A `false` from stop after a successful start would leave the callback registered: the shim's own `networkCallback` field is null, so its stop finds nothing to unregister. The holder's stop is the only thing that can undo the holder's start, so the native reports the JNI failure rather than pretending the shim can finish the job.

## Not a general mechanism

Worth saying plainly, since I said the opposite was true of `runOnMain`: **this does not generalise.** Each Java interface needs its own Kotlin subclass, so this shim buys the network pair and nothing else. `SensorEventListener`, `RecognitionListener`, `LifecycleEventObserver`, `ScanCallback` and the rest each need their own — the pattern is now established, but the cost is per-family.

## Testing

`zig build test:android` passes with the ratchet at 59. The mutation fired: pointing the event at a promise-shaped global instead of `_craftNetworkChangeCallback` fails a named test. Both `libcraft.so` targets still build with no NDK.