### PR TITLE
feat(android): getCurrentPosition in Zig — ratchet 52 → 51

### DIFF
--- a/packages/android/templates/CraftBridge.kt.template
+++ b/packages/android/templates/CraftBridge.kt.template
@@ -1633,6 +1633,12 @@ class CraftBridge(
 
     @JavascriptInterface
     fun getCurrentPosition(optionsJson: String) {
+        // The task listeners and the fresh-location callback are
+        // CraftNative's, because they are Java interfaces. fusedLocationClient
+        // below stays null, which is safe: watchPosition assigns it before
+        // every use, so clearWatch is unaffected.
+        if (CraftNative.getCurrentPosition(activity)) return
+
         if (ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION)
             != PackageManager.PERMISSION_GRANTED) {
             ActivityCompat.requestPermissions(

--- a/packages/android/templates/CraftNative.kt.template
+++ b/packages/android/templates/CraftNative.kt.template
@@ -1,6 +1,14 @@
 package com.craft.runtime
 
 import android.app.Activity
+import com.google.android.gms.location.Priority
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.LocationResult
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.FusedLocationProviderClient
+import android.location.Location
+import android.annotation.SuppressLint
 import android.hardware.SensorManager
 import android.hardware.SensorEventListener
 import android.hardware.SensorEvent
@@ -169,6 +177,17 @@ object CraftNative {
     private external fun nativeMotionSample(isAccelerometer: Boolean, x: Float, y: Float, z: Float)
     private external fun nativeStartMotionUpdates(activity: Activity, intervalMs: Int): Boolean
     private external fun nativeStopMotionUpdates(activity: Activity): Boolean
+    private external fun nativeLocationResult(
+        latitude: Double,
+        longitude: Double,
+        accuracy: Double,
+        altitude: Double,
+        speed: Double,
+        bearing: Double,
+        time: Long
+    )
+    private external fun nativeLocationFailed(message: String?)
+    private external fun nativeGetCurrentPosition(activity: Activity): Boolean
 
     /**
      * `getDeviceInfo`, or null to use the Kotlin implementation.
@@ -1088,6 +1107,111 @@ object CraftNative {
         if (!isAvailable) return false
         return try {
             nativeStopMotionUpdates(activity)
+        } catch (e: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    // ==================== Current position ====================
+    //
+    // The fifth listener shim, and the first with two Java interfaces in one
+    // flow: `OnSuccessListener` and `OnFailureListener` on the Play Services
+    // task, plus a `LocationCallback` for the fresh-location fallback.
+    //
+    // Every value crosses as a Double, including the three the framework types
+    // as Float. That is not a convenience: `CraftBridge` writes them with
+    // `put(name, value)`, and the overload Kotlin picks there is
+    // `put(String, double)` — primitive widening beats boxing — so they print
+    // as doubles. Passing them as Float and boxing them on the other side
+    // would print `0.1` where the shim prints `0.10000000149011612`.
+
+    @JvmStatic
+    fun requestLocationPermissions(activity: Activity) {
+        ActivityCompat.requestPermissions(
+            activity,
+            arrayOf(
+                android.Manifest.permission.ACCESS_FINE_LOCATION,
+                android.Manifest.permission.ACCESS_COARSE_LOCATION
+            ),
+            REQUEST_LOCATION
+        )
+    }
+
+    /** `CraftBridge.REQUEST_LOCATION`, which this has to match. */
+    private const val REQUEST_LOCATION = 1003
+
+    @JvmStatic
+    @SuppressLint("MissingPermission")
+    fun requestCurrentPosition(activity: Activity) {
+        val client = LocationServices.getFusedLocationProviderClient(activity)
+        client.lastLocation
+            .addOnSuccessListener { location: Location? ->
+                if (location != null) {
+                    deliverLocation(location)
+                } else {
+                    requestFreshPosition(activity, client)
+                }
+            }
+            .addOnFailureListener { e -> failLocation(e.message) }
+    }
+
+    /**
+     * The fallback when there is no cached fix.
+     *
+     * One update, then the callback removes itself — as `CraftBridge`'s does.
+     * If it never fires, nothing settles the page's promise, here or there.
+     */
+    @SuppressLint("MissingPermission")
+    private fun requestFreshPosition(
+        activity: Activity,
+        client: FusedLocationProviderClient
+    ) {
+        val request = LocationRequest.Builder(Priority.PRIORITY_HIGH_ACCURACY, 1000)
+            .setWaitForAccurateLocation(false)
+            .setMinUpdateIntervalMillis(500)
+            .setMaxUpdateDelayMillis(1000)
+            .setMaxUpdates(1)
+            .build()
+
+        client.requestLocationUpdates(
+            request,
+            object : LocationCallback() {
+                override fun onLocationResult(result: LocationResult) {
+                    client.removeLocationUpdates(this)
+                    result.lastLocation?.let { deliverLocation(it) }
+                }
+            },
+            activity.mainLooper
+        )
+    }
+
+    private fun deliverLocation(location: Location) {
+        try {
+            nativeLocationResult(
+                location.latitude,
+                location.longitude,
+                location.accuracy.toDouble(),
+                location.altitude,
+                location.speed.toDouble(),
+                location.bearing.toDouble(),
+                location.time
+            )
+        } catch (e: UnsatisfiedLinkError) {
+            // The library went away mid-flight. Nothing to answer to.
+        }
+    }
+
+    private fun failLocation(message: String?) {
+        try {
+            nativeLocationFailed(message)
+        } catch (e: UnsatisfiedLinkError) {
+        }
+    }
+
+    fun getCurrentPosition(activity: Activity): Boolean {
+        if (!isAvailable) return false
+        return try {
+            nativeGetCurrentPosition(activity)
         } catch (e: UnsatisfiedLinkError) {
             false
         }

--- a/packages/zig/build.zig
+++ b/packages/zig/build.zig
@@ -491,6 +491,9 @@ pub fn build(b: *std.Build) void {
     android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_motion.zig", .{
         .root_source_file = b.path("src/bridge_android_motion.zig"),
     });
+    android_conformance_tests.root_module.addAnonymousImport("src/bridge_android_position.zig", .{
+        .root_source_file = b.path("src/bridge_android_position.zig"),
+    });
     const run_android_conformance_tests = b.addRunArtifact(android_conformance_tests);
 
     // The page surface, across both bridges. Not folded into the iOS

--- a/packages/zig/src/android_dispatch.zig
+++ b/packages/zig/src/android_dispatch.zig
@@ -45,6 +45,7 @@ const network = @import("bridge_android_network.zig");
 const appstate = @import("bridge_android_appstate.zig");
 const bluetooth = @import("bridge_android_bluetooth.zig");
 const motion = @import("bridge_android_motion.zig");
+const position = @import("bridge_android_position.zig");
 const json_number = @import("android_json_number.zig");
 const securestore = @import("bridge_android_securestore.zig");
 const haptics = @import("bridge_android_haptics.zig");
@@ -466,6 +467,23 @@ const natives = [_]jni.JNINativeMethod{
         .name = "nativeStopMotionUpdates",
         .signature = "(Landroid/app/Activity;)Z",
         .fnPtr = @ptrCast(&nativeStopMotionUpdates),
+    },
+    // Not actions: the two ends of the Play Services task listeners the
+    // holder owns.
+    .{
+        .name = "nativeLocationResult",
+        .signature = "(DDDDDDJ)V",
+        .fnPtr = @ptrCast(&nativeLocationResult),
+    },
+    .{
+        .name = "nativeLocationFailed",
+        .signature = "(Ljava/lang/String;)V",
+        .fnPtr = @ptrCast(&nativeLocationFailed),
+    },
+    .{
+        .name = "nativeGetCurrentPosition",
+        .signature = "(Landroid/app/Activity;)Z",
+        .fnPtr = @ptrCast(&nativeGetCurrentPosition),
     },
 };
 
@@ -2096,6 +2114,109 @@ fn callHolderInt(j: Jni, comptime name: [:0]const u8, activity: jni.jobject, val
     );
 }
 
+/// `nativeLocationResult(...)` — a fix, from either the cached or fresh path.
+///
+/// Every value arrives as a `double`, including the three the framework types
+/// as `float`: the shim writes them with `put(name, value)`, and the overload
+/// Kotlin picks is `put(String, double)` because widening beats boxing. So
+/// they print as doubles, and the holder widens them for the same reason.
+fn nativeLocationResult(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    latitude: jni.jdouble,
+    longitude: jni.jdouble,
+    accuracy: jni.jdouble,
+    altitude: jni.jdouble,
+    speed: jni.jdouble,
+    bearing: jni.jdouble,
+    time: jni.jlong,
+) callconv(.c) void {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    var timestamp: [24]u8 = undefined;
+    const printed: position.Printed = .{
+        .latitude = json_number.fromDouble(j, allocator, latitude) catch return,
+        .longitude = json_number.fromDouble(j, allocator, longitude) catch return,
+        .accuracy = json_number.fromDouble(j, allocator, accuracy) catch return,
+        .altitude = json_number.fromDouble(j, allocator, altitude) catch return,
+        .speed = json_number.fromDouble(j, allocator, speed) catch return,
+        .heading = json_number.fromDouble(j, allocator, bearing) catch return,
+        // A long, not a double: `put(String, long)` boxes a Long, and
+        // `numberToString` prints one with `Long.toString` — which needs no
+        // JNI call, because there is no float format to reproduce.
+        .timestamp = std.fmt.bufPrint(&timestamp, "{d}", .{time}) catch return,
+    };
+
+    const json = position.renderPosition(allocator, printed) catch return;
+    events.settle(allocator, position.resolve_global, json) catch {};
+}
+
+/// `nativeLocationFailed(message)` — the failure listener.
+fn nativeLocationFailed(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    message: jni.jstring,
+) callconv(.c) void {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    // `${jsQuote(e.message)}` — a null message reaches the page as the four
+    // characters "null", which is what `Any?.toString()` produced there.
+    const text: []const u8 = if (message == null)
+        "null"
+    else
+        j.stringToUtf8(allocator, message) catch return;
+
+    const json = position.renderRejection(allocator, position.code_client_failure, text) catch return;
+    events.settle(allocator, position.reject_global, json) catch {};
+}
+
+/// `nativeGetCurrentPosition(activity)`.
+fn nativeGetCurrentPosition(
+    env: jni.JNIEnv,
+    _: jni.jobject,
+    activity: jni.jobject,
+) callconv(.c) jni.jboolean {
+    const j = Jni.init(env);
+    var arena = std.heap.ArenaAllocator.init(backing);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const granted = permissions.isGranted(j, activity, permissions.access_fine_location) catch |err| {
+        std.log.warn("craft: getCurrentPosition fell through to the shim ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+
+    if (!granted) {
+        // The shim asks for both the fine and the coarse permission, so the
+        // holder does too — a request for one where the shim asked for two
+        // would leave a page permanently unable to get a coarse fix.
+        callHolderVoid(j, "requestLocationPermissions", activity) catch |err| {
+            std.log.warn("craft: getCurrentPosition fell through to the shim ({s})", .{@errorName(err)});
+            return jni.JNI_FALSE;
+        };
+
+        const json = position.renderRejection(
+            allocator,
+            position.code_permission_denied,
+            position.permission_denied_message,
+        ) catch return jni.JNI_FALSE;
+        events.settle(allocator, position.reject_global, json) catch return jni.JNI_FALSE;
+        return jni.JNI_TRUE;
+    }
+
+    callHolderVoid(j, "requestCurrentPosition", activity) catch |err| {
+        std.log.warn("craft: getCurrentPosition fell through to the shim ({s})", .{@errorName(err)});
+        return jni.JNI_FALSE;
+    };
+    return jni.JNI_TRUE;
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -2207,7 +2328,7 @@ test "the registered natives name methods the Kotlin actually declares" {
     // A descriptor is checked by the JVM at registration, so a wrong one fails
     // at load rather than at call — but only if the *name* matches something.
     // These two strings are the contract with CraftBridge.kt.
-    try testing.expectEqual(@as(usize, 56), natives.len);
+    try testing.expectEqual(@as(usize, 59), natives.len);
     try testing.expectEqualStrings("nativeGetDeviceInfo", std.mem.span(natives[0].name));
 
     // And the class they bind to is the fixed one, not the templated bridge.

--- a/packages/zig/src/bridge_android_position.zig
+++ b/packages/zig/src/bridge_android_position.zig
@@ -1,0 +1,207 @@
+//! `getCurrentPosition` on Android.
+//!
+//! The fifth listener shim, and the second to need `android_json_number` —
+//! seven numbers, six of which are doubles.
+//!
+//! ## Six doubles, and three of them started as floats
+//!
+//! `Location.accuracy`, `.speed` and `.bearing` are `Float`, but the shim
+//! writes them with `put(name, value)` and the overload Kotlin picks is
+//! `put(String, double)` — primitive widening beats boxing. So they are
+//! `Double`s by the time `numberToString` sees them, and print as doubles.
+//!
+//! That matters because the same float prints differently in the two places
+//! this bridge sends one. `bridge_android_motion` puts its floats into a
+//! `Map`, which boxes them as `Float`, so an accuracy of `0.1f` reads "0.1"
+//! there and "0.10000000149011612" here. Neither is wrong; they are different
+//! calls. It is the reason `android_json_number` has two functions rather than
+//! one widening one.
+//!
+//! ## Two rejections with different codes and different shapes
+//!
+//! `{code: 1, message: 'Permission denied'}` is a fixed object. `{code: 2,
+//! message: <exception>}` carries whatever Play Services said. Both are JS
+//! object literals in the shim with unquoted keys; here they are JSON, which
+//! parses to the same object.
+//!
+//! There is no code 3, and no rejection at all for the case where the fresh
+//! location request never produces a result — the promise simply never
+//! settles. That is the shim's behaviour and is left alone here; see #157 for
+//! the same shape elsewhere.
+
+const std = @import("std");
+const bridge_error = @import("bridge_error.zig");
+
+pub const A = struct {
+    pub const get_current_position = "getCurrentPosition";
+};
+
+pub const resolve_global = "_craftLocationResolve";
+pub const reject_global = "_craftLocationReject";
+
+/// `{code: 1, ...}` — the permission refusal.
+pub const code_permission_denied: i32 = 1;
+
+/// `{code: 2, ...}` — whatever the location client failed with.
+pub const code_client_failure: i32 = 2;
+
+pub const permission_denied_message = "Permission denied";
+
+/// The seven values a position reply carries, already printed.
+///
+/// Strings rather than numbers, because printing them is `org.json`'s job —
+/// see `android_json_number`. What this file owns is which keys they go under
+/// and in what order.
+pub const Printed = struct {
+    latitude: []const u8,
+    longitude: []const u8,
+    accuracy: []const u8,
+    altitude: []const u8,
+    speed: []const u8,
+    /// `location.bearing`, under the key `heading`.
+    heading: []const u8,
+    timestamp: []const u8,
+};
+
+/// A position, as the shim's `JSONObject` prints it.
+///
+/// Insertion order, because `JSONObject` is a `LinkedHashMap` — and the key
+/// for `location.bearing` is `heading`, which is the one name here that does
+/// not match the field it came from.
+pub fn renderPosition(allocator: std.mem.Allocator, values: Printed) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.appendSlice(allocator, "{\"latitude\":");
+    try out.appendSlice(allocator, values.latitude);
+    try out.appendSlice(allocator, ",\"longitude\":");
+    try out.appendSlice(allocator, values.longitude);
+    try out.appendSlice(allocator, ",\"accuracy\":");
+    try out.appendSlice(allocator, values.accuracy);
+    try out.appendSlice(allocator, ",\"altitude\":");
+    try out.appendSlice(allocator, values.altitude);
+    try out.appendSlice(allocator, ",\"speed\":");
+    try out.appendSlice(allocator, values.speed);
+    try out.appendSlice(allocator, ",\"heading\":");
+    try out.appendSlice(allocator, values.heading);
+    try out.appendSlice(allocator, ",\"timestamp\":");
+    try out.appendSlice(allocator, values.timestamp);
+    try out.append(allocator, '}');
+    return out.toOwnedSlice(allocator);
+}
+
+/// `{code: n, message: "…"}`.
+pub fn renderRejection(allocator: std.mem.Allocator, code: i32, message: []const u8) ![]u8 {
+    var out: std.ArrayListUnmanaged(u8) = .empty;
+    errdefer out.deinit(allocator);
+
+    try out.appendSlice(allocator, "{\"code\":");
+    try out.print(allocator, "{d}", .{code});
+    try out.appendSlice(allocator, ",\"message\":\"");
+    try bridge_error.appendJsonEscaped(allocator, &out, message);
+    try out.appendSlice(allocator, "\"}");
+    return out.toOwnedSlice(allocator);
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+const testing = std.testing;
+
+test "a position prints seven keys, in the shim's order" {
+    const json = try renderPosition(testing.allocator, .{
+        .latitude = "51.5074",
+        .longitude = "-0.1278",
+        .accuracy = "12.5",
+        .altitude = "35.2",
+        .speed = "0",
+        .heading = "0",
+        .timestamp = "1700000000000",
+    });
+    defer testing.allocator.free(json);
+
+    try testing.expectEqualStrings(
+        \\{"latitude":51.5074,"longitude":-0.1278,"accuracy":12.5,"altitude":35.2,"speed":0,"heading":0,"timestamp":1700000000000}
+    , json);
+}
+
+test "bearing is called heading, which is the one name that changes" {
+    // `put("heading", location.bearing)`. Every other key matches its field,
+    // so this is the one a rewrite would silently get right-looking and wrong.
+    const json = try renderPosition(testing.allocator, .{
+        .latitude = "0",
+        .longitude = "0",
+        .accuracy = "0",
+        .altitude = "0",
+        .speed = "0",
+        .heading = "271.5",
+        .timestamp = "0",
+    });
+    defer testing.allocator.free(json);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+
+    try testing.expect(parsed.value.object.get("bearing") == null);
+    try testing.expectEqual(@as(f64, 271.5), parsed.value.object.get("heading").?.float);
+    try testing.expectEqual(@as(usize, 7), parsed.value.object.count());
+}
+
+test "org.json's integral form parses as a number, not a string" {
+    // A stationary device reports speed and bearing of exactly zero, and
+    // `numberToString` prints those as `0` rather than `0.0`. A page doing
+    // arithmetic on them needs them to be numbers, which they are.
+    const json = try renderPosition(testing.allocator, .{
+        .latitude = "0",
+        .longitude = "-0",
+        .accuracy = "9",
+        .altitude = "0",
+        .speed = "0",
+        .heading = "0",
+        .timestamp = "1700000000000",
+    });
+    defer testing.allocator.free(json);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqual(@as(i64, 9), parsed.value.object.get("accuracy").?.integer);
+    try testing.expectEqual(@as(i64, 1700000000000), parsed.value.object.get("timestamp").?.integer);
+}
+
+test "the two rejections carry different codes" {
+    // A page distinguishes "the user said no" from "the location client
+    // failed" by the code alone, so the numbers are API.
+    const denied = try renderRejection(testing.allocator, code_permission_denied, permission_denied_message);
+    defer testing.allocator.free(denied);
+    try testing.expectEqualStrings(
+        \\{"code":1,"message":"Permission denied"}
+    , denied);
+
+    const failed = try renderRejection(testing.allocator, code_client_failure, "GoogleApiClient is not connected yet");
+    defer testing.allocator.free(failed);
+    try testing.expectEqualStrings(
+        \\{"code":2,"message":"GoogleApiClient is not connected yet"}
+    , failed);
+
+    try testing.expectEqual(@as(i32, 1), code_permission_denied);
+    try testing.expectEqual(@as(i32, 2), code_client_failure);
+}
+
+test "a failure message carrying a quote survives as JSON" {
+    // The message is whatever Play Services threw, which is not text this
+    // repository controls — and it goes to the page through the same channel
+    // that hung the promise before #154.
+    const json = try renderRejection(testing.allocator, code_client_failure, "it's \"broken\"\n");
+    defer testing.allocator.free(json);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, testing.allocator, json, .{});
+    defer parsed.deinit();
+    try testing.expectEqualStrings("it's \"broken\"\n", parsed.value.object.get("message").?.string);
+}
+
+test "the action and globals match the shim exactly" {
+    try testing.expectEqualStrings("getCurrentPosition", A.get_current_position);
+    try testing.expectEqualStrings("_craftLocationResolve", resolve_global);
+    try testing.expectEqualStrings("_craftLocationReject", reject_global);
+}

--- a/packages/zig/test/android_conformance_test.zig
+++ b/packages/zig/test/android_conformance_test.zig
@@ -59,6 +59,7 @@ const zig_sources = [_][]const u8{
     @embedFile("src/bridge_android_appstate.zig"),
     @embedFile("src/bridge_android_bluetooth.zig"),
     @embedFile("src/bridge_android_motion.zig"),
+    @embedFile("src/bridge_android_position.zig"),
 };
 
 /// How many spec actions Zig does not serve yet.
@@ -94,8 +95,9 @@ const zig_sources = [_][]const u8{
 /// first listener shim — the callback object is the holder's, the work is
 /// Zig's; 56 with the app-state trio, the first migration where the state
 /// itself moved rather than being worked around; 54 with the Bluetooth scan
-/// pair; 52 with the motion pair, once org.json agreed to print the floats.
-const max_not_yet_migrated: usize = 52;
+/// pair; 52 with the motion pair, once org.json agreed to print the floats;
+/// 51 with getCurrentPosition, which needed the same and two Java interfaces.
+const max_not_yet_migrated: usize = 51;
 
 /// Every `@JavascriptInterface fun <name>(` in the Kotlin bridge.
 ///


### PR DESCRIPTION
The fifth listener shim, and the first with **two Java interfaces in one flow**: `OnSuccessListener` and `OnFailureListener` on the Play Services task, plus a `LocationCallback` for the fresh-location fallback.

## It was not actually entangled

I had passed this over as blocked alongside the deferred `watchPosition`/`clearWatch` pair (#179), on the grounds that they share `CraftBridge` fields. Checking rather than assuming: `fusedLocationClient` is the **only** field `getCurrentPosition` writes, and `watchPosition` assigns it before every use — so leaving it null costs `clearWatch` nothing. The comment at the seam says so, because the next reader will wonder the same thing.

## Six doubles, and three of them started as floats

`Location.accuracy`, `.speed` and `.bearing` are `Float`. The shim writes them with `put(name, value)`, and the overload Kotlin picks is `put(String, double)` — **primitive widening beats boxing** — so they are `Double`s by the time `numberToString` sees them.

That is not a detail to shrug at, because the same float prints differently in the two places this bridge sends one:

| | boxed as | `0.1f` prints as |
|---|---|---|
| `bridge_android_motion` (values go into a `Map`) | `Float` | `0.1` |
| `getCurrentPosition` (`put(String, double)`) | `Double` | `0.10000000149011612` |

Neither is wrong; they are different calls. It is exactly why `android_json_number` has two functions rather than one widening one — and why the holder widens on the Kotlin side rather than passing floats across.

`timestamp` needs no JNI call at all: `put(String, long)` boxes a `Long`, and `numberToString` prints one with `Long.toString`.

## `bearing` is called `heading`

The one key whose name does not match the field it came from — every other one matches — and so the one a rewrite would get right-looking and wrong. It has its own test.

## Two codes, and no third

`{code: 1}` is the permission refusal, `{code: 2}` is whatever the client failed with, and a page tells them apart by the number alone — so both are API and both are pinned.

There is no code for "the fresh location request never produced a result". That promise simply never settles, here as there; it is the #157 shape and is left alone rather than quietly improved.

## Testing

`zig build test:android` passes with the ratchet at 51. Two mutations fired: renaming `heading` back to `bearing`, and collapsing the two rejection codes. Both `libcraft.so` targets still build with no NDK.