### PR TITLE
feat(android): the app-state trio in Zig — ratchet 59 → 56

### DIFF
--- a/packages/android/templates/CraftBridge.kt.template
+++ b/packages/android/templates/CraftBridge.kt.template
@@ -2128,11 +2128,21 @@ class CraftBridge(
 
     @JavascriptInterface
     fun getAppState(): String {
+        // Null is "Zig declined". Otherwise this is the state Zig's observer
+        // has been maintaining, and currentAppState below is the one this
+        // file's observer maintains — whichever of the two is running.
+        CraftNative.getAppState()?.let { return it }
+
         return currentAppState
     }
 
     @JavascriptInterface
     fun startAppStateMonitoring() {
+        // The observer object is CraftNative's, and so is the state it
+        // maintains — which is why getAppState below has to reach the same
+        // way. All three move together or none of them can.
+        if (CraftNative.startAppStateMonitoring(activity)) return
+
         activity.runOnUiThread {
             ProcessLifecycleOwner.get().lifecycle.addObserver(appStateObserver)
         }
@@ -2140,6 +2150,8 @@ class CraftBridge(
 
     @JavascriptInterface
     fun stopAppStateMonitoring() {
+        if (CraftNative.stopAppStateMonitoring(activity)) return
+
         activity.runOnUiThread {
             ProcessLifecycleOwner.get().lifecycle.removeObserver(appStateObserver)
         }

--- a/packages/android/templates/CraftNative.kt.template
+++ b/packages/android/templates/CraftNative.kt.template
@@ -1,6 +1,8 @@
 package com.craft.runtime
 
 import android.app.Activity
+import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.lifecycle.LifecycleEventObserver
 import android.net.NetworkRequest
 import android.net.NetworkCapabilities
 import android.net.Network
@@ -147,6 +149,10 @@ object CraftNative {
     private external fun nativeNetworkChanged(activity: Activity)
     private external fun nativeStartNetworkMonitoring(activity: Activity): Boolean
     private external fun nativeStopNetworkMonitoring(activity: Activity): Boolean
+    private external fun nativeAppStateEvent(eventName: String)
+    private external fun nativeStartAppStateMonitoring(activity: Activity): Boolean
+    private external fun nativeStopAppStateMonitoring(activity: Activity): Boolean
+    private external fun nativeGetAppState(): String?
 
     /**
      * `getDeviceInfo`, or null to use the Kotlin implementation.
@@ -846,6 +852,69 @@ object CraftNative {
             nativeStopNetworkMonitoring(activity)
         } catch (e: UnsatisfiedLinkError) {
             false
+        }
+    }
+
+    // ==================== App state ====================
+    //
+    // The second listener shim. `LifecycleEventObserver` is a Java interface,
+    // so the object is here; the mapping, the state and the two deliveries are
+    // in Zig.
+    //
+    // One observer instance, added and removed — `LifecycleRegistry` keys its
+    // observers by identity, so adding twice is a no-op. That is why this one
+    // has no leak to reproduce, unlike the network watch.
+    //
+    // The native takes no Activity: everything it does is state and the reply
+    // channel, and neither needs one.
+
+    private val appStateObserver = LifecycleEventObserver { _, event ->
+        try {
+            nativeAppStateEvent(event.name)
+        } catch (e: UnsatisfiedLinkError) {
+            // The library went away. Nothing is waiting on this.
+        }
+    }
+
+    @JvmStatic
+    fun startAppStateWatch(activity: Activity) {
+        activity.runOnUiThread {
+            ProcessLifecycleOwner.get().lifecycle.addObserver(appStateObserver)
+        }
+    }
+
+    @JvmStatic
+    fun stopAppStateWatch(activity: Activity) {
+        activity.runOnUiThread {
+            ProcessLifecycleOwner.get().lifecycle.removeObserver(appStateObserver)
+        }
+    }
+
+    fun startAppStateMonitoring(activity: Activity): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeStartAppStateMonitoring(activity)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    fun stopAppStateMonitoring(activity: Activity): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeStopAppStateMonitoring(activity)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    /** Null is "Zig declined"; the state itself is never null. */
+    fun getAppState(): String? {
+        if (!isAvailable) return null
+        return try {
+            nativeGetAppState()
+        } catch (e: UnsatisfiedLinkError) {
+            null
         }
     }
 }

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -482,6 +482,9 @@ pub fn build(b: *std.Build) void {
     android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_locationstore.zig", .{
         .root_source_file = b.path("src/bridge_android_locationstore.zig"),
     });
+    android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_appstate.zig", .{
+        .root_source_file = b.path("src/bridge_android_appstate.zig"),
+    });
     const run_android_conformance_tests = b.addRunArtifact(android_conformance_tests);
 
     // The page surface, across both bridges. Not folded into the iOS

--- a/packages/zig/src/android_dispatch.zig
+++ b/packages/zig/src/android_dispatch.zig
@@ -42,6 +42,7 @@ const system = @import("bridge_android_system.zig");
 const clipboard = @import("bridge_android_clipboard.zig");
 const intents = @import("bridge_android_intents.zig");
 const network = @import("bridge_android_network.zig");
+const appstate = @import("bridge_android_appstate.zig");
 const securestore = @import("bridge_android_securestore.zig");
 const haptics = @import("bridge_android_haptics.zig");
 const notifications = @import("bridge_android_notifications.zig");
@@ -406,6 +407,29 @@ const natives = [_]jni.JNINativeMethod{
         .name = "nativeStopNetworkMonitoring",
         .signature = "(Landroid/app/Activity;)Z",
         .fnPtr = @ptrCast(&nativeStopNetworkMonitoring),
+    },
+    // Not an action: the other end of the lifecycle observer the holder owns.
+    // It takes no Activity, because everything it does is state and the reply
+    // channel — neither of which needs one.
+    .{
+        .name = "nativeAppStateEvent",
+        .signature = "(Ljava/lang/String;)V",
+        .fnPtr = @ptrCast(&nativeAppStateEvent),
+    },
+    .{
+        .name = "nativeStartAppStateMonitoring",
+        .signature = "(Landroid/app/Activity;)Z",
+        .fnPtr = @ptrCast(&nativeStartAppStateMonitoring),
+    },
+    .{
+        .name = "nativeStopAppStateMonitoring",
+        .signature = "(Landroid/app/Activity;)Z",
+        .fnPtr = @ptrCast(&nativeStopAppStateMonitoring),
+    },
+    .{
+        .name = "nativeGetAppState",
+        .signature = "()Ljava/lang/String;",
+        .fnPtr = @ptrCast(&nativeGetAppState),
     },
 };
 
@@ -1776,6 +1800,78 @@ fn callHolderVoid(j: Jni, comptime name: [:0]const u8, activity: jni.jobject) !v
     );
 }
 
+/// `nativeAppStateEvent(eventName)` — a lifecycle event, arrived at.
+///
+/// Runs on the main looper, where `ProcessLifecycleOwner` dispatches. Silent:
+/// there is no promise waiting, and a page that never registered a callback is
+/// the ordinary case rather than an error.
+fn nativeAppStateEvent(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    event_name: jni.jstring,
+) callconv(.c) void {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const name = j.stringToUtf8(allocator, event_name) catch return;
+
+    // Null covers both "this event carries no state" and "it carries the one
+    // already held", and the shim announces neither.
+    const changed = appstate.apply(name) orelse return;
+    appstate.announce(allocator, changed) catch {};
+}
+
+/// `nativeStartAppStateMonitoring(activity)`.
+///
+/// The observer is the holder's — `LifecycleEventObserver` is a Java interface
+/// — and adding it twice is a no-op, because `LifecycleRegistry` keys its
+/// observers by identity. The shim has the same property for the same reason,
+/// so unlike the network watch there is nothing to leak here.
+fn nativeStartAppStateMonitoring(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+
+    callHolderVoid(j, "startAppStateWatch", activity) catch |err| {
+        std.log.warn("craft: startAppStateMonitoring fell through to the shim ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+    return jni.JNI_TRUE;
+}
+
+/// `nativeStopAppStateMonitoring(activity)`.
+fn nativeStopAppStateMonitoring(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+
+    callHolderVoid(j, "stopAppStateWatch", activity) catch |err| {
+        std.log.warn("craft: stopAppStateMonitoring failed ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+    return jni.JNI_TRUE;
+}
+
+/// `nativeGetAppState()`.
+///
+/// Reads the state Zig now owns. This is why the trio moves together: the
+/// Kotlin's `currentAppState` is only written by the observer, so serving the
+/// observer without serving this would leave the field frozen at "active"
+/// while the real state moved on.
+fn nativeGetAppState(env: jni.JNIEnv, _: jni.jobject) callconv(.c) jni.jstring {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+
+    return j.newStringUtf8(arena.allocator(), appstate.state().name()) catch null;
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -1887,7 +1983,7 @@ test "the registered natives name methods the Kotlin actually declares" {
     // A descriptor is checked by the JVM at registration, so a wrong one fails
     // at load rather than at call — but only if the *name* matches something.
     // These two strings are the contract with CraftBridge.kt.
-    try testing.expectEqual(@as(usize, 46), natives.len);
+    try testing.expectEqual(@as(usize, 50), natives.len);
     try testing.expectEqualStrings("nativeGetDeviceInfo", std.mem.span(natives[0].name));
 
     // And the class they bind to is the fixed one, not the templated bridge.

--- a/packages/zig/src/bridge_android_appstate.zig
+++ b/packages/zig/src/bridge_android_appstate.zig
@@ -1,0 +1,237 @@
+//! `startAppStateMonitoring`, `stopAppStateMonitoring` and `getAppState`.
+//!
+//! The second listener shim, and the first migration that moves *state* rather
+//! than working around it.
+//!
+//! ## Why all three, or none
+//!
+//! `getAppState` returns `currentAppState`, a field only the lifecycle
+//! observer writes. Serving the observer from Zig without serving the getter
+//! would leave the Kotlin field frozen at its initial "active" while the real
+//! state moved — the exact failure the flashlight deferral describes, where
+//! one half writes a field the other half reads.
+//!
+//! So the state moves here, and all three actions come with it. That is what
+//! the flashlight row means by "migrating the pair together would need the
+//! state to move too": this is what it looks like when it can.
+//!
+//! Process-global, because `ProcessLifecycleOwner` is: one answer per process,
+//! not per Activity. Atomic, because the observer runs on the main looper and
+//! `getAppState` is called from the WebView's JavaBridge thread.
+//!
+//! ## Only a change is announced
+//!
+//! The observer compares against the current state and does nothing when they
+//! match. `ON_START` immediately after `ON_RESUME` is an ordinary sequence and
+//! both map to "active", so without that check a page would see two
+//! `craftAppStateChange` events for one foregrounding.
+//!
+//! ## Two deliveries, not one
+//!
+//! A change calls `window._craftAppStateCallback(state)` *and* dispatches
+//! `craftAppStateChange`. Both, in that order, because the shim does both —
+//! `onAppStateChange` reads the first and `addEventListener` the second, and a
+//! page may well use either.
+
+const std = @import("std");
+const events = @import("android_events.zig");
+const bridge_error = @import("bridge_error.zig");
+
+pub const A = struct {
+    pub const start_app_state_monitoring = "startAppStateMonitoring";
+    pub const stop_app_state_monitoring = "stopAppStateMonitoring";
+    pub const get_app_state = "getAppState";
+};
+
+/// The global `onAppStateChange` assigns, and the event name `sendEvent` uses.
+pub const callback_global = "_craftAppStateCallback";
+pub const event_name = "craftAppStateChange";
+
+pub const State = enum {
+    active,
+    inactive,
+    background,
+
+    pub fn name(self: State) []const u8 {
+        return switch (self) {
+            .active => "active",
+            .inactive => "inactive",
+            .background => "background",
+        };
+    }
+};
+
+/// The state a page sees before anything has happened.
+///
+/// `private var currentAppState = "active"` — so `getAppState` answers "active"
+/// even when monitoring was never started, and that is what a page gets today.
+const initial: State = .active;
+
+var current: std.atomic.Value(u8) = .init(@backingInt(initial));
+
+/// What the process currently believes.
+pub fn state() State {
+    return @fromBackingInt(@intCast(current.load(.acquire)));
+}
+
+/// Put the state back to its process start value.
+///
+/// For tests. Nothing in the bridge resets it, because nothing in a process
+/// un-launches the app.
+pub fn reset() void {
+    current.store(@backingInt(initial), .release);
+}
+
+/// `Lifecycle.Event` to a state, or null where the shim's `when` falls to
+/// `else` and keeps what it had.
+///
+/// The names are `Lifecycle.Event`'s own — the holder passes `event.name`
+/// rather than an ordinal, because an ordinal is a number that means nothing
+/// on its own and would move if the enum ever gained a member.
+pub fn stateFor(event: []const u8) ?State {
+    if (std.mem.eql(u8, event, "ON_START")) return .active;
+    if (std.mem.eql(u8, event, "ON_RESUME")) return .active;
+    if (std.mem.eql(u8, event, "ON_PAUSE")) return .inactive;
+    if (std.mem.eql(u8, event, "ON_STOP")) return .background;
+    return null;
+}
+
+/// Apply an event, and say whether it changed anything.
+///
+/// Null means "announce nothing" — either the event has no state (`ON_CREATE`,
+/// `ON_DESTROY`, `ON_ANY`) or it maps to the state already held.
+pub fn apply(event: []const u8) ?State {
+    const next = stateFor(event) orelse return null;
+    if (next == state()) return null;
+    current.store(@backingInt(next), .release);
+    return next;
+}
+
+/// `window._craftAppStateCallback("active")` — the payload, quoted.
+pub fn callbackPayload(allocator: std.mem.Allocator, value: State) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.append(allocator, '"');
+    try bridge_error.appendJsonEscaped(allocator, &out, value.name());
+    try out.append(allocator, '"');
+    return out.toOwnedSlice(allocator);
+}
+
+/// `{"state":"active"}` — the detail `sendEvent` builds.
+pub fn eventDetail(allocator: std.mem.Allocator, value: State) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.appendSlice(allocator, "{\"state\":\"");
+    try bridge_error.appendJsonEscaped(allocator, &out, value.name());
+    try out.appendSlice(allocator, "\"}");
+    return out.toOwnedSlice(allocator);
+}
+
+/// Announce a change, both ways the shim announces it.
+pub fn announce(allocator: std.mem.Allocator, value: State) !void {
+    const payload = try callbackPayload(allocator, value);
+    defer allocator.free(payload);
+    try events.settle(allocator, callback_global, payload);
+
+    const detail = try eventDetail(allocator, value);
+    defer allocator.free(detail);
+    try events.emitEvent(allocator, event_name, detail);
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+const testing = std.testing;
+
+test "every lifecycle event maps where the shim's when maps it" {
+    try testing.expectEqual(State.active, stateFor("ON_START").?);
+    try testing.expectEqual(State.active, stateFor("ON_RESUME").?);
+    try testing.expectEqual(State.inactive, stateFor("ON_PAUSE").?);
+    try testing.expectEqual(State.background, stateFor("ON_STOP").?);
+}
+
+test "an event with no state keeps the one already held" {
+    // The shim's `else -> currentAppState`. ON_CREATE and ON_DESTROY really do
+    // arrive, and ON_ANY is dispatched to observers registered for it.
+    try testing.expect(stateFor("ON_CREATE") == null);
+    try testing.expect(stateFor("ON_DESTROY") == null);
+    try testing.expect(stateFor("ON_ANY") == null);
+
+    // And anything unrecognised, which is what a future enum member would be.
+    try testing.expect(stateFor("") == null);
+    try testing.expect(stateFor("on_start") == null);
+}
+
+test "a process starts active, whether or not anything is monitoring" {
+    // `private var currentAppState = "active"`. A page calling getAppState
+    // before startAppStateMonitoring gets "active" rather than an error or an
+    // empty string, and that is the answer it gets today.
+    reset();
+    try testing.expectEqual(State.active, state());
+    try testing.expectEqualStrings("active", state().name());
+}
+
+test "only a change is announced" {
+    reset();
+
+    // Already active: ON_START and ON_RESUME are both no-ops, which is what
+    // stops one foregrounding producing two craftAppStateChange events.
+    try testing.expect(apply("ON_START") == null);
+    try testing.expect(apply("ON_RESUME") == null);
+
+    // A real change reports the new state and keeps it.
+    try testing.expectEqual(State.inactive, apply("ON_PAUSE").?);
+    try testing.expectEqual(State.inactive, state());
+
+    // The same event again changes nothing.
+    try testing.expect(apply("ON_PAUSE") == null);
+
+    // And on to background, then back.
+    try testing.expectEqual(State.background, apply("ON_STOP").?);
+    try testing.expectEqual(State.active, apply("ON_START").?);
+    reset();
+}
+
+test "an event with no state does not disturb the one held" {
+    reset();
+    _ = apply("ON_PAUSE");
+    try testing.expect(apply("ON_CREATE") == null);
+    try testing.expectEqual(State.inactive, state());
+    reset();
+}
+
+test "the two deliveries carry the same state in two shapes" {
+    // `_craftAppStateCallback("active")` and
+    // `dispatchEvent(new CustomEvent('craftAppStateChange', {detail: {"state":"active"}}))`
+    // — a bare string for the callback, an object for the event.
+    const payload = try callbackPayload(testing.allocator, .background);
+    defer testing.allocator.free(payload);
+    try testing.expectEqualStrings("\"background\"", payload);
+
+    const detail = try eventDetail(testing.allocator, .background);
+    defer testing.allocator.free(detail);
+    try testing.expectEqualStrings("{\"state\":\"background\"}", detail);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, detail, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("background", parsed.value.object.get("state").?.string);
+}
+
+test "the state names are the strings the page compares against" {
+    // A page writes `state === 'background'`, so these are API rather than
+    // internal spelling.
+    try testing.expectEqualStrings("active", State.active.name());
+    try testing.expectEqualStrings("inactive", State.inactive.name());
+    try testing.expectEqualStrings("background", State.background.name());
+}
+
+test "the actions and globals match the shim exactly" {
+    try testing.expectEqualStrings("startAppStateMonitoring", A.start_app_state_monitoring);
+    try testing.expectEqualStrings("stopAppStateMonitoring", A.stop_app_state_monitoring);
+    try testing.expectEqualStrings("getAppState", A.get_app_state);
+    try testing.expectEqualStrings("_craftAppStateCallback", callback_global);
+    try testing.expectEqualStrings("craftAppStateChange", event_name);
+}

--- a/packages/zig/test/android_conformance_test.zig
+++ b/packages/zig/test/android_conformance_test.zig
@@ -56,6 +56,7 @@ const zig_sources = [_][]const u8{
     @embedFile("src/bridge_android_screen.zig"),
     @embedFile("src/bridge_android_files.zig"),
     @embedFile("src/bridge_android_locationstore.zig"),
+    @embedFile("src/bridge_android_appstate.zig"),
 };
 
 /// How many spec actions Zig does not serve yet.
@@ -89,8 +90,9 @@ const zig_sources = [_][]const u8{
 /// the service that owns them; 61 with the four controls, once Kotlin agreed
 /// to name its own service class; 59 with the network monitoring pair, the
 /// first listener shim — the callback object is the holder's, the work is
-/// Zig's.
-const max_not_yet_migrated: usize = 59;
+/// Zig's; 56 with the app-state trio, the first migration where the state
+/// itself moved rather than being worked around.
+const max_not_yet_migrated: usize = 56;
 
 /// Every `@JavascriptInterface fun <name>(` in the Kotlin bridge.
 ///


### PR DESCRIPTION
The second listener shim, and the first migration where the **state itself moved** rather than being worked around.

## Why all three, or none

`getAppState` returns `currentAppState`, a field only the lifecycle observer writes. Serving the observer from Zig without serving the getter would leave the Kotlin field frozen at `"active"` while the real state moved on — the exact failure the flashlight deferral describes, where one half writes a field the other half reads.

So the state moves, and all three actions come with it. That deferral row says migrating the flashlight pair "would need the state to move too"; this is what it looks like when it can.

Process-global, because `ProcessLifecycleOwner` is — one answer per process, not per Activity. Atomic, because the observer runs on the main looper and `getAppState` is called from the WebView's JavaBridge thread.

## Only a change is announced

The observer compares before announcing, and that check is load-bearing: `ON_START` immediately after `ON_RESUME` is an ordinary sequence and **both map to "active"**, so without it a page would see two `craftAppStateChange` events for one foregrounding. The mutation that removes the comparison fails two tests.

## Two deliveries, not one

A change calls `window._craftAppStateCallback(state)` **and** dispatches `craftAppStateChange`. Both, in that order, because the shim does both — `onAppStateChange` reads the first and `addEventListener` the second, and a page may use either.

## No leak to reproduce this time

`LifecycleRegistry` keys its observers by identity, so adding the same one twice is a no-op. The holder keeps one instance and adds it, exactly as the shim does.

That is worth contrasting with #183: there the shim's second `startNetworkMonitoring` orphans the first callback, and Zig had to reproduce the leak (#182) because guarding on one path only would have changed the event count. Here there is nothing to reproduce, and the reason is a property of `LifecycleRegistry` rather than of either implementation.

## The event arrives by name

`event.name` rather than an ordinal — an ordinal is a number that means nothing on its own and would move if `Lifecycle.Event` ever gained a member. Everything the shim's `when` does not match falls to `else -> currentAppState`, which is a null here and announces nothing; `ON_CREATE`, `ON_DESTROY` and `ON_ANY` all take that path and have tests.

## Testing

`zig build test:android` passes with the ratchet at 56. Two mutations fired: removing the changed-check, and pointing `ON_PAUSE` at `background`. Both `libcraft.so` targets still build with no NDK.