### PR TITLE
feat(android): the motion pair, and org.json's numbers — ratchet 54 → 52

### DIFF
--- a/packages/android/templates/CraftBridge.kt.template
+++ b/packages/android/templates/CraftBridge.kt.template
@@ -2866,6 +2866,11 @@ class CraftBridge(
 
     @JavascriptInterface
     fun startMotionUpdates(intervalMs: Int): Boolean {
+        // The SensorEventListener object is CraftNative's, and so is the
+        // last-value bookkeeping — which is why stopMotionUpdates has to reach
+        // the same way, or its own fields stay null and nothing unregisters.
+        if (CraftNative.startMotionUpdates(activity, intervalMs)) return true
+
         sensorManager = activity.getSystemService(Context.SENSOR_SERVICE) as SensorManager
         accelerometer = sensorManager?.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
         gyroscope = sensorManager?.getDefaultSensor(Sensor.TYPE_GYROSCOPE)
@@ -2907,6 +2912,8 @@ class CraftBridge(
 
     @JavascriptInterface
     fun stopMotionUpdates() {
+        if (CraftNative.stopMotionUpdates(activity)) return
+
         sensorListener?.let { sensorManager?.unregisterListener(it) }
         sensorListener = null
     }

--- a/packages/android/templates/CraftNative.kt.template
+++ b/packages/android/templates/CraftNative.kt.template
@@ -1,6 +1,10 @@
 package com.craft.runtime
 
 import android.app.Activity
+import android.hardware.SensorManager
+import android.hardware.SensorEventListener
+import android.hardware.SensorEvent
+import android.hardware.Sensor
 import androidx.core.app.ActivityCompat
 import android.os.Build
 import android.bluetooth.le.ScanResult
@@ -162,6 +166,9 @@ object CraftNative {
     private external fun nativeBluetoothDevice(address: String, name: String?, rssi: Int)
     private external fun nativeStartBluetoothScan(activity: Activity): Boolean
     private external fun nativeStopBluetoothScan(activity: Activity): Boolean
+    private external fun nativeMotionSample(isAccelerometer: Boolean, x: Float, y: Float, z: Float)
+    private external fun nativeStartMotionUpdates(activity: Activity, intervalMs: Int): Boolean
+    private external fun nativeStopMotionUpdates(activity: Activity): Boolean
 
     /**
      * `getDeviceInfo`, or null to use the Kotlin implementation.
@@ -1013,6 +1020,74 @@ object CraftNative {
         if (!isAvailable) return false
         return try {
             nativeStopBluetoothScan(activity)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    // ==================== Motion sensors ====================
+    //
+    // The fourth listener shim. `SensorEventListener` is a Java interface, so
+    // the object is here — but only the object: which sensor a sample came
+    // from is passed across as a boolean and everything else, including the
+    // last-value bookkeeping and the delay the interval maps to, is Zig's.
+    //
+    // `registerListener` without a Handler delivers on the main looper, so
+    // every sample arrives on one thread and the state on the other side
+    // needs no lock.
+
+    private var sensorManager: SensorManager? = null
+    private var motionListener: SensorEventListener? = null
+
+    @JvmStatic
+    fun startMotionWatch(activity: Activity, delay: Int) {
+        val manager = activity.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+        sensorManager = manager
+
+        val accelerometer = manager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
+        val gyroscope = manager.getDefaultSensor(Sensor.TYPE_GYROSCOPE)
+
+        val listener = object : SensorEventListener {
+            override fun onSensorChanged(event: SensorEvent) {
+                try {
+                    nativeMotionSample(
+                        event.sensor.type == Sensor.TYPE_ACCELEROMETER,
+                        event.values[0],
+                        event.values[1],
+                        event.values[2]
+                    )
+                } catch (e: UnsatisfiedLinkError) {
+                    // The library went away. Nothing is waiting on this.
+                }
+            }
+
+            override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {}
+        }
+
+        accelerometer?.let { manager.registerListener(listener, it, delay) }
+        gyroscope?.let { manager.registerListener(listener, it, delay) }
+        motionListener = listener
+    }
+
+    @JvmStatic
+    fun stopMotionWatch(activity: Activity) {
+        motionListener?.let { sensorManager?.unregisterListener(it) }
+        motionListener = null
+    }
+
+    fun startMotionUpdates(activity: Activity, intervalMs: Int): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeStartMotionUpdates(activity, intervalMs)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    fun stopMotionUpdates(activity: Activity): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeStopMotionUpdates(activity)
         } catch (e: UnsatisfiedLinkError) {
             false
         }

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -488,6 +488,9 @@ pub fn build(b: *std.Build) void {
     android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_bluetooth.zig", .{
         .root_source_file = b.path("src/bridge_android_bluetooth.zig"),
     });
+    android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_motion.zig", .{
+        .root_source_file = b.path("src/bridge_android_motion.zig"),
+    });
     const run_android_conformance_tests = b.addRunArtifact(android_conformance_tests);
 
     // The page surface, across both bridges. Not folded into the iOS

--- a/packages/zig/src/android_dispatch.zig
+++ b/packages/zig/src/android_dispatch.zig
@@ -44,6 +44,8 @@ const intents = @import("bridge_android_intents.zig");
 const network = @import("bridge_android_network.zig");
 const appstate = @import("bridge_android_appstate.zig");
 const bluetooth = @import("bridge_android_bluetooth.zig");
+const motion = @import("bridge_android_motion.zig");
+const json_number = @import("android_json_number.zig");
 const securestore = @import("bridge_android_securestore.zig");
 const haptics = @import("bridge_android_haptics.zig");
 const notifications = @import("bridge_android_notifications.zig");
@@ -448,6 +450,22 @@ const natives = [_]jni.JNINativeMethod{
         .name = "nativeStopBluetoothScan",
         .signature = "(Landroid/app/Activity;)Z",
         .fnPtr = @ptrCast(&nativeStopBluetoothScan),
+    },
+    // Not an action: the other end of the SensorEventListener the holder owns.
+    .{
+        .name = "nativeMotionSample",
+        .signature = "(ZFFF)V",
+        .fnPtr = @ptrCast(&nativeMotionSample),
+    },
+    .{
+        .name = "nativeStartMotionUpdates",
+        .signature = "(Landroid/app/Activity;I)Z",
+        .fnPtr = @ptrCast(&nativeStartMotionUpdates),
+    },
+    .{
+        .name = "nativeStopMotionUpdates",
+        .signature = "(Landroid/app/Activity;)Z",
+        .fnPtr = @ptrCast(&nativeStopMotionUpdates),
     },
 };
 
@@ -1975,6 +1993,109 @@ fn nativeStopBluetoothScan(
     return jni.JNI_TRUE;
 }
 
+/// `nativeMotionSample(isAccelerometer, x, y, z)` — one sensor reading.
+///
+/// Every sample sends a complete event: the sensor that just reported and the
+/// last value the other one gave, which is what the shim does and is why a
+/// device with both sensors produces two events per cycle.
+fn nativeMotionSample(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    is_accelerometer: jni.jboolean,
+    x: jni.jfloat,
+    y: jni.jfloat,
+    z: jni.jfloat,
+) callconv(.c) void {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    motion.record(is_accelerometer != jni.JNI_FALSE, .{ x, y, z });
+
+    const acceleration = motion.lastAcceleration();
+    const rotation = motion.lastRotation();
+
+    // Formatted by org.json, because these are the numbers a page reads and
+    // `Float.toString` is not a format string — see `android_json_number`.
+    var printed: [6][]const u8 = undefined;
+    inline for (0..3) |i| {
+        printed[i] = json_number.fromFloat(j, allocator, acceleration[i]) catch return;
+        printed[i + 3] = json_number.fromFloat(j, allocator, rotation[i]) catch return;
+    }
+
+    motion.announce(
+        allocator,
+        .{ printed[0], printed[1], printed[2] },
+        .{ printed[3], printed[4], printed[5] },
+    ) catch {};
+}
+
+/// `nativeStartMotionUpdates(activity, intervalMs)`.
+///
+/// The delay constant is read here and handed across, so the shim's `when`
+/// stays a Zig decision while the field it names stays the platform's number.
+fn nativeStartMotionUpdates(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+    interval_ms: jni.jint,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+
+    const delay = sensorDelay(j, motion.delayFor(interval_ms)) catch |err| {
+        std.log.warn("craft: startMotionUpdates fell through to the shim ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+
+    // The shim builds a new listener object, whose lastAccel and lastGyro
+    // start null — so a restart forgets what the last one saw.
+    motion.reset();
+
+    callHolderInt(j, "startMotionWatch", activity, delay) catch |err| {
+        std.log.warn("craft: startMotionUpdates fell through to the shim ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+    return jni.JNI_TRUE;
+}
+
+/// `nativeStopMotionUpdates(activity)`.
+fn nativeStopMotionUpdates(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+
+    callHolderVoid(j, "stopMotionWatch", activity) catch |err| {
+        std.log.warn("craft: stopMotionUpdates failed ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+    return jni.JNI_TRUE;
+}
+
+/// `SensorManager.<field>`.
+fn sensorDelay(j: Jni, delay: motion.Delay) !jni.jint {
+    try j.pushLocalFrame(4);
+    defer _ = j.popLocalFrame(null);
+
+    const manager_cls = try j.findClass("android/hardware/SensorManager");
+    return j.staticIntField(manager_cls, try j.staticFieldId(manager_cls, delay.field(), "I"));
+}
+
+/// Call an `(Activity, int) -> void` static on the holder.
+fn callHolderInt(j: Jni, comptime name: [:0]const u8, activity: jni.jobject, value: jni.jint) !void {
+    try j.pushLocalFrame(8);
+    defer _ = j.popLocalFrame(null);
+
+    const holder = try j.findClass(holder_class);
+    try j.callStaticVoidMethodA(
+        holder,
+        try j.staticMethodId(holder, name, "(Landroid/app/Activity;I)V"),
+        &.{ .{ .l = activity }, .{ .i = value } },
+    );
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -2086,7 +2207,7 @@ test "the registered natives name methods the Kotlin actually declares" {
     // A descriptor is checked by the JVM at registration, so a wrong one fails
     // at load rather than at call — but only if the *name* matches something.
     // These two strings are the contract with CraftBridge.kt.
-    try testing.expectEqual(@as(usize, 53), natives.len);
+    try testing.expectEqual(@as(usize, 56), natives.len);
     try testing.expectEqualStrings("nativeGetDeviceInfo", std.mem.span(natives[0].name));
 
     // And the class they bind to is the fixed one, not the templated bridge.

--- a/packages/zig/src/android_json_number.zig
+++ b/packages/zig/src/android_json_number.zig
@@ -1,0 +1,98 @@
+//! Numbers, printed the way `org.json` prints them.
+//!
+//! Four migrated modules have declined to format a float, and the reason is
+//! always the same: `JSONObject` does not print numbers with a format string.
+//! Android's `numberToString` is
+//!
+//! ```java
+//! double doubleValue = number.doubleValue();
+//! JSON.checkDouble(doubleValue);                       // throws on NaN, ±Inf
+//! if (number.equals(NEGATIVE_ZERO)) return "-0";
+//! long longValue = number.longValue();
+//! if (doubleValue == (double) longValue) return Long.toString(longValue);
+//! return number.toString();                            // Float or Double
+//! ```
+//!
+//! Three of those five lines are decisions a reimplementation would have to
+//! rediscover — an integral double prints as an integer, negative zero prints
+//! as `-0`, and the fallback is `Float.toString` or `Double.toString`
+//! depending on which box the number arrived in, which are *different*
+//! functions for the same value.
+//!
+//! So this asks Java. It is the same judgement `bridge_android_notifications`
+//! makes about `hashCode` and `bridge_android_files` about `Base64.decode`:
+//! where the platform already has the thing, ask it rather than rebuild it —
+//! and here rebuilding means reproducing the shortest-round-trip algorithm for
+//! two float widths, where being wrong is a silently different number rather
+//! than a failure.
+//!
+//! ## What it costs
+//!
+//! Three JNI calls per number: box, format, read back. `getCurrentPosition`
+//! makes seven of those once. A motion stream at 50 Hz makes six per event,
+//! which is 900 calls a second — real, and still far below what the sensor
+//! delivery itself costs.
+
+const std = @import("std");
+const jni = @import("jni_runtime.zig");
+
+const Jni = jni.Jni;
+
+/// `JSONObject.numberToString(Float.valueOf(value))`.
+pub fn fromFloat(j: Jni, allocator: std.mem.Allocator, value: f32) ![]u8 {
+    try j.pushLocalFrame(8);
+    defer _ = j.popLocalFrame(null);
+
+    const float_cls = try j.findClass("java/lang/Float");
+    const boxed = try j.callStaticObjectMethodA(
+        float_cls,
+        try j.staticMethodId(float_cls, "valueOf", "(F)Ljava/lang/Float;"),
+        &.{.{ .f = value }},
+    );
+    return numberToString(j, allocator, boxed);
+}
+
+/// `JSONObject.numberToString(Double.valueOf(value))`.
+///
+/// A separate function rather than a widened `fromFloat`, because the two do
+/// not agree: `Float.toString(0.1f)` is "0.1" and `Double.toString(0.1f)` is
+/// "0.10000000149011612". Which box a number arrives in is part of what the
+/// shim's output means.
+pub fn fromDouble(j: Jni, allocator: std.mem.Allocator, value: f64) ![]u8 {
+    try j.pushLocalFrame(8);
+    defer _ = j.popLocalFrame(null);
+
+    const double_cls = try j.findClass("java/lang/Double");
+    const boxed = try j.callStaticObjectMethodA(
+        double_cls,
+        try j.staticMethodId(double_cls, "valueOf", "(D)Ljava/lang/Double;"),
+        &.{.{ .d = value }},
+    );
+    return numberToString(j, allocator, boxed);
+}
+
+fn numberToString(j: Jni, allocator: std.mem.Allocator, boxed: jni.jobject) ![]u8 {
+    const json_cls = try j.findClass("org/json/JSONObject");
+    const text = try j.callStaticObjectMethodA(
+        json_cls,
+        try j.staticMethodId(
+            json_cls,
+            "numberToString",
+            "(Ljava/lang/Number;)Ljava/lang/String;",
+        ),
+        &.{.{ .l = boxed }},
+    );
+    return j.stringToUtf8(allocator, text);
+}
+
+// No tests, deliberately.
+//
+// Everything here is three JNI calls and a descriptor; there is no formatting
+// to check, because not formatting is the point. A host test would have to
+// stand up a fake `numberToString` and would then be asserting that a fake
+// agrees with itself.
+//
+// What *is* checked lives with the callers: `bridge_android_motion` tests the
+// shape of the object these numbers go into, with the formatted strings
+// injected, so the part this file does not own is tested and the part it does
+// own is Java's.

--- a/packages/zig/src/bridge_android_motion.zig
+++ b/packages/zig/src/bridge_android_motion.zig
@@ -1,0 +1,269 @@
+//! `startMotionUpdates` and `stopMotionUpdates` on Android.
+//!
+//! The fourth listener shim, and the one that needed `android_json_number`
+//! first: the payload is six floats printed by `org.json`, which is why this
+//! pair was passed over three times.
+//!
+//! ## One event per sample, carrying both sensors
+//!
+//! The accelerometer and the gyroscope are registered separately and arrive
+//! separately, but every arrival sends *both* — the one that just changed and
+//! the last value the other reported. So a device with both sensors at
+//! `SENSOR_DELAY_GAME` produces two `craftMotionUpdate` events per cycle, each
+//! a complete reading.
+//!
+//! A sensor that has not reported yet reads as zeroes rather than being
+//! absent: `lastAccel ?: floatArrayOf(0f, 0f, 0f)`. So the first event after
+//! `startMotionUpdates` always claims one of the two is perfectly still, and a
+//! page cannot tell that from a device lying on a table.
+//!
+//! ## The state is per-registration
+//!
+//! The shim keeps `lastAccel` and `lastGyro` inside the listener object it
+//! creates in `startMotionUpdates`, so stopping and starting forgets them.
+//! Reproduced: `reset` runs on start.
+//!
+//! Both sensors deliver on the main looper — `registerListener` without a
+//! `Handler` uses it — so the samples arrive on one thread and the last-value
+//! state needs no lock. `stopMotionUpdates` does not touch it.
+
+const std = @import("std");
+const events = @import("android_events.zig");
+
+pub const A = struct {
+    pub const start_motion_updates = "startMotionUpdates";
+    pub const stop_motion_updates = "stopMotionUpdates";
+};
+
+pub const event_name = "craftMotionUpdate";
+
+/// The `SensorManager` delay the shim's `when` picks.
+pub const Delay = enum {
+    fastest,
+    game,
+    ui,
+    normal,
+
+    /// The field on `android.hardware.SensorManager`.
+    pub fn field(self: Delay) [:0]const u8 {
+        return switch (self) {
+            .fastest => "SENSOR_DELAY_FASTEST",
+            .game => "SENSOR_DELAY_GAME",
+            .ui => "SENSOR_DELAY_UI",
+            .normal => "SENSOR_DELAY_NORMAL",
+        };
+    }
+};
+
+/// The shim's `when`, boundaries included.
+///
+/// Every comparison is `<=`, so 20 is fastest and 21 is game — and the
+/// boundaries are the part worth writing down, because "20ms" reading as
+/// `SENSOR_DELAY_GAME` would be a plausible off-by-one that nobody would
+/// notice except as a slightly wrong sample rate.
+pub fn delayFor(interval_ms: i32) Delay {
+    if (interval_ms <= 20) return .fastest;
+    if (interval_ms <= 60) return .game;
+    if (interval_ms <= 200) return .ui;
+    return .normal;
+}
+
+/// The last reading from each sensor, and whether it has reported at all.
+const Reading = struct {
+    values: [3]f32 = .{ 0, 0, 0 },
+    seen: bool = false,
+};
+
+var accelerometer: Reading = .{};
+var gyroscope: Reading = .{};
+
+/// Forget both sensors, as creating a new listener object does.
+pub fn reset() void {
+    accelerometer = .{};
+    gyroscope = .{};
+}
+
+/// Record a sample. `is_accelerometer` false means the gyroscope.
+///
+/// The shim's `when` has only those two arms and no else, so a sample from any
+/// other sensor updates nothing and still sends an event — which cannot happen
+/// today, because only those two are registered.
+pub fn record(is_accelerometer: bool, values: [3]f32) void {
+    const slot = if (is_accelerometer) &accelerometer else &gyroscope;
+    slot.values = values;
+    slot.seen = true;
+}
+
+pub fn lastAcceleration() [3]f32 {
+    return accelerometer.values;
+}
+
+pub fn lastRotation() [3]f32 {
+    return gyroscope.values;
+}
+
+/// `{"acceleration":{"x":…,"y":…,"z":…},"rotation":{"alpha":…,"beta":…,"gamma":…}}`
+///
+/// The numbers arrive already formatted, because formatting them is
+/// `org.json`'s job and not this file's — see `android_json_number`. What is
+/// this file's job is the shape: two nested objects, six keys, and the fact
+/// that the rotation's keys are Euler angle names rather than x/y/z.
+pub fn renderDetail(
+    allocator: std.mem.Allocator,
+    acceleration: [3][]const u8,
+    rotation: [3][]const u8,
+) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.appendSlice(allocator, "{\"acceleration\":{\"x\":");
+    try out.appendSlice(allocator, acceleration[0]);
+    try out.appendSlice(allocator, ",\"y\":");
+    try out.appendSlice(allocator, acceleration[1]);
+    try out.appendSlice(allocator, ",\"z\":");
+    try out.appendSlice(allocator, acceleration[2]);
+    try out.appendSlice(allocator, "},\"rotation\":{\"alpha\":");
+    try out.appendSlice(allocator, rotation[0]);
+    try out.appendSlice(allocator, ",\"beta\":");
+    try out.appendSlice(allocator, rotation[1]);
+    try out.appendSlice(allocator, ",\"gamma\":");
+    try out.appendSlice(allocator, rotation[2]);
+    try out.appendSlice(allocator, "}}");
+    return out.toOwnedSlice(allocator);
+}
+
+/// Send one reading as `craftMotionUpdate`.
+pub fn announce(
+    allocator: std.mem.Allocator,
+    acceleration: [3][]const u8,
+    rotation: [3][]const u8,
+) !void {
+    const detail = try renderDetail(allocator, acceleration, rotation);
+    defer allocator.free(detail);
+    try events.emitEvent(allocator, event_name, detail);
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+const testing = std.testing;
+
+test "every interval lands on the delay the shim's when picks" {
+    // The boundaries, which are all `<=`. An off-by-one here is a slightly
+    // wrong sample rate and nothing else — no error, no warning.
+    try testing.expectEqual(Delay.fastest, delayFor(0));
+    try testing.expectEqual(Delay.fastest, delayFor(20));
+    try testing.expectEqual(Delay.game, delayFor(21));
+    try testing.expectEqual(Delay.game, delayFor(60));
+    try testing.expectEqual(Delay.ui, delayFor(61));
+    try testing.expectEqual(Delay.ui, delayFor(200));
+    try testing.expectEqual(Delay.normal, delayFor(201));
+    try testing.expectEqual(Delay.normal, delayFor(100_000));
+
+    // A negative interval is fastest, because the first `<=` catches it. The
+    // injected JS sends `interval || 100`, so zero already arrives as 100 —
+    // but nothing stops a page calling the interface directly.
+    try testing.expectEqual(Delay.fastest, delayFor(-1));
+}
+
+test "each delay names a real SensorManager field" {
+    try testing.expectEqualStrings("SENSOR_DELAY_FASTEST", Delay.fastest.field());
+    try testing.expectEqualStrings("SENSOR_DELAY_GAME", Delay.game.field());
+    try testing.expectEqualStrings("SENSOR_DELAY_UI", Delay.ui.field());
+    try testing.expectEqualStrings("SENSOR_DELAY_NORMAL", Delay.normal.field());
+
+    // All four distinct, which a copy-paste in the switch would break without
+    // changing anything a compiler could see.
+    const fields = [_][]const u8{
+        Delay.fastest.field(), Delay.game.field(),
+        Delay.ui.field(),      Delay.normal.field(),
+    };
+    for (fields, 0..) |a, i| {
+        for (fields[i + 1 ..]) |b| try testing.expect(!std.mem.eql(u8, a, b));
+    }
+}
+
+test "a sensor that has not reported reads as zero, not as absent" {
+    reset();
+    try testing.expectEqual([3]f32{ 0, 0, 0 }, lastAcceleration());
+    try testing.expectEqual([3]f32{ 0, 0, 0 }, lastRotation());
+
+    // And after one accelerometer sample the gyroscope is still zeroes — so
+    // the first event claims the device is not rotating, which a page cannot
+    // tell from a device lying still.
+    record(true, .{ 1, 2, 3 });
+    try testing.expectEqual([3]f32{ 1, 2, 3 }, lastAcceleration());
+    try testing.expectEqual([3]f32{ 0, 0, 0 }, lastRotation());
+    reset();
+}
+
+test "each sensor keeps its own last value" {
+    reset();
+    record(true, .{ 1, 2, 3 });
+    record(false, .{ 4, 5, 6 });
+    try testing.expectEqual([3]f32{ 1, 2, 3 }, lastAcceleration());
+    try testing.expectEqual([3]f32{ 4, 5, 6 }, lastRotation());
+
+    // A second accelerometer sample leaves the gyroscope alone, which is what
+    // makes every event a complete reading rather than a partial one.
+    record(true, .{ 7, 8, 9 });
+    try testing.expectEqual([3]f32{ 7, 8, 9 }, lastAcceleration());
+    try testing.expectEqual([3]f32{ 4, 5, 6 }, lastRotation());
+    reset();
+}
+
+test "starting again forgets what the last registration saw" {
+    // The shim's lastAccel/lastGyro live on the listener object, which
+    // startMotionUpdates creates fresh — so a stop and start does not carry
+    // stale readings across.
+    reset();
+    record(true, .{ 1, 2, 3 });
+    reset();
+    try testing.expectEqual([3]f32{ 0, 0, 0 }, lastAcceleration());
+}
+
+test "the detail nests two objects, and the rotation is not x y z" {
+    // The numbers are already formatted — that is org.json's job, not this
+    // file's — so this is about the shape: the rotation's keys are Euler
+    // angles, and swapping them for x/y/z would be an easy and invisible
+    // mistake.
+    const json = try renderDetail(
+        testing.allocator,
+        .{ "9.81", "0", "-0.5" },
+        .{ "0.01", "0", "-0" },
+    );
+    defer testing.allocator.free(json);
+
+    try testing.expectEqualStrings(
+        \\{"acceleration":{"x":9.81,"y":0,"z":-0.5},"rotation":{"alpha":0.01,"beta":0,"gamma":-0}}
+    , json);
+}
+
+test "the detail parses, including org.json's integral and negative-zero forms" {
+    // `numberToString` prints an integral float as an integer and negative
+    // zero as `-0`. Both are legal JSON numbers, and a page parsing this must
+    // not choke on them — which is worth checking, because they look wrong.
+    const json = try renderDetail(
+        testing.allocator,
+        .{ "0", "-0", "9" },
+        .{ "1.5", "-2", "0" },
+    );
+    defer testing.allocator.free(json);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+
+    const acceleration = parsed.value.object.get("acceleration").?.object;
+    const rotation = parsed.value.object.get("rotation").?.object;
+    try testing.expectEqual(@as(usize, 3), acceleration.count());
+    try testing.expectEqual(@as(usize, 3), rotation.count());
+    try testing.expect(acceleration.get("x") != null);
+    try testing.expect(rotation.get("alpha") != null);
+}
+
+test "the actions and event name match the shim exactly" {
+    try testing.expectEqualStrings("startMotionUpdates", A.start_motion_updates);
+    try testing.expectEqualStrings("stopMotionUpdates", A.stop_motion_updates);
+    try testing.expectEqualStrings("craftMotionUpdate", event_name);
+}

--- a/packages/zig/test/android_conformance_test.zig
+++ b/packages/zig/test/android_conformance_test.zig
@@ -58,6 +58,7 @@ const zig_sources = [_][]const u8{
     @embedFile("src/bridge_android_locationstore.zig"),
     @embedFile("src/bridge_android_appstate.zig"),
     @embedFile("src/bridge_android_bluetooth.zig"),
+    @embedFile("src/bridge_android_motion.zig"),
 };
 
 /// How many spec actions Zig does not serve yet.
@@ -93,8 +94,8 @@ const zig_sources = [_][]const u8{
 /// first listener shim — the callback object is the holder's, the work is
 /// Zig's; 56 with the app-state trio, the first migration where the state
 /// itself moved rather than being worked around; 54 with the Bluetooth scan
-/// pair.
-const max_not_yet_migrated: usize = 54;
+/// pair; 52 with the motion pair, once org.json agreed to print the floats.
+const max_not_yet_migrated: usize = 52;
 
 /// Every `@JavascriptInterface fun <name>(` in the Kotlin bridge.
 ///


### PR DESCRIPTION
Four migrated modules have declined to format a float, and this pair was passed over three times for the same reason. So the reason gets dealt with rather than routed around again.

## `numberToString` is asked, not reimplemented

Android's `JSONObject.numberToString` is five lines, three of which are decisions a reimplementation would have to rediscover:

```java
if (number.equals(NEGATIVE_ZERO)) return "-0";
long longValue = number.longValue();
if (doubleValue == (double) longValue) return Long.toString(longValue);
return number.toString();
```

An integral double prints as an **integer** (`9`, not `9.0`), negative zero prints as `-0`, and the fallback is `Float.toString` **or** `Double.toString` depending on which box the number arrived in — which are different functions for the same value (`Float.toString(0.1f)` is `"0.1"`; `Double.toString((double) 0.1f)` is `"0.10000000149011612"`).

`android_json_number` boxes and calls it. Same judgement `bridge_android_notifications` makes about `hashCode` and `bridge_android_files` about `Base64.decode`: **where the platform already has the thing, ask it rather than rebuild it.** Here rebuilding means the shortest-round-trip algorithm for two float widths, where being wrong is a silently different number rather than a failure.

Three JNI calls per number. `getCurrentPosition` will make seven of those once; a motion stream at 50 Hz makes six per event.

That file has **no tests, and says why**: there is no formatting in it to check, and a host test would stand up a fake `numberToString` and assert that the fake agrees with itself. What is testable is the shape the numbers go into, and that is tested here with the formatted strings injected.

## One event per sample, carrying both sensors

The accelerometer and gyroscope are registered separately and arrive separately, but every arrival sends **both** — the one that just changed and the last value the other gave. A device with both produces two `craftMotionUpdate` events per cycle, each a complete reading.

A sensor that has not reported yet reads as zeroes rather than being absent (`lastAccel ?: floatArrayOf(0f, 0f, 0f)`), so the first event always claims one of the two is perfectly still, and a page cannot tell that from a device lying on a table.

The last-value state is per-registration, as the shim's is — it lives on the listener object that `startMotionUpdates` creates fresh — so a stop and start forgets it.

## Two things with their own tests

**The delay boundaries** are all `<=`, so 20ms is `SENSOR_DELAY_FASTEST` and 21ms is `SENSOR_DELAY_GAME`. An off-by-one there is a slightly wrong sample rate and nothing else — no error, no warning.

**The rotation's keys are `alpha`, `beta`, `gamma`** where the acceleration's are `x`, `y`, `z`. Swapping them would be easy and invisible.

Both mutations were run: `< 20` instead of `<= 20`, and renaming `alpha` to `x`, each fail named tests.

## Testing

`zig build test:android` passes with the ratchet at 52. Both `libcraft.so` targets still build with no NDK.