### PR TITLE
feat(android): the Bluetooth scan pair in Zig — ratchet 56 → 54

### DIFF
--- a/packages/android/templates/CraftBridge.kt.template
+++ b/packages/android/templates/CraftBridge.kt.template
@@ -2993,6 +2993,11 @@ class CraftBridge(
 
     @JavascriptInterface
     fun startBluetoothScan() {
+        // The ScanCallback object is CraftNative's, and so are the scanner and
+        // callback fields — which is why stopBluetoothScan has to reach the
+        // same way, or its own fields stay null and stopScan is never called.
+        if (CraftNative.startBluetoothScan(activity)) return
+
         if (ContextCompat.checkSelfPermission(activity, Manifest.permission.BLUETOOTH_SCAN)
             != PackageManager.PERMISSION_GRANTED) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -3026,6 +3031,8 @@ class CraftBridge(
 
     @JavascriptInterface
     fun stopBluetoothScan() {
+        if (CraftNative.stopBluetoothScan(activity)) return
+
         bleScanCallback?.let { bluetoothScanner?.stopScan(it) }
         bleScanCallback = null
     }

--- a/packages/android/templates/CraftNative.kt.template
+++ b/packages/android/templates/CraftNative.kt.template
@@ -1,6 +1,12 @@
 package com.craft.runtime
 
 import android.app.Activity
+import androidx.core.app.ActivityCompat
+import android.os.Build
+import android.bluetooth.le.ScanResult
+import android.bluetooth.le.ScanCallback
+import android.bluetooth.le.BluetoothLeScanner
+import android.bluetooth.BluetoothManager
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.LifecycleEventObserver
 import android.net.NetworkRequest
@@ -153,6 +159,9 @@ object CraftNative {
     private external fun nativeStartAppStateMonitoring(activity: Activity): Boolean
     private external fun nativeStopAppStateMonitoring(activity: Activity): Boolean
     private external fun nativeGetAppState(): String?
+    private external fun nativeBluetoothDevice(address: String, name: String?, rssi: Int)
+    private external fun nativeStartBluetoothScan(activity: Activity): Boolean
+    private external fun nativeStopBluetoothScan(activity: Activity): Boolean
 
     /**
      * `getDeviceInfo`, or null to use the Kotlin implementation.
@@ -915,6 +924,97 @@ object CraftNative {
             nativeGetAppState()
         } catch (e: UnsatisfiedLinkError) {
             null
+        }
+    }
+
+    // ==================== Bluetooth scanning ====================
+    //
+    // The third listener shim. `ScanCallback` is an abstract Java class, so
+    // the object is here and every result forwards to Zig — with the device
+    // name still nullable, so the "Unknown" default stays one decision in one
+    // place rather than two that have to agree.
+
+    private var bleScanner: BluetoothLeScanner? = null
+    private var bleScanCallback: ScanCallback? = null
+
+    /**
+     * Start scanning, including the part that does nothing.
+     *
+     * `bleScanner` is null when the device has no adapter or Bluetooth is off,
+     * and the `?.` then skips the scan — while the caller resolves true
+     * regardless, exactly as `CraftBridge` does. Reproduced rather than
+     * guarded, because the reply is what a page acts on. See #185.
+     */
+    @JvmStatic
+    fun startBluetoothWatch(activity: Activity) {
+        val manager = activity.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
+        bleScanner = manager.adapter?.bluetoothLeScanner
+
+        val callback = object : ScanCallback() {
+            override fun onScanResult(callbackType: Int, result: ScanResult) {
+                try {
+                    nativeBluetoothDevice(
+                        result.device.address,
+                        result.device.name,
+                        result.rssi
+                    )
+                } catch (e: UnsatisfiedLinkError) {
+                    // The library went away. Nothing is waiting on this.
+                } catch (e: SecurityException) {
+                    // `device.name` needs BLUETOOTH_CONNECT on API 31+, which
+                    // this scan does not require. The shim would throw out of
+                    // the callback here; dropping the result is the smaller
+                    // difference, and it is the only one.
+                }
+            }
+        }
+
+        bleScanner?.startScan(callback)
+        bleScanCallback = callback
+    }
+
+    @JvmStatic
+    fun stopBluetoothWatch(activity: Activity) {
+        bleScanCallback?.let { bleScanner?.stopScan(it) }
+        bleScanCallback = null
+    }
+
+    /**
+     * Ask for BLUETOOTH_SCAN, but only where it exists.
+     *
+     * The permission arrived in API 31. Below that the shim does not ask at
+     * all — it rejects and leaves it — so the version check lives here, next
+     * to the call that would throw without it.
+     */
+    @JvmStatic
+    fun requestBluetoothScanPermission(activity: Activity) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            ActivityCompat.requestPermissions(
+                activity,
+                arrayOf(android.Manifest.permission.BLUETOOTH_SCAN),
+                REQUEST_BLUETOOTH
+            )
+        }
+    }
+
+    /** `CraftBridge.REQUEST_BLUETOOTH`, which this has to match. */
+    private const val REQUEST_BLUETOOTH = 1009
+
+    fun startBluetoothScan(activity: Activity): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeStartBluetoothScan(activity)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    fun stopBluetoothScan(activity: Activity): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeStopBluetoothScan(activity)
+        } catch (e: UnsatisfiedLinkError) {
+            false
         }
     }
 }

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -485,6 +485,9 @@ pub fn build(b: *std.Build) void {
     android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_appstate.zig", .{
         .root_source_file = b.path("src/bridge_android_appstate.zig"),
     });
+    android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_bluetooth.zig", .{
+        .root_source_file = b.path("src/bridge_android_bluetooth.zig"),
+    });
     const run_android_conformance_tests = b.addRunArtifact(android_conformance_tests);
 
     // The page surface, across both bridges. Not folded into the iOS

--- a/packages/zig/src/android_dispatch.zig
+++ b/packages/zig/src/android_dispatch.zig
@@ -43,6 +43,7 @@ const clipboard = @import("bridge_android_clipboard.zig");
 const intents = @import("bridge_android_intents.zig");
 const network = @import("bridge_android_network.zig");
 const appstate = @import("bridge_android_appstate.zig");
+const bluetooth = @import("bridge_android_bluetooth.zig");
 const securestore = @import("bridge_android_securestore.zig");
 const haptics = @import("bridge_android_haptics.zig");
 const notifications = @import("bridge_android_notifications.zig");
@@ -430,6 +431,23 @@ const natives = [_]jni.JNINativeMethod{
         .name = "nativeGetAppState",
         .signature = "()Ljava/lang/String;",
         .fnPtr = @ptrCast(&nativeGetAppState),
+    },
+    // Not an action: the other end of the ScanCallback the holder owns. The
+    // name arrives nullable, so the "Unknown" default stays a Zig decision.
+    .{
+        .name = "nativeBluetoothDevice",
+        .signature = "(Ljava/lang/String;Ljava/lang/String;I)V",
+        .fnPtr = @ptrCast(&nativeBluetoothDevice),
+    },
+    .{
+        .name = "nativeStartBluetoothScan",
+        .signature = "(Landroid/app/Activity;)Z",
+        .fnPtr = @ptrCast(&nativeStartBluetoothScan),
+    },
+    .{
+        .name = "nativeStopBluetoothScan",
+        .signature = "(Landroid/app/Activity;)Z",
+        .fnPtr = @ptrCast(&nativeStopBluetoothScan),
     },
 };
 
@@ -1872,6 +1890,91 @@ fn nativeGetAppState(env: jni.JNIEnv, _: jni.jobject) callconv(.c) jni.jstring {
     return j.newStringUtf8(arena.allocator(), appstate.state().name()) catch null;
 }
 
+/// `nativeBluetoothDevice(address, name, rssi)` — one scan result.
+fn nativeBluetoothDevice(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    address: jni.jstring,
+    name: jni.jstring,
+    rssi: jni.jint,
+) callconv(.c) void {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const address_text = j.stringToUtf8(allocator, address) catch return;
+
+    // Null is a device advertising no name, which is the common case rather
+    // than the edge one — `bluetooth.announce` applies the shim's "Unknown".
+    const name_text: ?[]const u8 = if (name == null)
+        null
+    else
+        j.stringToUtf8(allocator, name) catch return;
+
+    bluetooth.announce(allocator, address_text, name_text, rssi) catch {};
+}
+
+/// `nativeStartBluetoothScan(activity)`.
+///
+/// Resolves `true` whether or not a scan actually started, because the shim
+/// does: `bluetoothScanner?.startScan(...)` is skipped when there is no
+/// adapter or Bluetooth is off, and the resolve fires regardless. See #185.
+fn nativeStartBluetoothScan(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const granted = permissions.isGranted(j, activity, permissions.bluetooth_scan) catch |err| {
+        std.log.warn("craft: startBluetoothScan fell through to the shim ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+
+    if (!granted) {
+        // The shim only asks on API 31+, where the permission exists at all;
+        // the holder makes that check, because it is the one that knows how to
+        // ask without throwing on older releases.
+        callHolderVoid(j, "requestBluetoothScanPermission", activity) catch |err| {
+            std.log.warn("craft: startBluetoothScan fell through to the shim ({s})", .{@errorName(err)});
+            return jni.JNI_FALSE;
+        };
+        calendar.rejectOn(allocator, bluetooth.reject_global, "Permission denied") catch {};
+        return jni.JNI_TRUE;
+    }
+
+    callHolderVoid(j, "startBluetoothWatch", activity) catch |err| {
+        std.log.warn("craft: startBluetoothScan fell through to the shim ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+
+    events.settle(allocator, bluetooth.resolve_global, "true") catch return jni.JNI_FALSE;
+    return jni.JNI_TRUE;
+}
+
+/// `nativeStopBluetoothScan(activity)`.
+///
+/// Cannot decline after a successful start, for the reason the network watch
+/// cannot: the shim's own `bleScanCallback` is null, so its stop finds nothing
+/// to hand to `stopScan`.
+fn nativeStopBluetoothScan(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+
+    callHolderVoid(j, "stopBluetoothWatch", activity) catch |err| {
+        std.log.warn("craft: stopBluetoothScan failed ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+    return jni.JNI_TRUE;
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -1983,7 +2086,7 @@ test "the registered natives name methods the Kotlin actually declares" {
     // A descriptor is checked by the JVM at registration, so a wrong one fails
     // at load rather than at call — but only if the *name* matches something.
     // These two strings are the contract with CraftBridge.kt.
-    try testing.expectEqual(@as(usize, 50), natives.len);
+    try testing.expectEqual(@as(usize, 53), natives.len);
     try testing.expectEqualStrings("nativeGetDeviceInfo", std.mem.span(natives[0].name));
 
     // And the class they bind to is the fixed one, not the templated bridge.

--- a/packages/zig/src/android_permissions.zig
+++ b/packages/zig/src/android_permissions.zig
@@ -42,6 +42,10 @@ pub const read_contacts = "android.permission.READ_CONTACTS";
 pub const write_contacts = "android.permission.WRITE_CONTACTS";
 pub const access_fine_location = "android.permission.ACCESS_FINE_LOCATION";
 
+/// API 31 and later only — see `CraftNative.requestBluetoothScanPermission`,
+/// which is where the version check lives.
+pub const bluetooth_scan = "android.permission.BLUETOOTH_SCAN";
+
 /// `activity.checkSelfPermission(permission) == PERMISSION_GRANTED`.
 pub fn isGranted(j: Jni, activity: jobject, permission: [*:0]const u8) !bool {
     try j.pushLocalFrame(8);
@@ -94,6 +98,7 @@ test "the permission names match Manifest.permission exactly" {
     try testing.expectEqualStrings("android.permission.READ_CONTACTS", read_contacts);
     try testing.expectEqualStrings("android.permission.WRITE_CONTACTS", write_contacts);
     try testing.expectEqualStrings("android.permission.ACCESS_FINE_LOCATION", access_fine_location);
+    try testing.expectEqualStrings("android.permission.BLUETOOTH_SCAN", bluetooth_scan);
 }
 
 test "PERMISSION_GRANTED is zero, and PERMISSION_DENIED is not" {

--- a/packages/zig/src/bridge_android_bluetooth.zig
+++ b/packages/zig/src/bridge_android_bluetooth.zig
@@ -1,0 +1,154 @@
+//! `startBluetoothScan` and `stopBluetoothScan` on Android.
+//!
+//! The third listener shim. `ScanCallback` is an abstract Java class, so the
+//! object lives in `CraftNative` and every result forwards here.
+//!
+//! ## The scan can not start and still resolve true
+//!
+//! ```kotlin
+//! bluetoothScanner?.startScan(bleScanCallback)
+//! activity.runOnUiThread { ...craftBleResolve(true)... }
+//! ```
+//!
+//! `bluetoothScanner` is null when the device has no Bluetooth adapter or when
+//! Bluetooth is switched off — and the `?.` then skips the scan while the
+//! resolve fires anyway. A page is told scanning started, no
+//! `craftBluetoothDevice` events ever arrive, and there is nothing to
+//! distinguish that from an empty room.
+//!
+//! Reproduced rather than corrected, because the reply is what a page acts on.
+//! See #185.
+//!
+//! ## The name default is a decision, so it is made here
+//!
+//! `result.device.name ?: "Unknown"` — a BLE advertisement often carries no
+//! name at all, so this is the common case rather than the edge one. The
+//! holder passes the nullable name across and this module applies the default,
+//! which keeps the one judgement in the file that has tests.
+
+const std = @import("std");
+const events = @import("android_events.zig");
+const bridge_error = @import("bridge_error.zig");
+
+pub const A = struct {
+    pub const start_bluetooth_scan = "startBluetoothScan";
+    pub const stop_bluetooth_scan = "stopBluetoothScan";
+};
+
+pub const resolve_global = "_craftBleResolve";
+pub const reject_global = "_craftBleReject";
+
+/// The event each scan result becomes.
+pub const event_name = "craftBluetoothDevice";
+
+/// What a device with no advertised name is called.
+pub const unknown_name = "Unknown";
+
+/// `CraftBridge.REQUEST_BLUETOOTH`.
+pub const request_bluetooth: i32 = 1009;
+
+/// `{"id":"…","name":"…","rssi":-70}`.
+///
+/// Key order is the shim's `mapOf`, which is a `LinkedHashMap` — so id, name,
+/// rssi, and not alphabetical.
+pub fn renderDevice(
+    allocator: std.mem.Allocator,
+    address: []const u8,
+    name: ?[]const u8,
+    rssi: i32,
+) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.appendSlice(allocator, "{\"id\":\"");
+    try bridge_error.appendJsonEscaped(allocator, &out, address);
+    try out.appendSlice(allocator, "\",\"name\":\"");
+    try bridge_error.appendJsonEscaped(allocator, &out, name orelse unknown_name);
+    try out.appendSlice(allocator, "\",\"rssi\":");
+    try out.print(allocator, "{d}", .{rssi});
+    try out.append(allocator, '}');
+    return out.toOwnedSlice(allocator);
+}
+
+/// Send one scan result as `craftBluetoothDevice`.
+pub fn announce(
+    allocator: std.mem.Allocator,
+    address: []const u8,
+    name: ?[]const u8,
+    rssi: i32,
+) !void {
+    const detail = try renderDevice(allocator, address, name, rssi);
+    defer allocator.free(detail);
+    try events.emitEvent(allocator, event_name, detail);
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+const testing = std.testing;
+
+test "a named device prints the shim's three keys, in its order" {
+    const json = try renderDevice(testing.allocator, "AA:BB:CC:DD:EE:FF", "Pixel Buds", -63);
+    defer testing.allocator.free(json);
+
+    // `mapOf` is a LinkedHashMap and `JSONObject(Map)` keeps its iteration
+    // order, so this is insertion order rather than alphabetical.
+    try testing.expectEqualStrings(
+        \\{"id":"AA:BB:CC:DD:EE:FF","name":"Pixel Buds","rssi":-63}
+    , json);
+}
+
+test "a device with no name is Unknown, not empty and not absent" {
+    // `result.device.name ?: "Unknown"`. A BLE advertisement often carries no
+    // name, so this is the common case — and "Unknown" is a string a page may
+    // well be filtering on.
+    const json = try renderDevice(testing.allocator, "AA:BB", null, -90);
+    defer testing.allocator.free(json);
+
+    try testing.expectEqualStrings(
+        \\{"id":"AA:BB","name":"Unknown","rssi":-90}
+    , json);
+
+    // An empty name is not the absent case: the device advertised one, and it
+    // is empty.
+    const empty = try renderDevice(testing.allocator, "AA:BB", "", -90);
+    defer testing.allocator.free(empty);
+    try testing.expectEqualStrings(
+        \\{"id":"AA:BB","name":"","rssi":-90}
+    , empty);
+}
+
+test "rssi is a number, and it is usually negative" {
+    // Signal strength in dBm — a bare JSON number, not a string, so a page can
+    // compare it. Zero and positive values are legal and do occur very close
+    // to a transmitter.
+    for ([_]i32{ -100, -63, 0, 7 }) |rssi| {
+        const json = try renderDevice(testing.allocator, "AA", "x", rssi);
+        defer testing.allocator.free(json);
+
+        var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+        defer parsed.deinit();
+        try testing.expectEqual(@as(i64, rssi), parsed.value.object.get("rssi").?.integer);
+    }
+}
+
+test "a device name carrying a quote survives as JSON" {
+    // A BLE name is whatever the peripheral advertises — arbitrary bytes the
+    // app has no say over, arriving through the event channel.
+    const json = try renderDevice(testing.allocator, "AA", "Bob's \"speaker\"\n", -50);
+    defer testing.allocator.free(json);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("Bob's \"speaker\"\n", parsed.value.object.get("name").?.string);
+}
+
+test "the actions, globals and event name match the shim exactly" {
+    try testing.expectEqualStrings("startBluetoothScan", A.start_bluetooth_scan);
+    try testing.expectEqualStrings("stopBluetoothScan", A.stop_bluetooth_scan);
+    try testing.expectEqualStrings("_craftBleResolve", resolve_global);
+    try testing.expectEqualStrings("_craftBleReject", reject_global);
+    try testing.expectEqualStrings("craftBluetoothDevice", event_name);
+    try testing.expectEqualStrings("Unknown", unknown_name);
+}

--- a/packages/zig/test/android_conformance_test.zig
+++ b/packages/zig/test/android_conformance_test.zig
@@ -57,6 +57,7 @@ const zig_sources = [_][]const u8{
     @embedFile("src/bridge_android_files.zig"),
     @embedFile("src/bridge_android_locationstore.zig"),
     @embedFile("src/bridge_android_appstate.zig"),
+    @embedFile("src/bridge_android_bluetooth.zig"),
 };
 
 /// How many spec actions Zig does not serve yet.
@@ -91,8 +92,9 @@ const zig_sources = [_][]const u8{
 /// to name its own service class; 59 with the network monitoring pair, the
 /// first listener shim — the callback object is the holder's, the work is
 /// Zig's; 56 with the app-state trio, the first migration where the state
-/// itself moved rather than being worked around.
-const max_not_yet_migrated: usize = 56;
+/// itself moved rather than being worked around; 54 with the Bluetooth scan
+/// pair.
+const max_not_yet_migrated: usize = 54;
 
 /// Every `@JavascriptInterface fun <name>(` in the Kotlin bridge.
 ///


### PR DESCRIPTION
The third listener shim. `ScanCallback` is an abstract Java class, so the object lives in `CraftNative` and every result forwards to Zig — with the device name still **nullable**, so the `?: "Unknown"` default stays one decision in one place rather than two that have to agree.

## Why Bluetooth and not motion

The motion pair looked like the easier next step and is not. `sendEvent("craftMotionUpdate", ...)` carries `FloatArray` values, and `JSONObject` prints a `Float` through `numberToString` — which falls through to `Float.toString` for anything non-integral. Reproducing that exactly is the `Double.toString` problem the calendar, database and widget modules all decline to guess at, and getting it wrong would be silently wrong numbers rather than a failure.

Bluetooth's payload is two strings and an int: `{"id": address, "name": name ?: "Unknown", "rssi": rssi}`.

## The scan can not start and still resolve true (#185)

```kotlin
bluetoothScanner?.startScan(bleScanCallback)
activity.runOnUiThread { ...craftBleResolve(true)... }
```

`bluetoothScanner` is null when the device has no adapter **or when Bluetooth is switched off**. The `?.` skips the scan, the resolve fires anyway, and nothing distinguishes "scanning, nothing found" from "never started". Bluetooth being off is not an edge case, and the page has no way to tell the user to turn it on.

Reproduced rather than corrected: rejecting on the Zig path alone would mean the same call succeeds or fails depending on which implementation served it, and the difference would only show up as a missing rejection.

## The version check lives next to the call that needs it

`BLUETOOTH_SCAN` arrived in API 31, and below that the shim does not ask for it at all. `requestBluetoothScanPermission` is in the holder because that is where `ActivityCompat.requestPermissions` is called — putting the guard on the Zig side would leave a call that throws on older releases one refactor away.

## One deliberate difference, written down

`result.device.name` requires `BLUETOOTH_CONNECT` on API 31+, which this scan does **not** request — so it can throw `SecurityException` *inside* the callback. The shim lets that escape a framework callback; the holder catches it and drops the result.

That is the only place the two implementations differ, and it is the smaller of the two behaviours.

## Testing

`zig build test:android` passes with the ratchet at 54. The mutation fired: replacing the `"Unknown"` default with an empty string fails a named test. Both `libcraft.so` targets still build with no NDK.